### PR TITLE
Fix invalid settings file path and make parseSettingsFile more generic

### DIFF
--- a/src/moe.nim
+++ b/src/moe.nim
@@ -14,7 +14,7 @@ import moepkg/unicodeext
 import moepkg/cmdoption
 import moepkg/settings
 
-when isMainModule:
+proc main() =
   let parsedList = parseCommandLineOption(commandLineParams())
 
   defer:
@@ -22,6 +22,7 @@ when isMainModule:
     discard execShellCmd("printf '\\033[2 q'")
 
   startUi()
+
   var status = initEditorStatus()
   status.settings = parseSettingsFile("~/.moerc.toml".expandTilde)
   
@@ -33,8 +34,8 @@ when isMainModule:
         status.buffer = textAndEncoding.text.toGapBuffer
         status.settings.characterEncoding = textAndEncoding.encoding
       except IOError:
-        echo(fmt"Failed to open: {status.filename}")
-        quit()
+        writeFileOpenErrorMessage(status.commandWindow, status.filename)
+        return
     elif existsDir($(status.filename)):
       try:
         setCurrentDir($(status.filename))
@@ -64,3 +65,4 @@ when isMainModule:
     of Mode.quit:
       break
 
+when isMainModule: main()

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -12,7 +12,7 @@ type EditorSettings* = object
   autoCloseParen*: bool
   autoIndent*: bool 
   tabStop*: int
-  characterEncoding*: CharacterEncoding
+  characterEncoding*: CharacterEncoding # TODO: move to EditorStatus ...?
 
 type EditorStatus* = object
   buffer*: GapBuffer[seq[Rune]]
@@ -40,7 +40,7 @@ proc initRegisters(): Registers =
   result.yankedLines = @[]
   result.yankedStr = @[]
 
-proc initEditorSettings(): EditorSettings =
+proc initEditorSettings*(): EditorSettings =
   result.autoCloseParen = true
   result.autoIndent = true
   result.tabStop = 2

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -1,20 +1,21 @@
 import parsetoml
 import editorstatus
 
-proc parseConfigFile*(settings: var EditorSettings): EditorSettings =
-
-  var config: TomlValueRef
+proc parseSettingsFile*(filename: string): EditorSettings =
+  result = initEditorSettings()
+  
+  var settings: TomlValueRef
   try:
-    config = parsetoml.parseFile("~/.moerc.toml")
+    settings = parsetoml.parseFile(filename)
   except IOError:
-    return settings
+    return
 
-  if config.contains("Standard"):
-    if config["Standard"].contains("tabStop"):
-      result.tabStop = config["Standard"]["tabStop"].getInt()
+  if settings.contains("Standard"):
+    if settings["Standard"].contains("tabStop"):
+      result.tabStop = settings["Standard"]["tabStop"].getInt()
 
-    if config["Standard"].contains("autoCloseParen"):
-      result.autoCloseParen = config["Standard"]["autoCloseParen"].getbool()
+    if settings["Standard"].contains("autoCloseParen"):
+      result.autoCloseParen = settings["Standard"]["autoCloseParen"].getbool()
 
-    if config["Standard"].contains("autoIndent"):
-      result.autoIndent = config["Standard"]["autoIndent"].getbool()
+    if settings["Standard"].contains("autoIndent"):
+      result.autoIndent = settings["Standard"]["autoIndent"].getbool()


### PR DESCRIPTION
- Fix invalid setting file path (`"~/.moerc.toml"`  to `"~/.moerc.toml".expandTilde`)
- Rename "config" to "settings" to be consistent naming
- Make parseSettingsFile more generic