### PR TITLE
Add initial support for MarkDown

### DIFF
--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -566,7 +566,8 @@ proc addNewBuffer*(status: var EditorStatus, filename: string, mode: Mode) =
   let index = status.bufStatus.high
 
   if mode != Mode.filer:
-    if not fileExists(filename): status.bufStatus[index].buffer = newFile()
+    if not fileExists(filename):
+      status.bufStatus[index].buffer = newFile()
     else:
       try:
         let textAndEncoding = openFile(filename.toRunes)
@@ -576,7 +577,8 @@ proc addNewBuffer*(status: var EditorStatus, filename: string, mode: Mode) =
         status.commandLine.writeFileOpenError(filename, status.messageLog)
         return
 
-    if filename != "": status.bufStatus[index].language = detectLanguage(filename)
+    if filename != "":
+      status.bufStatus[index].language = detectLanguage(filename)
 
   let buffer = status.bufStatus[index].buffer
   currentMainWindowNode.view = buffer.initEditorView(1, 1)
@@ -977,7 +979,8 @@ proc updateHighlight*(status: var EditorStatus, windowNode: var WindowNode) =
   for i in startLine ..< endLine: bufferInView.add(bufStatus.buffer[i])
 
   # highlight trailing spaces
-  if status.settings.highlightSettings.trailingSpaces:
+  if status.settings.highlightSettings.trailingSpaces and
+     bufStatus.language != SourceLanguage.langMarkDown:
     status.highlightTrailingSpaces
 
   # highlight full width space

--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -220,7 +220,8 @@ proc initHighlight*(buffer: string,
         empty = false
     if not empty: result.colorSegments.add(cs)
 
-  if language == SourceLanguage.langNone:
+  if language == SourceLanguage.langNone or
+     language == SourceLanguage.langMarkDown:
     splitByNewline(buffer, EditorColorPair.defaultChar)
     return result
 
@@ -318,5 +319,7 @@ proc detectLanguage*(filename: string): SourceLanguage =
     return SourceLanguage.langJavaScript
   of ".sh", ".bash":
     return SourceLanguage.langShell
+  of ".md":
+    return SourceLanguage.langMarkDown
   else:
     return SourceLanguage.langNone

--- a/src/moepkg/syntax/highlite.nim
+++ b/src/moepkg/syntax/highlite.nim
@@ -87,11 +87,12 @@ type
 
   SourceLanguage* = enum
     langNone, langNim, langCpp, langCsharp, langC, langJava,
-    langYaml, langPython, langJavaScript, langShell
+    langYaml, langPython, langJavaScript, langShell, langMarkDown
 
 const
   sourceLanguageToStr*: array[SourceLanguage, string] = ["none",
-    "Nim", "C++", "C#", "C", "Java", "Yaml", "Python", "JavaScript", "Shell"]
+    "Nim", "C++", "C#", "C", "Java", "Yaml", "Python", "JavaScript", "Shell",
+    "MarkDown"]
 
   OpChars* = {'+', '-', '*', '/', '\\', '<', '>', '!', '?', '^', '.',
               '|', '=', '%', '&', '$', '@', '~', ':'}


### PR DESCRIPTION
Does not include support for syntax highlighting in this PR.

Does not highlight trailing spaces when open MarkDown.
Show "MarkDown" on the status line.