### PR TITLE
Change setup-nim-action version

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -40,7 +40,7 @@ jobs:
       with:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-${{ env.NIM_VERSION }}
-    - uses: jiro4989/setup-nim-action@v1.0.1
+    - uses: jiro4989/setup-nim-action@v1
       with:
         nim-version: ${{ env.NIM_VERSION }}
 

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -2,7 +2,15 @@ name: Build
 
 on:
   push:
+    paths-ignore:
+      - 'LICENSE'
+      - '*.md'
+      - 'documents/*.md'
   pull_request:
+    paths-ignore:
+      - 'LICENSE'
+      - '*.md'
+      - 'documents/*.md'
 
 jobs:
   before:

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -13,6 +13,11 @@ on:
       - 'documents/*.md'
 
 jobs:
+  skip:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Skip job"
+
   before:
     runs-on: ubuntu-latest
     if: "! contains(github.event.head_commit.message, '[skip ci]')"


### PR DESCRIPTION
- Using setup-nim-action `v1`
- Add paths-ignore
- Add `skip` job
  - `before` job will be skipped when commit message has `[skip ci]`. But GitHub Actions raises error when all jobs were canceled. So `skip` job needs. `skip` job always success.