### PR TITLE
Fix to cannot start when invalid configuration file is loaded (#780)

### DIFF
--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -529,7 +529,7 @@ proc parseSettingsFile*(filename: string): EditorSettings =
   var vscodeTheme = false
   var settings: TomlValueRef
   try: settings = parsetoml.parseFile(filename)
-  except IOError: return
+  except IOError, TomlError: return
 
   if settings.contains("Standard"):
     if settings["Standard"].contains("theme"):


### PR DESCRIPTION
Close #780 