### PR TITLE
Make settings file location XDG compliant

### DIFF
--- a/src/moe.nim
+++ b/src/moe.nim
@@ -24,8 +24,8 @@ proc main() =
   startUi()
 
   var status = initEditorStatus()
-  status.settings = parseSettingsFile("~/.moerc.toml".expandTilde)
-  
+  status.settings = parseSettingsFile(getConfigDir() / "moe" / "moerc.toml")
+
   if parsedList.filename != "":
     status.filename = parsedList.filename.toRunes
     if existsFile($(status.filename)):


### PR DESCRIPTION
Maybe filename could be changed to more generic `config.toml`, since its now located in separate folder.