### PR TITLE
Insert mode: Fix auto-complete suggestion window behavior

### DIFF
--- a/src/moepkg/suggestionwindow.nim
+++ b/src/moepkg/suggestionwindow.nim
@@ -45,9 +45,15 @@ proc handleKeyInSuggestionWindow*(
   let prevSuggestion = suggestionWindow.selectedSuggestion
 
   if isTabKey(key) or isDownKey(key):
-    inc(suggestionWindow.selectedSuggestion)
+    if suggestionWindow.selectedSuggestion == suggestionWindow.suggestoins.high:
+      suggestionWindow.selectedSuggestion = 0
+    else:
+      inc(suggestionWindow.selectedSuggestion)
   elif isShiftTab(key) or isUpKey(key):
-    dec(suggestionWindow.selectedSuggestion)
+    if suggestionWindow.selectedSuggestion == 0:
+      suggestionWindow.selectedSuggestion = suggestionWindow.suggestoins.high
+    else:
+      dec(suggestionWindow.selectedSuggestion)
   elif isPageDownkey(key):
     suggestionWindow.selectedSuggestion += suggestionWindow.popUpWindow.height - 1
   elif isPageUpKey(key):


### PR DESCRIPTION
- Press the Up key or Tab key at the end of a line to jump to the first line in the suggestion window.
- Press the Down key or Shift + Tab key at the first of a line to jump to that end of the line in the suggestion window.
