### PR TITLE
Fix #873

### DIFF
--- a/src/moepkg/filermode.nim
+++ b/src/moepkg/filermode.nim
@@ -108,8 +108,7 @@ proc refreshDirList(sortBy: Sort): seq[PathInfo] =
 
     if item.path.len > 0:
       item.path = $(item.path.toRunes.normalizePath)
-    else:
-      item.path = ""
+
     if list.kind in {pcLinkToDir, pcDir}:
       dirList.add item
     else:


### PR DESCRIPTION
The target of the symbolic link that failed to expand in filer mode was made the same string as the filename. I used the behavior of vim/nvim as a reference.

Close #873