### PR TITLE
Fixed #44

### DIFF
--- a/vector.c
+++ b/vector.c
@@ -117,3 +117,10 @@ int charArrayFree(charArray* array){
   
   return 1;
 }
+
+charArray* charArrayCopy(charArray* array){
+  charArray* copy = (charArray*)malloc(sizeof(charArray));
+  charArrayInit(copy);
+  for(int i = 0; i < array->numOfChar; ++i) charArrayPush(copy, array->elements[i]);
+  return copy;
+}

--- a/vector.h
+++ b/vector.h
@@ -24,3 +24,4 @@ int charArrayPop(charArray* array);
 int charArrayDel(charArray* array, int position);
 bool charArrayIsEmpty(charArray* array);
 int charArrayFree(charArray* array);
+charArray* charArrayCopy(charArray*);


### PR DESCRIPTION
ヤンク/ペースト時にcharArrayのポインタをコピーしていのがエラーの原因だった.
これによってdd実行時に同じcharArrayのインスタンスを参照しているポインタが全て不正になり,ddで消された行以外の行の表示がおかしくなっていた.また,それが結果的にアプリをクラッシュさせていた.
ヤンク/ペースト時にcharArrayの要素をコピーすることによって解決した.

close #44 