### PR TITLE
This makes ^ , _ and 'I' match the behavior of vim

### DIFF
--- a/src/moepkg/editor.nim
+++ b/src/moepkg/editor.nim
@@ -160,7 +160,7 @@ proc deleteCharacterBeginningOfLine*(bufStatus: var BufferStatus, autoDeletePare
 proc deleteCharactersOfLine*(bufStatus: var BufferStatus, autoDeleteParen: bool, windowNode: WindowNode) =
   let
     currentLine = windowNode.currentLine
-    firstNonBlank = getFirstNonBlankOfLine(bufStatus, windowNode)
+    firstNonBlank = getFirstNonBlankOfLineOrFirstColumn(bufStatus, windowNode)
   windowNode.currentColumn = firstNonBlank
   windowNode.expandedColumn = firstNonBlank
   for _ in firstNonBlank ..< bufStatus.buffer[currentLine].len:

--- a/src/moepkg/movement.nim
+++ b/src/moepkg/movement.nim
@@ -30,14 +30,26 @@ proc keyDown*(bufStatus: var BufferStatus, windowNode: var WindowNode) =
   windowNode.currentColumn = min(windowNode.expandedColumn, maxColumn)
   if windowNode.currentColumn < 0: windowNode.currentColumn = 0
 
-proc getFirstNonBlankOfLine*(bufStatus: BufferStatus, windowNode: WindowNode): Natural =
+proc getFirstNonBlankOfLine*(bufStatus: BufferStatus, windowNode: WindowNode): int =
   if bufStatus.buffer[windowNode.currentLine].len() == 0:
     return 0
   let lineLen = bufStatus.buffer[windowNode.currentLine].len()
   while bufStatus.buffer[windowNode.currentLine][result] == ru' ':
     inc(result)
     if result == lineLen:
-      return 0
+      return -1
+
+proc getFirstNonBlankOfLineOrLastColumn*(bufStatus  : BufferStatus,
+                                         windowNode : WindowNode  ): int =
+  result = getFirstNonBlankOfLine(bufStatus, windowNode)
+  if result == -1:
+    return bufStatus.buffer[windowNode.currentLine].len()-1
+
+proc getFirstNonBlankOfLineOrFirstColumn*(bufStatus  : BufferStatus,
+                                          windowNode : WindowNode  ): int =
+  result = getFirstNonBlankOfLine(bufStatus, windowNode)
+  if result == -1:
+    return 0
 
 proc getLastNonBlankOfLine*(bufStatus: BufferStatus, windowNode: WindowNode): Natural =
   if bufStatus.buffer[windowNode.currentLine].len() == 0:
@@ -48,7 +60,7 @@ proc getLastNonBlankOfLine*(bufStatus: BufferStatus, windowNode: WindowNode): Na
     dec(result)
 
 proc moveToFirstNonBlankOfLine*(bufStatus: var BufferStatus, windowNode: var WindowNode) =
-  windowNode.currentColumn = getFirstNonBlankOfLine(bufStatus, windowNode)
+  windowNode.currentColumn = getFirstNonBlankOfLineOrLastColumn(bufStatus, windowNode)
   windowNode.expandedColumn = windowNode.currentColumn
 
 proc moveToLastNonBlankOfLine*(bufStatus: var BufferStatus, windowNode: var WindowNode) =

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -356,7 +356,7 @@ proc normalCommand(status: var EditorStatus, key: Rune) =
   elif key == ord('i'):
     status.changeMode(Mode.insert)
   elif key == ord('I'):
-    windowNode.currentColumn = 0
+    status.bufStatus[currentBufferIndex].moveToFirstNonBlankOfLine(windowNode)
     status.changeMode(Mode.insert)
   elif key == ord('v'):
     status.changeMode(Mode.visual)


### PR DESCRIPTION
 for lines only containing spaces/blanks,

by moving the cursor to the last column, if all columns are blank.

This also makes 'I' behave as known from vim/nvim
by moving to the first non-blank character before inserting.