### PR TITLE
Initial VSCode Theme support - Implement #646

### DIFF
--- a/src/moepkg/color.nim
+++ b/src/moepkg/color.nim
@@ -1,263 +1,399 @@
 import ncurses
+import strutils
+import tables
+import macros
 
-type Color* = enum
-  default             = -1
-  black               = 0
-  maroon              = 1
-  green               = 2
-  olive               = 3
-  navy                = 4
-  purple_1            = 5
-  teal                = 6
-  silver              = 7
-  gray                = 8
-  red                 = 9
-  lime                = 10
-  yellow              = 11
-  blue                = 12
-  fuchsia             = 13
-  aqua                = 14
-  white               = 15
-  gray0               = 16
-  navyBlue            = 17
-  darkBlue            = 18
-  blue3_1             = 19
-  blue3_2             = 20
-  blue1               = 21
-  darkGreen           = 22
-  deepSkyBlue4_1      = 23
-  deepSkyBlue4_2      = 24
-  deepSkyBlue4_3      = 25
-  dodgerBlue3_1       = 26
-  dodgerBlue3_2       = 27
-  green4              = 28
-  springGreen4        = 29
-  turquoise4          = 30
-  deepSkyBlue3_1      = 31
-  deepSkyBlue3_2      = 32
-  dodgerBlue1         = 33
-  green3_1            = 34
-  springGreen3_1      = 35
-  darkCyan            = 36
-  lightSeaGreen       = 37
-  deepSkyBlue2        = 38
-  deepSkyBlue1        = 39
-  green3_2            = 40
-  springGreen3_3      = 41
-  springGreen2_1      = 42
-  cyan3               = 43
-  darkTurquoise       = 44
-  turquoise2          = 45
-  green1              = 46
-  springGreen2_2      = 47
-  springGreen1        = 48
-  mediumSpringGreen   = 49
-  cyan2               = 50
-  cyan1               = 51
-  darkRed_1           = 52
-  deepPink4_1         = 53
-  purple4_1           = 54
-  purple4_2           = 55
-  purple3             = 56
-  blueViolet          = 57
-  orange4_1           = 58
-  gray37              = 59
-  mediumPurple4       = 60
-  slateBlue3_1        = 61
-  slateBlue3_2        = 62
-  royalBlue1          = 63
-  chartreuse4         = 64
-  darkSeaGreen4_1     = 65
-  paleTurquoise4      = 66
-  steelBlue           = 67
-  steelBlue3          = 68
-  cornflowerBlue      = 69
-  chartreuse3_1       = 70
-  darkSeaGreen4_2     = 71
-  cadetBlue_1         = 72
-  cadetBlue_2         = 73
-  skyBlue3            = 74
-  steelBlue1_1        = 75
-  chartreuse3_2       = 76
-  paleGreen3_1        = 77
-  seaGreen3           = 78
-  aquamarine3         = 79
-  mediumTurquoise     = 80
-  steelBlue1_2        = 81
-  chartreuse2_1       = 82
-  seaGreen2           = 83
-  seaGreen1_1         = 84
-  seaGreen1_2         = 85
-  aquamarine1_1       = 86
-  darkSlateGray2      = 87
-  darkRed_2           = 88
-  deepPink4_2         = 89
-  darkMagenta_1       = 90
-  darkMagenta_2       = 91
-  darkViolet_1        = 92
-  purple_2            = 93
-  orange4_2           = 94
-  lightPink4          = 95
-  plum4               = 96
-  mediumPurple3_1     = 97
-  mediumPurple3_2     = 98
-  slateBlue1          = 99
-  yellow4_1           = 100
-  wheat4              = 101
-  gray53              = 102
-  lightSlategray      = 103
-  mediumPurple        = 104
-  lightSlateBlue      = 105
-  yellow4_2           = 106
-  Wheat4              = 107
-  darkSeaGreen        = 108
-  lightSkyBlue3_1     = 109
-  lightSkyBlue3_2     = 110
-  skyBlue2            = 111
-  chartreuse2_2       = 112
-  darkOliveGreen3_1   = 113
-  paleGreen3_2        = 114
-  darkSeaGreen3_1     = 115
-  darkSlateGray3      = 116
-  skyBlue1            = 117
-  chartreuse1         = 118
-  lightGreen_1        = 119
-  lightGreen_2        = 120
-  paleGreen1_1        = 121
-  aquamarine1_2       = 122
-  darkSlateGray1      = 123
-  red3_1              = 124
-  deepPink4           = 125
-  mediumVioletRed     = 126
-  magenta3            = 127
-  darkViolet_2        = 128
-  purple              = 129
-  darkOrange3_1       = 130
-  indianRed_1         = 131
-  hotPink3_1          = 132
-  mediumOrchid3       = 133
-  mediumOrchid        = 134
-  mediumPurple2_1     = 135
-  darkGoldenrod       = 136
-  lightSalmon3_1      = 137
-  rosyBrown           = 138
-  gray63              = 139
-  mediumPurple2_2     = 140
-  mediumPurple1       = 141
-  gold3_1             = 142
-  darkKhaki           = 143
-  navajoWhite3        = 144
-  gray69              = 145
-  lightSteelBlue3     = 146
-  lightSteelBlue      = 147
-  yellow3_1           = 148
-  darkOliveGreen3_2   = 149
-  darkSeaGreen3_2     = 150
-  darkSeaGreen2_1     = 151
-  lightCyan3          = 152
-  lightSkyBlue1       = 153
-  greenYellow         = 154
-  darkOliveGreen2     = 155
-  paleGreen1_2        = 156
-  darkSeaGreen2_2     = 157
-  darkSeaGreen1_1     = 158
-  paleTurquoise1      = 159
-  red3_2              = 160
-  deepPink3_1         = 161
-  deepPink3_2         = 162
-  magenta3_1          = 163
-  magenta3_2          = 164
-  magenta2_1          = 165
-  darkOrange3_2       = 166
-  indianRed_2         = 167
-  hotPink3_2          = 168
-  hotPink2            = 169
-  orchid              = 170
-  mediumOrchid1_1     = 171
-  orange3             = 172
-  lightSalmon3_2      = 173
-  lightPink3          = 174
-  pink3               = 175
-  plum3               = 176
-  violet              = 177
-  gold3_2             = 178
-  lightGoldenrod3     = 179
-  tan                 = 180
-  mistyRose3          = 181
-  thistle3            = 182
-  plum2               = 183
-  yellow3_2           = 184
-  khaki3              = 185
-  lightGoldenrod2     = 186
-  lightYellow3        = 187
-  gray84              = 188
-  lightSteelBlue1     = 189
-  yellow2             = 190
-  darkOliveGreen1_1   = 191
-  darkOliveGreen1_2   = 192
-  darkSeaGreen1_2     = 193
-  honeydew2           = 194
-  lightCyan1          = 195
-  red1                = 196
-  deepPink2           = 197
-  deepPink1_1         = 198
-  deepPink1_2         = 199
-  magenta2_2          = 200
-  magenta1            = 201
-  orangeRed1          = 202
-  indianRed1_1        = 203
-  indianRed1_2        = 204
-  hotPink1_1          = 205
-  hotPink1_2          = 206
-  mediumOrchid1_2     = 207
-  darkOrange          = 208
-  salmon1             = 209
-  lightCoral          = 210
-  paleVioletRed1      = 211
-  orchid2             = 212
-  orchid1             = 213
-  orange1             = 214
-  sandyBrown          = 215
-  lightSalmon1        = 216
-  lightPink1          = 217
-  pink1               = 218
-  plum1               = 219
-  gold1               = 220
-  lightGoldenrod2_1   = 221
-  lightGoldenrod2_2   = 222
-  navajoWhite1        = 223
-  mistyRose1          = 224
-  thistle1            = 225
-  yellow1             = 226
-  lightGoldenrod1     = 227
-  khaki1              = 228
-  wheat1              = 229
-  cornsilk1           = 230
-  gray100             = 231
-  gray3               = 232
-  gray7               = 233
-  gray11              = 234
-  gray15              = 235
-  gray19              = 236
-  gray23              = 237
-  gray27              = 238
-  gray30              = 239
-  gray35              = 240
-  gray39              = 241
-  gray42              = 242
-  gray46              = 243
-  gray50              = 244
-  gray54              = 245
-  gray58              = 246
-  gray62              = 247
-  gray66              = 248
-  gray70              = 249
-  gray74              = 250
-  gray78              = 251
-  gray82              = 252
-  gray85              = 253
-  gray89              = 254
-  gray93              = 255
+# maps annotations of the enum to a hexToColor table
+macro mapAnnotationToTable(args: varargs[untyped]): untyped =
+  var lines: seq[string]
+  let original = args[0]
+  # read source file at compile time into string
+  # and put all ines in the lines sequence
+  for line in staticRead(original.lineInfoObj.filename).splitLines():
+    lines.add line
+  let typeDef           = original[0][0]
+  let enumTy            = typeDef[2]
+  let tableIdent        = ident"hexToColorTable"
+  let tableReverseIdent = ident"colorToHexTable"
+  let tableRGBIdent     = ident"colorToRGBTable"
+
+  # create filling lines for the hexToColor table
+  var fillTable: NimNode = quote do: discard
+  for child in enumTy:
+    if child.kind != nnkEnumFieldDef:
+      continue
+    let line = lines[child.lineInfoObj.line-1].strip()
+    # check for annotations
+    if "##" notIn line:
+      continue
+
+    let hexCode = line[line.len()-6..line.len()-1]
+    let red     = parseHexInt(hexCode[0..1])
+    let green   = parseHexInt(hexCode[2..3])
+    let blue    = parseHexInt(hexCode[4..5])
+    if hexCode.len() == 6:
+      let intLit = child[1]
+      fillTable = quote do:
+        `fillTable`
+        `tableIdent`[`hexCode`]       = `intLit`
+        `tableReverseIdent`[`intLit`] = `hexCode`
+        `tableRGBIdent`[`intLit`]     = (`red`, `green`, `blue`)
+  
+  # emit source code
+  return quote do:
+    var `tableIdent`        = initTable[string, int]()
+    var `tableReverseIdent` = initTable[int, string]()
+    var `tableRGBIdent`     = initTable[int, (int, int, int)]()
+    `original`
+    `fillTable`
+
+mapAnnotationToTable:
+  type Color* = enum
+    default             = -1
+    black               = 0    ## hex: #000000
+    maroon              = 1    ## hex: #800000
+    green               = 2    ## hex: #008000
+    olive               = 3    ## hex: #808000
+    navy                = 4    ## hex: #000080
+    purple_1            = 5    ## hex: #800080
+    teal                = 6    ## hex: #008080
+    silver              = 7    ## hex: #c0c0c0
+    gray                = 8    ## hex: #808080
+    red                 = 9    ## hex: #ff0000
+    lime                = 10   ## hex: #00ff00
+    yellow              = 11   ## hex: #ffff00
+    blue                = 12   ## hex: #0000ff
+    fuchsia             = 13   ## hex: #ff00ff
+    aqua                = 14   ## hex: #00ffff
+    white               = 15   ## hex: #ffffff
+    gray0               = 16   ## hex: #000000
+    navyBlue            = 17   ## hex: #00005f
+    darkBlue            = 18   ## hex: #000087
+    blue3_1             = 19   ## hex: #0000af
+    blue3_2             = 20   ## hex: #0000d7
+    blue1               = 21   ## hex: #0000ff
+    darkGreen           = 22   ## hex: #005f00
+    deepSkyBlue4_1      = 23   ## hex: #005f5f
+    deepSkyBlue4_2      = 24   ## hex: #005f87
+    deepSkyBlue4_3      = 25   ## hex: #005faf
+    dodgerBlue3_1       = 26   ## hex: #005fd7
+    dodgerBlue3_2       = 27   ## hex: #005fff
+    green4              = 28   ## hex: #008700
+    springGreen4        = 29   ## hex: #00875f
+    turquoise4          = 30   ## hex: #008787
+    deepSkyBlue3_1      = 31   ## hex: #0087af
+    deepSkyBlue3_2      = 32   ## hex: #0087d7
+    dodgerBlue1         = 33   ## hex: #0087ff
+    green3_1            = 34   ## hex: #00af00
+    springGreen3_1      = 35   ## hex: #00af5f
+    darkCyan            = 36   ## hex: #00af87
+    lightSeaGreen       = 37   ## hex: #00afaf
+    deepSkyBlue2        = 38   ## hex: #00afd7
+    deepSkyBlue1        = 39   ## hex: #00afff
+    green3_2            = 40   ## hex: #00d700
+    springGreen3_3      = 41   ## hex: #00d75f
+    springGreen2_1      = 42   ## hex: #00d787
+    cyan3               = 43   ## hex: #00d7af
+    darkTurquoise       = 44   ## hex: #00d7df
+    turquoise2          = 45   ## hex: #00d7ff
+    green1              = 46   ## hex: #00ff00
+    springGreen2_2      = 47   ## hex: #00ff5f
+    springGreen1        = 48   ## hex: #00ff87
+    mediumSpringGreen   = 49   ## hex: #00ffaf
+    cyan2               = 50   ## hex: #00ffd7
+    cyan1               = 51   ## hex: #00ffff
+    darkRed_1           = 52   ## hex: #5f0000
+    deepPink4_1         = 53   ## hex: #5f005f
+    purple4_1           = 54   ## hex: #5f0087
+    purple4_2           = 55   ## hex: #5f00af
+    purple3             = 56   ## hex: #5f00df
+    blueViolet          = 57   ## hex: #5f00ff
+    orange4_1           = 58   ## hex: #5f5f00
+    gray37              = 59   ## hex: #5f5f5f
+    mediumPurple4       = 60   ## hex: #5f5f87
+    slateBlue3_1        = 61   ## hex: #5f5faf
+    slateBlue3_2        = 62   ## hex: #5f5fd7
+    royalBlue1          = 63   ## hex: #5f5fff
+    chartreuse4         = 64   ## hex: #5f8700
+    darkSeaGreen4_1     = 65   ## hex: #5f875f
+    paleTurquoise4      = 66   ## hex: #5f8787
+    steelBlue           = 67   ## hex: #5f87af
+    steelBlue3          = 68   ## hex: #5f87d7
+    cornflowerBlue      = 69   ## hex: #5f87ff
+    chartreuse3_1       = 70   ## hex: #5faf00
+    darkSeaGreen4_2     = 71   ## hex: #5faf5f
+    cadetBlue_1         = 72   ## hex: #5faf87
+    cadetBlue_2         = 73   ## hex: #5fafaf
+    skyBlue3            = 74   ## hex: #5fafd7
+    steelBlue1_1        = 75   ## hex: #5fafff
+    chartreuse3_2       = 76   ## hex: #5fd000
+    paleGreen3_1        = 77   ## hex: #5fd75f
+    seaGreen3           = 78   ## hex: #5fd787
+    aquamarine3         = 79   ## hex: #5fd7af
+    mediumTurquoise     = 80   ## hex: #5fd7d7
+    steelBlue1_2        = 81   ## hex: #5fd7ff
+    chartreuse2_1       = 82   ## hex: #5fff00
+    seaGreen2           = 83   ## hex: #5fff5f
+    seaGreen1_1         = 84   ## hex: #5fff87
+    seaGreen1_2         = 85   ## hex: #5fffaf
+    aquamarine1_1       = 86   ## hex: #5fffd7
+    darkSlateGray2      = 87   ## hex: #5fffff
+    darkRed_2           = 88   ## hex: #870000
+    deepPink4_2         = 89   ## hex: #87005f
+    darkMagenta_1       = 90   ## hex: #870087
+    darkMagenta_2       = 91   ## hex: #8700af
+    darkViolet_1        = 92   ## hex: #8700d7
+    purple_2            = 93   ## hex: #8700ff
+    orange4_2           = 94   ## hex: #875f00
+    lightPink4          = 95   ## hex: #875f5f
+    plum4               = 96   ## hex: #875f87
+    mediumPurple3_1     = 97   ## hex: #875faf
+    mediumPurple3_2     = 98   ## hex: #875fd7
+    slateBlue1          = 99   ## hex: #875fff
+    yellow4_1           = 100  ## hex: #878700
+    wheat4              = 101  ## hex: #87875f
+    gray53              = 102  ## hex: #878787
+    lightSlategray      = 103  ## hex: #8787af
+    mediumPurple        = 104  ## hex: #8787d7
+    lightSlateBlue      = 105  ## hex: #8787ff
+    yellow4_2           = 106  ## hex: #87af00
+    Wheat4              = 107  ## hex: #87af5f
+    darkSeaGreen        = 108  ## hex: #87af87
+    lightSkyBlue3_1     = 109  ## hex: #87afaf
+    lightSkyBlue3_2     = 110  ## hex: #87afd7
+    skyBlue2            = 111  ## hex: #87afff
+    chartreuse2_2       = 112  ## hex: #87d700
+    darkOliveGreen3_1   = 113  ## hex: #87d75f
+    paleGreen3_2        = 114  ## hex: #87d787
+    darkSeaGreen3_1     = 115  ## hex: #87d7af
+    darkSlateGray3      = 116  ## hex: #87d7d7
+    skyBlue1            = 117  ## hex: #87d7ff
+    chartreuse1         = 118  ## hex: #87ff00
+    lightGreen_1        = 119  ## hex: #87ff5f
+    lightGreen_2        = 120  ## hex: #87ff87
+    paleGreen1_1        = 121  ## hex: #87ffaf
+    aquamarine1_2       = 122  ## hex: #87ffd7
+    darkSlateGray1      = 123  ## hex: #87ffff
+    red3_1              = 124  ## hex: #af0000
+    deepPink4           = 125  ## hex: #af005f
+    mediumVioletRed     = 126  ## hex: #af0087
+    magenta3            = 127  ## hex: #af00af
+    darkViolet_2        = 128  ## hex: #af00d7
+    purple              = 129  ## hex: #af00ff
+    darkOrange3_1       = 130  ## hex: #af5f00
+    indianRed_1         = 131  ## hex: #af5f5f
+    hotPink3_1          = 132  ## hex: #af5f87
+    mediumOrchid3       = 133  ## hex: #af5faf
+    mediumOrchid        = 134  ## hex: #af5fd7
+    mediumPurple2_1     = 135  ## hex: #af5fff
+    darkGoldenrod       = 136  ## hex: #af8700
+    lightSalmon3_1      = 137  ## hex: #af875f
+    rosyBrown           = 138  ## hex: #af8787
+    gray63              = 139  ## hex: #af87af
+    mediumPurple2_2     = 140  ## hex: #af87d7
+    mediumPurple1       = 141  ## hex: #af87ff
+    gold3_1             = 142  ## hex: #afaf00
+    darkKhaki           = 143  ## hex: #afaf5f
+    navajoWhite3        = 144  ## hex: #afaf87
+    gray69              = 145  ## hex: #afafaf
+    lightSteelBlue3     = 146  ## hex: #afafd7
+    lightSteelBlue      = 147  ## hex: #afafff
+    yellow3_1           = 148  ## hex: #afd700
+    darkOliveGreen3_2   = 149  ## hex: #afd75f
+    darkSeaGreen3_2     = 150  ## hex: #afd787
+    darkSeaGreen2_1     = 151  ## hex: #afd7af
+    lightCyan3          = 152  ## hex: #afafd7
+    lightSkyBlue1       = 153  ## hex: #afd7ff
+    greenYellow         = 154  ## hex: #afff00
+    darkOliveGreen2     = 155  ## hex: #afff5f
+    paleGreen1_2        = 156  ## hex: #afff87
+    darkSeaGreen2_2     = 157  ## hex: #afffaf
+    darkSeaGreen1_1     = 158  ## hex: #afffd7
+    paleTurquoise1      = 159  ## hex: #afffff
+    red3_2              = 160  ## hex: #d70000
+    deepPink3_1         = 161  ## hex: #d7005f
+    deepPink3_2         = 162  ## hex: #d70087
+    magenta3_1          = 163  ## hex: #d700af
+    magenta3_2          = 164  ## hex: #d700d7
+    magenta2_1          = 165  ## hex: #d700ff
+    darkOrange3_2       = 166  ## hex: #d75f00
+    indianRed_2         = 167  ## hex: #d75f5f
+    hotPink3_2          = 168  ## hex: #d75f87
+    hotPink2            = 169  ## hex: #d75faf
+    orchid              = 170  ## hex: #d75fd7
+    mediumOrchid1_1     = 171  ## hex: #d75fff
+    orange3             = 172  ## hex: #d78700
+    lightSalmon3_2      = 173  ## hex: #d7875f
+    lightPink3          = 174  ## hex: #d78787
+    pink3               = 175  ## hex: #d787af
+    plum3               = 176  ## hex: #d787d7
+    violet              = 177  ## hex: #d787ff
+    gold3_2             = 178  ## hex: #d7af00
+    lightGoldenrod3     = 179  ## hex: #d7af5f
+    tan                 = 180  ## hex: #d7af87
+    mistyRose3          = 181  ## hex: #d7afaf
+    thistle3            = 182  ## hex: #d7afd7
+    plum2               = 183  ## hex: #d7afff
+    yellow3_2           = 184  ## hex: #d7d700
+    khaki3              = 185  ## hex: #d7d75f
+    lightGoldenrod2     = 186  ## hex: #d7d787
+    lightYellow3        = 187  ## hex: #d7d7af
+    gray84              = 188  ## hex: #d7d7d7
+    lightSteelBlue1     = 189  ## hex: #d7d7ff
+    yellow2             = 190  ## hex: #d7ff00
+    darkOliveGreen1_1   = 191  ## hex: #d7ff5f
+    darkOliveGreen1_2   = 192  ## hex: #d7ff87
+    darkSeaGreen1_2     = 193  ## hex: #d7ffaf
+    honeydew2           = 194  ## hex: #d7ffd7
+    lightCyan1          = 195  ## hex: #d7ffff
+    red1                = 196  ## hex: #ff0000
+    deepPink2           = 197  ## hex: #ff005f
+    deepPink1_1         = 198  ## hex: #ff0087
+    deepPink1_2         = 199  ## hex: #ff00af
+    magenta2_2          = 200  ## hex: #ff00d7
+    magenta1            = 201  ## hex: #ff00ff
+    orangeRed1          = 202  ## hex: #ff5f00
+    indianRed1_1        = 203  ## hex: #ff5f5f
+    indianRed1_2        = 204  ## hex: #ff5f87
+    hotPink1_1          = 205  ## hex: #ff5faf
+    hotPink1_2          = 206  ## hex: #ff5fd7
+    mediumOrchid1_2     = 207  ## hex: #ff5fff
+    darkOrange          = 208  ## hex: #ff8700
+    salmon1             = 209  ## hex: #ff875f
+    lightCoral          = 210  ## hex: #ff8787
+    paleVioletRed1      = 211  ## hex: #ff87af
+    orchid2             = 212  ## hex: #ff87d7
+    orchid1             = 213  ## hex: #ff87ff
+    orange1             = 214  ## hex: #ffaf00
+    sandyBrown          = 215  ## hex: #ffaf5f
+    lightSalmon1        = 216  ## hex: #ffaf87
+    lightPink1          = 217  ## hex: #ffafaf
+    pink1               = 218  ## hex: #ffafd7
+    plum1               = 219  ## hex: #ffafff
+    gold1               = 220  ## hex: #ffd700
+    lightGoldenrod2_1   = 221  ## hex: #ffd75f
+    lightGoldenrod2_2   = 222  ## hex: #ffd787
+    navajoWhite1        = 223  ## hex: #ffd7af
+    mistyRose1          = 224  ## hex: #ffd7d7
+    thistle1            = 225  ## hex: #ffd7ff
+    yellow1             = 226  ## hex: #ffff00
+    lightGoldenrod1     = 227  ## hex: #ffff5f
+    khaki1              = 228  ## hex: #ffff87
+    wheat1              = 229  ## hex: #ffffaf
+    cornsilk1           = 230  ## hex: #ffffd7
+    gray100             = 231  ## hex: #ffffff
+    gray3               = 232  ## hex: #080808
+    gray7               = 233  ## hex: #121212
+    gray11              = 234  ## hex: #1c1c1c
+    gray15              = 235  ## hex: #262626
+    gray19              = 236  ## hex: #303030
+    gray23              = 237  ## hex: #3a3a3a
+    gray27              = 238  ## hex: #444444
+    gray30              = 239  ## hex: #4e4e4e
+    gray35              = 240  ## hex: #585858
+    gray39              = 241  ## hex: #626262
+    gray42              = 242  ## hex: #6c6c6c
+    gray46              = 243  ## hex: #767676
+    gray50              = 244  ## hex: #808080
+    gray54              = 245  ## hex: #8a8a8a
+    gray58              = 246  ## hex: #949494
+    gray62              = 247  ## hex: #9e9e9e
+    gray66              = 248  ## hex: #a8a8a8
+    gray70              = 249  ## hex: #b2b2b2
+    gray74              = 250  ## hex: #bcbcbc
+    gray78              = 251  ## hex: #c6c6c6
+    gray82              = 252  ## hex: #d0d0d0
+    gray85              = 253  ## hex: #dadada
+    gray89              = 254  ## hex: #e4e4e4
+    gray93              = 255  ## hex: #eeeeee
+
+# Calculates the difference between two rgb colors
+template calcRGBDifference(col1: (int, int, int), col2: (int, int, int)): int =
+  abs(col1[0] - col2[0]) + abs(col1[1] - col2[1]) + abs(col1[2] - col2[2])
+
+# Converts an rgb value to a color,
+# the closest color is approximated
+proc RGBToColor*(red, green, blue: int): Color =
+  var closestColor     : Color
+  var lowestDifference : int    = 100000
+  for key, value in colorToRGBTable:
+    let keyRed   = value[0]
+    let keyGreen = value[1]
+    let keyBlue  = value[2]
+    let difference = calcRGBDifference((red, green, blue),(keyRed, keyGreen, keyBlue))
+    if difference < lowestDifference:
+      lowestDifference = difference
+      closestColor     = Color(key)
+      if difference == 0:
+        break
+  return closestColor
+
+# Note: this takes a hex string of the form
+# f0f0f0 as opposed to #f0f0f0
+proc hexToColor*(hex: string): Color =
+  let red   = parseHexInt(hex[0..1])
+  let green = parseHexInt(hex[2..3])
+  let blue  = parseHexInt(hex[4..5])
+  return RGBToColor(red, green, blue)
+
+# Returns the closest inverse Color
+# for col.
+proc inverseColor*(col: Color): Color =
+  if not colorToHexTable.hasKey(int(col)):
+    return Color.default
+
+  var rgb      = colorToRGBTable[int(col)]
+  rgb[0] = abs(rgb[0] - 255)
+  rgb[1] = abs(rgb[1] - 255)
+  rgb[2] = abs(rgb[2] - 255)
+  return RGBToColor(rgb[0], rgb[1], rgb[2])
+
+# Make Color col readable on the background.
+# This tries to preserve the color of col as much as
+# possible, but adjusts it when needed for
+# becoming readable on the background.
+# Returns col without changes, if it's already readable.
+proc readableOnBackground*(col: Color, background: Color): Color =
+  template incDiff(val1: untyped, val2: untyped) =
+    if val1 > val2:
+      let newVal = val1 + (val1 - val2) * 1
+      if newVal > 255:
+        val1 = 255
+      else:
+        val1 = newVal
+    elif val1 < val2:
+      let newVal = val1 - (val2 - val1) * 1
+      if newVal < 0:
+        val1 = 0
+      else:
+        val1 = newVal
+
+  let minDiff = 255
+
+  var
+    rgb1 : (int, int, int)
+    rgb2 : (int, int, int)
+  if colorToRGBTable.hasKey(int(col)):
+    rgb1 = colorToRGBTable[int(col)]
+  else:
+    #rgb1 = (128,128,128)
+    rgb1 = (0, 0, 0)
+  if colorToRGBTable.hasKey(int(background)):
+    rgb2 = colorToRGBTable[int(background)]
+  else:
+    #rgb2 = (128,128,128)
+    rgb2 = (0, 0, 0)
+
+  var diff = calcRGBDifference((rgb1[0], rgb1[1], rgb1[2]), (rgb2[0], rgb2[1], rgb2[2]))
+  if diff < minDiff:
+    let missingDiff = minDiff - diff
+    incDiff(rgb1[0], rgb2[0])
+    incDiff(rgb1[1], rgb2[1])
+    incDiff(rgb1[2], rgb2[2])
+  diff = calcRGBDifference((rgb1[0], rgb1[1], rgb1[2]), (rgb2[0], rgb2[1], rgb2[2]))
+  if diff < minDiff:
+    return inverseColor(col)
+  return RGBToColor(rgb1[0], rgb1[1], rgb1[2])
 
 type ColorTheme* = enum
   config  = 0

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -815,7 +815,7 @@ proc parseSettingsFile*(filename: string): EditorSettings =
       var vsCodeExtensionsDir = homeDir & "/.vscode-oss/extensions/"
       var vsCodeThemeSetting = ""
       if not existsFile(vsCodeSettingsFile):
-        vsCodeSettingsFile = homeDir & "/.config/VSCode/User/settings.json"
+        vsCodeSettingsFile = homeDir & "/.config/Code/User/settings.json"
       if existsFile(vsCodeSettingsFile):
         let vsCodeSettingsJson = json.parseFile(vsCodeSettingsFile)
         vsCodeThemeSetting = vsCodeSettingsJson{"workbench.colorTheme"}.getStr()

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -1,5 +1,5 @@
-import parsetoml, os
-from strutils import parseEnum
+import parsetoml, os, json, macros
+from strutils import parseEnum, endsWith
 
 when (NimMajor, NimMinor, NimPatch) > (1, 3, 0):
   # This addresses a breaking change in https://github.com/nim-lang/Nim/pull/14046.
@@ -113,18 +113,356 @@ proc getCursorType(cursorType, mode: string): CursorType =
 proc getTheme(theme: string): ColorTheme =
   if theme == "dark": return ColorTheme.dark
   elif theme == "light": return ColorTheme.light
+  elif theme == "config": return ColorTheme.config
+  elif theme == "vscode": return ColorTheme.config
   else: return ColorTheme.vivid
+
+# This macro takes statement lists for the foreground and
+# background colors of a foreground/background color setting.
+# these statements are supposed to set the color, and
+# the first statement that doesn't result in Color.default
+# will be used. Color.default will only be used when there's
+# no success at all.
+# Finally adjusts can be used to generate a suitable color.
+# adjusts:
+#   InverseBackground    - inversing the background color
+#   InverseForeground    - inversing the foreground color
+#   ReadableVsBackground - adjusts foreground to be readable
+macro setEditorColor(args: varargs[untyped]): untyped =
+  echo args.treeRepr
+  let colorNameIdent           = args[0]
+  let colorNameBackgroundIdent = ident(colorNameIdent.strVal & "Bg")
+  let resultIdent              = ident"result"
+  let fgColorIdent             = genSym(nskVar, "fgColor")
+  let bgColorIdent             = genSym(nskVar, "bgColor")
+  let stmtList                 = args[^1]
+  let fgStmtList               = stmtList[0][^1]
+  let bgStmtList               = stmtList[^1][^1]
+  var setFgColor               : NimNode = quote do: discard
+  var setBgColor               : NimNode = quote do: discard
+  var fgDynamicAdjust          : NimNode = quote do: discard
+  var bgDynamicAdjust          : NimNode = quote do: discard
+  var assignColors             : NimNode = quote do: discard
+  var fallbackInverseBg        : NimNode = quote do:
+    if (`fgColorIdent` == Color.default and
+        `bgColorIdent` != Color.default):
+      `fgColorIdent` = inverseColor(`bgColorIdent`)
+  var fallbackInverseFg        : NimNode = quote do:
+    if (`fgColorIdent` != Color.default and
+        `bgColorIdent` == Color.default):
+      `bgColorIdent` = inverseColor(`fgColorIdent`)
+  var readableVsBackground     : NimNode = quote do:
+    `fgColorIdent` = readableOnBackground(`fgColorIdent`, `bgColorIdent`)
+  for statement in fgStmtList:
+    if (statement.kind == nnkCall and statement[0].kind == nnkIdent and
+        statement[0].strVal() == "adjust"):
+        let adjust = statement[^1][0].strVal()
+        case adjust
+        of "InverseBackground":
+          fgDynamicAdjust = quote do:
+            `fgDynamicAdjust`
+            `fallbackInverseBg`
+        of "ReadableVsBackground":
+          fgDynamicAdjust = quote do:
+            `fgDynamicAdjust`
+            `readableVsBackground`
+        else: discard
+    else:
+      setFgColor = quote do:
+        `setFgColor`
+        if `fgColorIdent` == Color.default:
+          `fgColorIdent` = `statement`
+  for statement in bgStmtList:
+    setBgColor = quote do:
+      `setBgColor`
+      if `bgColorIdent` == Color.default:
+        `bgColorIdent` = `statement`
+  if stmtList[0][0].strVal() == stmtList[^1][0].strVal():
+    # they are the same => there's only one
+    setBgColor = quote do: discard
+    #fgDynamicAdjust = quote do: discard
+    #bgDynamicAdjust = quote do: discard
+    assignColors    = quote do:
+      `resultIdent`.`colorNameIdent`           = `fgColorIdent`
+  else:
+    assignColors    = quote do:
+      `resultIdent`.`colorNameIdent`           = `fgColorIdent`
+      `resultIdent`.`colorNameBackgroundIdent` = `bgColorIdent`
+
+  return quote do:
+    var `fgColorIdent` = Color.default
+    var `bgColorIdent` = Color.default
+    `setFgColor`
+    `setBgColor`
+    `fgDynamicAdjust`
+    `bgDynamicAdjust`
+    `assignColors`
+
+proc makeColorThemeFromVSCodeThemeFile(fileName: string): EditorColor =
+  let jsonNode = json.parseFile(fileName)
+
+  # This converts a JsonNode JString to a 256-Color-Terminal-Color
+  proc colorFromNode(node: JsonNode): Color =
+    if node == nil:
+      return Color.default
+    var asString = node.getStr()
+    if (asString.len() >= 7   and
+        asString[0]    == '#'):
+        return hexToColor(asString[1..asString.len()-1])
+    return Color.default
+
+  var tokenNodes = initTable[string, JsonNode]()
+  for node in jsonNode{"tokenColors"}:
+    var scope = node{"scope"}
+    let settings = node{"settings"}
+    if scope == nil:
+      scope = parseJson("\"unnamedScope\"")
+    if settings == nil:
+      continue
+    if scope.len() > 0:
+      for item in scope:
+        tokenNodes[item.getStr()] = settings
+    else:
+      tokenNodes[scope.getStr()] = settings
+
+  # Convenience
+  proc getScope(key: string): JsonNode =
+    if tokenNodes.hasKey(key):
+      return tokenNodes[key]
+    else:
+      JsonNode.default()
+
+  # This is currently optimized and tested for the Forest Focus theme
+  # and even for that theme it only produces a partial and imperfect
+  # translation
+  expandMacros:
+    setEditorColor editorBg:
+      background:
+        colorFromNode(jsonNode{"colors", "editor.background"})
+    setEditorColor defaultChar:
+      foreground:
+        colorFromNode(jsonNode{"colors", "editor.foreground"})
+    setEditorColor gtKeyword:
+      foreground:
+        colorFromNode(getScope("keyword"){"foreground"})
+    setEditorColor gtStringLit:
+      foreground:
+        colorFromNode(getScope("string"){"foreground"})
+    setEditorColor gtDecNumber:
+      foreground:
+        colorFromNode(getScope("constant"){"foreground"})
+    setEditorColor gtComment:
+      foreground:
+        colorFromNode(getScope("comment"){"foreground"})
+    setEditorColor gtLongComment:
+      foreground:
+        colorFromNode(getScope("comment"){"foreground"})
+    setEditorColor gtWhitespace:
+      foreground:
+        colorFromNode(jsonNode{"colors", "editorWhitespace.foreground"})
+    # status bar
+    setEditorColor statusBarNormalMode:
+      foreground:
+        colorFromNode(jsonNode{"colors", "editor.foreground"})
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarModeNormalMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarInsertMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarModeInsertMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        white
+    setEditorColor statusBarVisualMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarModeVisualMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        white
+    setEditorColor statusBarReplaceMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarModeReplaceMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        white
+    setEditorColor statusBarFilerMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarModeFilerMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        white
+    setEditorColor statusBarExMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarModeExMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        white
+    # command  bar
+    setEditorColor commandBar:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        Color.default
+    # error message
+    setEditorColor errorMessage:
+      foreground:
+        colorFromNode(getScope("console.error"){"foreground"})
+      background:
+        Color.default
+    setEditorColor currentTab:
+      foreground:
+        colorFromNode(jsonNode{"colors", "tab.foreground"})
+      background:
+        colorFromNode(jsonNode{"colors", "tab.activeBackground"})
+
+    setEditorColor tab:
+      foreground:
+        colorFromNode(jsonNode{"colors", "tab.foreground"})
+      background:
+        colorFromNode(jsonNode{"colors", "tab.inactiveBackground"})
+    
+    setEditorColor lineNum:
+      foreground:
+        colorFromNode(jsonNode{"colors", "editorLineNumber.foreground"})
+        adjust: InverseBackground
+      background:
+        colorFromNode(jsonNode{"colors", "editorLineNumber.background"})
+    
+    setEditorColor currentLineNum:
+      foreground:
+        colorFromNode(jsonNode{"colors", "editorCursor.foreground"})
+      background:
+        colorFromNode(jsonNode{"colors", "editor.background"})
+
+    setEditorColor pcLink:
+      foreground:
+        colorFromNode(getScope("hyperlink"){"foreground"})
+        adjust: ReadableVsBackground
+      background:
+        Color.default
+    
+    # highlight other uses current word
+    setEditorColor currentWord:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "editor.selectionBackground"})
+    
+    setEditorColor popUpWinCurrentLine:
+      foreground:
+        colorFromNode(jsonNode{"colors", "sideBarTitle.forground"})
+      background:
+        colorFromNode(jsonNode{"colors", "sideBarSectionHeader.background"})
+        
+    # pop up window
+    setEditorColor popUpWindow:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "sideBar.background"})
+
+    # pair of paren highlighting
+    setEditorColor parenText:
+      foreground:
+        colorFromNode(getScope("unnamedScope"){"bracketsForeground"})
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "editor.selectionBackground"})
+
+    # replace text highlighting
+    setEditorColor replaceText:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors",
+          "gitDecoration.conflictingResourceForeground"})
+    # filer mode
+    setEditorColor currentFile:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "editor.selectionBackground"})
+    setEditorColor file:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        Color.default
+    setEditorColor dir:
+      foreground:
+        colorFromNode(getScope("hyperlink"){"foreground"})
+        adjust: ReadableVsBackground
+      background:
+        Color.default
+    # highlight full width space
+    setEditorColor highlightFullWidthSpace:
+      foreground:
+        colorFromNode(jsonNode{"colors", "tab.activeBorder"})
+      background:
+        colorFromNode(jsonNode{"colors", "tab.activeBorder"})
+    # work space bar
+    setEditorColor workSpaceBar:
+      foreground:
+        colorFromNode(jsonNode{"colors", "activityBar.foreground"})
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "activityBar.background"})
+    setEditorColor todo:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "activityBarBadge.background"})
+    # search result highlighting
+    setEditorColor searchResult:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "tab.activeBorder"})
+    # selected area in visual mode
+    setEditorColor visualMode:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "tab.activeBorder"})
 
 proc parseSettingsFile*(filename: string): EditorSettings =
   result = initEditorSettings()
 
+  var vscodeTheme = false
   var settings: TomlValueRef
   try: settings = parsetoml.parseFile(filename)
   except IOError: return
 
   if settings.contains("Standard"):
     if settings["Standard"].contains("theme"):
-      result.editorColorTheme = getTheme(settings["Standard"]["theme"].getStr())
+      let themeString = settings["Standard"]["theme"].getStr()
+      result.editorColorTheme = getTheme(themeString)
+      if themeString == "vscode":
+        vscodeTheme = true
 
     if settings["Standard"].contains("number"):
       result.view.lineNumber = settings["Standard"]["number"].getbool()
@@ -244,10 +582,14 @@ proc parseSettingsFile*(filename: string): EditorSettings =
     if settings["WorkSpace"].contains("useBar"):
         result.workSpace.useBar = settings["WorkSpace"]["useBar"].getbool()
 
-  if settings.contains("Theme"):
+  if not vscodeTheme and settings.contains("Theme"):
     if settings["Theme"].contains("baseTheme"):
-      let theme = parseEnum[ColorTheme](settings["Theme"]["baseTheme"].getStr())
-      ColorThemeTable[ColorTheme.config] = ColorThemeTable[theme]
+      let themeString = settings["Theme"]["baseTheme"].getStr()
+      if fileExists(themeString):
+        ColorThemeTable[ColorTheme.config] = makeColorThemeFromVSCodeThemeFile(themeString)
+      else:
+        let theme = parseEnum[ColorTheme](themeString)
+        ColorThemeTable[ColorTheme.config] = ColorThemeTable[theme]
 
     template color(str: string): untyped =
       parseEnum[Color](settings["Theme"][str].getStr())
@@ -457,6 +799,67 @@ proc parseSettingsFile*(filename: string): EditorSettings =
       ColorThemeTable[ColorTheme.config].workSpaceBarBg = color("wrokSpaceBarBg")
 
     result.editorColorTheme = ColorTheme.config
+  if vscodeTheme:
+    # search for the vscode theme that is set in the current preferences of
+    # vscode/vscodium. Vscodium takes precedence, since you can assume that,
+    # people that install VScodium prefer it over Vscode for privacy reasons.
+    # If no vscode theme can be found, this defaults to the vivid theme.
+    # The first implementation is for finding the VsCode/VsCodium config and
+    # extension folders on Linux. Hopefully other contributors will come and
+    # add support for Windows, and other systems.
+    var vsCodeThemeLoaded = false
+    block vsCodeThemeLoading:
+      let homeDir = getHomeDir()
+      var vsCodeSettingsFile = homeDir & "/.config/VSCodium/User/settings.json"
+      var vsCodeThemeFile = ""
+      var vsCodeExtensionsDir = homeDir & "/.vscode-oss/extensions/"
+      var vsCodeThemeSetting = ""
+      if not existsFile(vsCodeSettingsFile):
+        vsCodeSettingsFile = homeDir & "/.config/VSCode/User/settings.json"
+      if existsFile(vsCodeSettingsFile):
+        let vsCodeSettingsJson = json.parseFile(vsCodeSettingsFile)
+        vsCodeThemeSetting = vsCodeSettingsJson{"workbench.colorTheme"}.getStr()
+        if vsCodeThemeSetting == "":
+          break vsCodeThemeLoading
+
+      else:
+        break vsCodeThemeLoading
+      
+      if not existsDir(vsCodeExtensionsDir):
+        vsCodeExtensionsDir = homeDir & "/.vscode/extensions/"
+        if not existsDir(vsCodeExtensionsDir):
+          break vsCodeThemeLoading
+      
+      # note: walkDirRec was first used to solve this, however
+      #       the performance at runtime was much worse
+      for file in walkPattern(vsCodeExtensionsDir & "/*/package.json"):
+        if file.endsWith("/package.json"):
+          var vsCodePackageJson: JsonNode
+          try:
+            vsCodePackageJson = json.parseFile(file)
+          except:
+            break vsCodeThemeLoading
+          let displayName = vsCodePackageJson{"displayName"}
+          if displayName == nil: continue
+
+          if displayName.getStr() == vsCodeThemeSetting:
+            let themesJson = vsCodePackageJson{"contributes", "themes"}
+            if themesJson != nil and themesJson.len() > 0:
+              let theTheme = themesJson[0]
+              let theThemePath = theTheme{"path"}
+              if theThemePath != nil and theThemePath.kind == JString:
+                vsCodeThemeFile = parentDir(file) / theThemePath.getStr()
+            else:
+              break vsCodeThemeLoading
+            break
+      
+      if fileExists(vsCodeThemeFile):
+        result.editorColorTheme = ColorTheme.config
+        ColorThemeTable[ColorTheme.config] =
+          makeColorThemeFromVSCodeThemeFile(vsCodeThemeFile)
+        vsCodeThemeLoaded = true
+    if not vsCodeThemeLoaded:
+      result.editorColorTheme = ColorTheme.vivid
 
 proc loadSettingFile*(settings: var EditorSettings) =
   try: settings = parseSettingsFile(getConfigDir() / "moe" / "moerc.toml")


### PR DESCRIPTION
This was only tested against the Forest Focus theme for VSCode/VSCodium,
and was made to approximate the theme, not to imitate it perfectly,  (this is work in progress).
There are some rough corners.

It might work fine with other VSCode themes, but it's untested so far.
Help appreciated!

The vscode theme can be detected automatically, but support for this was
only tested on Linux. For this you simply set "vscode" as the theme in
the Standard section of the config.
You can set the baseTheme setting of the Theme section in the config
to a VSCode theme file and set the theme in the Standard section to "config",
this should work on all systems.

I created a macro named setEditorColor, that should make it relatively easy to
fix the code for more themes.
Here's one example:
```
    setEditorColor searchResult:
      foreground:
        adjust: ReadableVsBackground
      background:
        colorFromNode(jsonNode{"colors", "tab.activeBorder"})
```
As you can see "tab.activeBorder" is used for the background of search results,
which is a very creative mapping of colors from VSCode to moe, that randomly
works for the Forest Focus theme (and my taste), but will probably fail for other
themes. "adjust: ReadableVsBackground" ensures, that foreground colors are
readable compared to their background by doing some "magic" calculations and
adjusting the foreground color.
If we find some other VSCode theme properties that work better for a great number
of themes, they should be put first in the respective foreground/background lists,
as every statement there that doesn't return Color.default will be deemed a success,
and will thus be used to set that color.
Example:
```
    setEditorColor searchResult:
      foreground:
        colorFromNode(jsonNode{"colors", "some.betterForegroundForSearch"})
        adjust: ReadableVsBackground
      background:
        colorFromNode(jsonNode{"colors", "some.betterBackgroundForSearch"})
        colorFromNode(jsonNode{"colors", "tab.activeBorder"})
```
With these changes (but first we would have to know what that better property is!),
"tab.activeBorder" will simply be ignored, for all VSCode theme files, that contain
"some.betterBackgroundForSearch". And if "some.betterBackgroundForSearch" is
missing (like in Forest Focus) "tab.activeBorder" would be used as a fallback.

You can ask me anything. 