### PR TITLE
fix: visual and command mode messages

### DIFF
--- a/src/moepkg/commandview.nim
+++ b/src/moepkg/commandview.nim
@@ -72,7 +72,7 @@ proc writeMessageOnCommandWindow(cmdWin: var Window,
   cmdWin.refresh
 
 proc writeNoWriteError*(cmdWin: var Window, messageLog: var seq[seq[Rune]]) =
-  let mess = "Error: No write since last change"
+  let mess = "Error: No changes since last write"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.errorMessage)
   messageLog.add(mess.toRunes)
 
@@ -82,17 +82,17 @@ proc writeSaveError*(cmdWin: var Window, messageLog: var seq[seq[Rune]]) =
   messageLog.add(mess.toRunes)
 
 proc writeRemoveFileError*(cmdWin: var Window, messageLog: var seq[seq[Rune]]) =
-  let mess = "Error: can not remove file"
+  let mess = "Error: Can not remove file"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.errorMessage)
   messageLog.add(mess.toRunes)
 
 proc writeRemoveDirError*(cmdWin: var Window, messageLog: var seq[seq[Rune]]) =
-  let mess = "Error: can not remove directory"
+  let mess = "Error: Can not remove directory"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.errorMessage)
   messageLog.add(mess.toRunes)
 
 proc writeCopyFileError*(cmdWin: var Window, messageLog: var seq[seq[Rune]]) =
-  let mess = "Error: can not copy file"
+  let mess = "Error: Can not copy file"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.errorMessage)
   messageLog.add(mess.toRunes)
 
@@ -100,12 +100,12 @@ proc writeFileOpenError*(cmdWin: var Window,
                          fileName: string,
                          messageLog: var seq[seq[Rune]]) =
                          
-  let mess = "Error: can not open: " & fileName
+  let mess = "Error: Can not open: " & fileName
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.errorMessage)
   messageLog.add(mess.toRunes)
 
 proc writeCreateDirError*(cmdWin: var Window, messageLog: var seq[seq[Rune]]) =
-  let mess = "Error: : can not create direcotry"
+  let mess = "Error: Can not create directory"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.errorMessage)
   messageLog.add(mess.toRunes)
 
@@ -126,7 +126,7 @@ proc writeMessageYankedLine*(cmdWin: var Window,
                              numOfLine: int,
                              messageLog: var seq[seq[Rune]]) =
                              
-  let mess = fmt"{numOfLine} line yanked"
+  let mess = fmt"{numOfLine} line(s) yanked"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.commandBar)
   messageLog.add(mess.toRunes)
 
@@ -134,7 +134,7 @@ proc writeMessageYankedCharactor*(cmdWin: var Window,
                                   numOfChar: int,
                                   messageLog: var seq[seq[Rune]]) =
                                   
-  let mess = fmt"{numOfChar} charactor yanked"
+  let mess = fmt"{numOfChar} character(s) yanked"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.commandBar)
   messageLog.add(mess.toRunes)
 
@@ -156,7 +156,7 @@ proc writeMessageBuildOnSave*(cmdWin: var Window,
 proc writeMessageSuccessBuildOnSave*(cmdWin: var Window,
                                      messageLog: var seq[seq[Rune]]) =
                                      
-  const mess = "Success save and build"
+  const mess = "Build successful, file saved"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.commandBar)
   messageLog.add(mess.toRunes)
 
@@ -202,7 +202,7 @@ proc writePutConfigFileError*(cmdWin: var Window,
 proc writePutConfigFileAlreadyExistError*(cmdWin: var Window,
                                           messageLog: var seq[seq[Rune]]) =
 
-  const mess = "Error: Already exist configuration file"
+  const mess = "Error: Configuration file already exists"
   cmdWin.writeMessageOnCommandWindow(mess, EditorColorPair.errorMessage)
 
 proc askCreateDirPrompt*(cmdWin: var Window,

--- a/src/moepkg/visualmode.nim
+++ b/src/moepkg/visualmode.nim
@@ -12,7 +12,7 @@ proc updateSelectArea(area: var SelectArea, currentLine, currentColumn: int) =
   area.endLine = currentLine
   area.endColumn = currentColumn
 
-proc swapSlectArea(area: var SelectArea) =
+proc swapSelectArea(area: var SelectArea) =
   if area.startLine == area.endLine:
     if area.endColumn < area.startColumn: swap(area.startColumn, area.endColumn)
   elif area.endLine < area.startLine:
@@ -167,7 +167,7 @@ proc insertIndent(bufStatus: var BufferStatus, area: SelectArea, tabStop: int) =
                    bufStatus.buffer[i].high))
     if oldLine != newLine: bufStatus.buffer[i] = newLine
 
-proc replaceCharactor(bufStatus: var BufferStatus, area: SelectArea, ch: Rune) =
+proc replaceCharacter(bufStatus: var BufferStatus, area: SelectArea, ch: Rune) =
   for i in area.startLine .. area.endLine:
     let oldLine = bufStatus.buffer[i]
     var newLine = bufStatus.buffer[i]
@@ -183,7 +183,7 @@ proc replaceCharactor(bufStatus: var BufferStatus, area: SelectArea, ch: Rune) =
 
   inc(bufStatus.countChange)
 
-proc replaceCharactorBlock(bufStatus: var BufferStatus,
+proc replaceCharacterBlock(bufStatus: var BufferStatus,
                            area: SelectArea,
                            ch: Rune) =
 
@@ -256,7 +256,7 @@ proc toUpperStringBlock(bufStatus: var BufferStatus, area: SelectArea) =
     if oldLine != newLine: bufStatus.buffer[i] = newLine
 
 proc visualCommand(status: var EditorStatus, area: var SelectArea, key: Rune) =
-  area.swapSlectArea
+  area.swapSelectArea
 
   let
     clipboard = status.settings.systemClipboard
@@ -295,11 +295,11 @@ proc visualCommand(status: var EditorStatus, area: var SelectArea, key: Rune) =
   elif key == ord('r'):
     let ch = status.workSpace[status.currentWorkSpaceIndex].currentMainWindowNode.window.getKey
     if not isEscKey(ch):
-      status.bufStatus[currentBufferIndex].replaceCharactor(area, ch)
+      status.bufStatus[currentBufferIndex].replaceCharacter(area, ch)
   else: discard
 
 proc visualBlockCommand(status: var EditorStatus, area: var SelectArea, key: Rune) =
-  area.swapSlectArea
+  area.swapSelectArea
 
   let
     clipboard = status.settings.systemClipboard
@@ -335,7 +335,7 @@ proc visualBlockCommand(status: var EditorStatus, area: var SelectArea, key: Run
     status.bufStatus[currentBufferIndex].toUpperStringBlock(area)
   elif key == ord('r'):
     let ch = status.workSpace[status.currentWorkSpaceIndex].currentMainWindowNode.window.getKey
-    if not isEscKey(ch): status.bufStatus[currentBufferIndex].replaceCharactorBlock(area, ch)
+    if not isEscKey(ch): status.bufStatus[currentBufferIndex].replaceCharacterBlock(area, ch)
   else: discard
 
 proc visualMode*(status: var EditorStatus) =


### PR DESCRIPTION
Adjusted the spelling of three functions in `visualmode.nim` and a few messages in `commandview.nim`.