### PR TITLE
[fix-#35] replaceChar()でcmdLoopが現在地点から行末までの文字数を上回っていたときreturnするようにした

### DIFF
--- a/moe.c
+++ b/moe.c
@@ -533,8 +533,8 @@ int keyD(WINDOW **win, gapBuffer *gb, editorStat *stat){
   return 0;
 }
 
-// does not works...
 int replaceChar(gapBuffer *gb, editorStat *stat, int key){
+  if((stat->x - stat->lineDigitSpace) + stat->cmdLoop > gapBufferAt(gb, stat->currentLine)->numOfChar) return 0;
   for(int i=0; i<stat->cmdLoop; i++){
     gapBufferAt(gb, stat->currentLine)->elements[(stat->x - stat->lineDigitSpace) + i] = key;
   }


### PR DESCRIPTION
close #35 