### PR TITLE
add: D, m, ', line-directed G. fix: new files

### DIFF
--- a/src/moe.nim
+++ b/src/moe.nim
@@ -50,7 +50,7 @@ proc main() =
         status.bufStatus.add(BufferStatus(filename: "".toRunes))
         status.bufStatus[0].buffer = newFile()
     else:
-      status.bufStatus.add(BufferStatus(filename: "".toRunes))
+      status.bufStatus.add(BufferStatus(filename: parsedList.filename.toRunes))
       status.bufStatus[0].buffer = newFile()
   else:
     status.bufStatus.add(BufferStatus(filename: "".toRunes))

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -45,6 +45,7 @@ type BufferStatus* = object
   language*: SourceLanguage
   view*: EditorView
   cursor*: CursorPosition
+  mark*: CursorPosition
   isHighlight*: bool
   filename*: seq[Rune]
   openDir: seq[Rune]


### PR DESCRIPTION
  D - delete text to end of line
  m - set a mark (no argument for now)
  ' - go to mark (no argument for now)
  G - 1G should go to line 1, 10G to line 10, etc.
      without arguments, it goes to the end of the file
      since this distinguishes between 1 and no argument,
      used origCmd. which is ugly but minimal change.

fix:

  if you run "moe new-file-name", and then try to save with :w, moe
  complains that you haven't told it what file name to save as.
  moe should default to 'new-file-name' the way it does when that file
  already exists and moe is started to edit it.

still wanted:
  ZZ - save and quit
  zt, zb, z., zz - move display so current line is first visible line,
                   etc.
  ^ how are multiple-key commands handled?

  typing ] should move the cursor past a ] that was added by a
  previously typed [, etc.
  ^ I thought this might require marking the chars somehow, but ] could
    probably just always skip past ] when in a mod where [ are auto entered.

  undo, even 1-stack-deep undo!
  with undo I can use moe for practical tasks