### PR TITLE
Fix lastWriteTime of symbolic links

### DIFF
--- a/src/moepkg/filermode.nim
+++ b/src/moepkg/filermode.nim
@@ -92,7 +92,7 @@ proc refreshDirList(sortBy: Sort): seq[PathInfo] =
       item = (list.kind,
               list.path,
               0.int64,
-              getLastModificationTimeOrDefault(getCurrentDir()))
+              getLastModificationTimeOrDefault(list.path))
     of pcFile:
       let fileSize = try: getFileSize(list.path)
                      except IOError, OSError: 0.int64


### PR DESCRIPTION
Use `getLastModificationTime(list.path)` as lastWriteTime of symbolic links instead of `getLastModificationTime(getCurrentDir())`.