### PR TITLE
add [Theme] as moerc.toml section

### DIFF
--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -133,36 +133,7 @@ proc changeMode*(status: var EditorStatus, mode: Mode) =
   status.bufStatus[status.currentBuffer].mode = mode
 
 proc changeTheme*(status: var EditorStatus) =
-  if status.settings.editorColorTheme == ColorTheme.dark:
-    status.settings.editorColor.editor = Colorpair.brightWhiteDefauLt
-    status.settings.editorColor.lineNum = Colorpair.grayDefault
-    status.settings.editorColor.currentLineNum = Colorpair.cyanDefault
-    status.settings.editorColor.statusBar = Colorpair.brightWhiteBlue
-    status.settings.editorColor.statusBarMode = Colorpair.blackWhite
-    status.settings.editorColor.tab = Colorpair.brightWhiteDefault
-    status.settings.editorColor.currentTab = Colorpair.brightWhiteBlue
-    status.settings.editorColor.commandBar = Colorpair.brightWhiteDefault
-    status.settings.editorColor.errorMessage = Colorpair.redDefault
-  elif status.settings.editorColorTheme == ColorTheme.light:
-    status.settings.editorColor.editor = Colorpair.blackDefault
-    status.settings.editorColor.lineNum = Colorpair.grayDefault
-    status.settings.editorColor.currentLineNum = Colorpair.blackDefault
-    status.settings.editorColor.statusBar = Colorpair.cyanGray
-    status.settings.editorColor.statusBarMode = Colorpair.whiteCyan
-    status.settings.editorColor.tab = Colorpair.cyanGray
-    status.settings.editorColor.currentTab = Colorpair.whiteCyan
-    status.settings.editorColor.commandBar = Colorpair.blackDefault
-    status.settings.editorColor.errorMessage = Colorpair.redDefault
-  elif status.settings.editorColorTheme == ColorTheme.vivid:
-    status.settings.editorColor.editor = Colorpair.brightWhiteDefauLt
-    status.settings.editorColor.lineNum = Colorpair.grayDefault
-    status.settings.editorColor.currentLineNum = Colorpair.pinkDefault
-    status.settings.editorColor.statusBar = Colorpair.blackPink
-    status.settings.editorColor.statusBarMode = Colorpair.blackWhite
-    status.settings.editorColor.tab = Colorpair.brightWhiteDefault
-    status.settings.editorColor.currentTab = Colorpair.blackPink
-    status.settings.editorColor.commandBar = Colorpair.brightWhiteDefault
-    status.settings.editorColor.errorMessage = Colorpair.redDefault
+  status.settings.editorColor = ColorThemeTable[status.settings.editorColorTheme]
 
 proc changeCurrentWin*(status:var EditorStatus, index: int) =
   if index < status.mainWindowInfo.high and index > 0: status.currentMainWindow = index

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -121,6 +121,7 @@ proc changeThemeSettingCommand(status: var EditorStatus, command: seq[Rune]) =
   if command == ru"dark": status.settings.editorColorTheme = ColorTheme.dark
   elif command == ru"light": status.settings.editorColorTheme = ColorTheme.light
   elif command == ru"vivid": status.settings.editorColorTheme = ColorTheme.vivid
+  elif command == ru"config": status.settings.editorColorTheme = ColorTheme.config
 
   changeTheme(status)
   status.resize(terminalHeight(), terminalWidth())

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -1,5 +1,6 @@
 import parsetoml
 import editorstatus, ui
+from strutils import parseEnum
 
 proc getCursorType(cursorType, mode: string): CursorType =
   case cursorType
@@ -83,3 +84,41 @@ proc parseSettingsFile*(filename: string): EditorSettings =
 
     if settings["StatusBar"].contains("directory"):
         result.statusBar.language = settings["StatusBar"]["directory"].getbool()
+
+  if settings.contains("Theme"):
+    if settings["Theme"].contains("baseTheme"):
+      let theme = parseEnum[ColorTheme](settings["Theme"]["baseTheme"].getStr())
+      ColorThemeTable[ColorTheme.config] = ColorThemeTable[theme]
+
+    template color(str: string): untyped =
+      parseEnum[ColorPair](settings["Theme"][str].getStr())
+
+    if settings["Theme"].contains("editor"):
+      ColorThemeTable[ColorTheme.config].editor = color("editor")
+
+    if settings["Theme"].contains("lineNum"):
+      ColorThemeTable[ColorTheme.config].lineNum = color("lineNum")
+
+    if settings["Theme"].contains("currentLineNum"):
+      ColorThemeTable[ColorTheme.config].currentLineNum = color("currentLineNum")
+
+    if settings["Theme"].contains("statusBar"):
+      ColorThemeTable[ColorTheme.config].statusBar = color("statusBar")
+
+    if settings["Theme"].contains("statusBarMode"):
+      ColorThemeTable[ColorTheme.config].statusBarMode = color("statusBarMode")
+
+    if settings["Theme"].contains("tab"):
+      ColorThemeTable[ColorTheme.config].tab = color("tab")
+
+    if settings["Theme"].contains("currentTab"):
+      ColorThemeTable[ColorTheme.config].currentTab = color("currentTab")
+
+    if settings["Theme"].contains("commandBar"):
+      ColorThemeTable[ColorTheme.config].commandBar = color("commandBar")
+
+    if settings["Theme"].contains("errorMessage"):
+      ColorThemeTable[ColorTheme.config].errorMessage = color("errorMessage")
+
+    result.editorColorTheme = ColorTheme.config
+    result.editorColor = ColorThemeTable[ColorTheme.config]

--- a/src/moepkg/ui.nim
+++ b/src/moepkg/ui.nim
@@ -47,6 +47,7 @@ type ColorPair* = enum
   blueDefault           = 20
 
 type ColorTheme* = enum
+  config  = 0
   dark    = 1
   light   = 2
   vivid   = 3
@@ -61,6 +62,53 @@ type EditorColor* = object
   currentTab*: ColorPair
   commandBar*: ColorPair
   errorMessage*: ColorPair
+
+var ColorThemeTable*: array[ColorTheme, EditorColor] = [
+  config: EditorColor(
+    editor: brightWhiteDefault,
+    lineNum: grayDefault,
+    currentLineNum: cyanDefault,
+    statusBar: brightWhiteBlue,
+    statusBarMode: blackWhite,
+    tab: brightWhiteDefault,
+    currentTab: brightWhiteBlue,
+    commandBar: brightWhiteDefault,
+    errorMessage: redDefault,
+  ),
+  dark: EditorColor(
+    editor: brightWhiteDefault,
+    lineNum: grayDefault,
+    currentLineNum: cyanDefault,
+    statusBar: brightWhiteBlue,
+    statusBarMode: blackWhite,
+    tab: brightWhiteDefault,
+    currentTab: brightWhiteBlue,
+    commandBar: brightWhiteDefault,
+    errorMessage: redDefault,
+  ),
+  light: EditorColor(
+    editor: blackDefault,
+    lineNum: grayDefault,
+    currentLineNum: blackDefault,
+    statusBar: cyanGray,
+    statusBarMode: whiteCyan,
+    tab: cyanGray,
+    currentTab: whiteCyan,
+    commandBar: blackDefault,
+    errorMessage: redDefault,
+  ),
+  vivid: EditorColor(
+    editor: brightWhiteDefault,
+    lineNum: grayDefault,
+    currentLineNum: pinkDefault,
+    statusBar: blackPink,
+    statusBarMode: blackWhite,
+    tab: brightWhiteDefault,
+    currentTab: blackPink,
+    commandBar: brightWhiteDefault,
+    errorMessage: redDefault,
+  ),
+]
 
 type Window* = object
   cursesWindow*: ptr window


### PR DESCRIPTION
This PR allows you to add a section like

```
[Theme]
baseTheme = "dark"
editor = "whiteDefault"
```

to slightly modify one of the built-in themes, or you can define your own theme from scratch. This theme is named 'config' for the purposes of `:theme` in exmode, so you can `:theme vivid` and then `:theme config` to compare your settings vs. vivid.

An invalid color will result in an startup error like:
```
moe.nim(49)              moe
moe.nim(25)              main
settings.nim(94)         parseSettingsFile
strutils.nim             parseEnum
Error: unhandled exception: invalid enum value: xxxDefault [ValueError]
```

an invalid field name like `fakeConfig = "cyanGray"` will be ignored.