### PR TITLE
VSCode theme: Fix git branch name color in the status bar (#893)

### DIFF
--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -421,6 +421,11 @@ proc makeColorThemeFromVSCodeThemeFile(fileName: string): EditorColor =
         adjust: ReadableVsBackground
       background:
         colorFromNode(jsonNode{"colors", "statusBar.background"})
+    setEditorColor statusBarGitBranch:
+      foreground:
+        adjust: ReadableVsBackground
+      background:
+        colorFromNode(jsonNode{"colors", "statusBar.background"})
     # command  bar
     setEditorColor commandBar:
       foreground:


### PR DESCRIPTION
Close #893 