### PR TITLE
fix crash after deletion to EOL then 'a'ppend

### DIFF
--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -515,7 +515,10 @@ proc normalCommand(status: var EditorStatus, key: Rune) =
   elif key == ord('v'):
     status.changeMode(Mode.visual)
   elif key == ord('a'):
-    if status.bufStatus[currentBuf].buffer[status.bufStatus[currentBuf].currentLine].len > 0: inc(status.bufStatus[currentBuf].currentColumn)
+    let lineWidth = status.bufStatus[currentBuf].buffer[status.bufStatus[currentBuf].currentLine].len
+    if lineWidth == 0: discard
+    elif lineWidth == status.bufStatus[currentBuf].currentColumn: discard
+    else: inc(status.bufStatus[currentBuf].currentColumn)
     status.changeMode(Mode.insert)
   elif key == ord('A'):
     status.bufStatus[currentBuf].currentColumn = status.bufStatus[currentBuf].buffer[status.bufStatus[currentBuf].currentLine].len


### PR DESCRIPTION
Currently, moe crashes if you delete the end of a line and then start appending. This PR fixes that. A more general fix might be to make `columnNumber` a distinct number with its own `inc` and `dec` functions that refuse to go out of bounds.

Given this buffer:
```
1 a <CURSOR>line
```
moe will crash on: `vwda` (visual, skip word, delete, append) and on `veda` (visual, to end of word, delete, append), with the following error:
```
Error: unhandled exception: /Users/jfondren/nim/moe/src/moepkg/cursor.nim(21, 11) `false` Failed to update cursorPosition: (y, x) = (0, 3), originalLine = [0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1], start = [0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1], length = [2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], lines = [a , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , , ], height = 45, width = 113 [AssertionError]
```
