### PR TITLE
Fix nim-ncurses package

### DIFF
--- a/moe.nimble
+++ b/moe.nimble
@@ -10,7 +10,7 @@ bin           = @["moe"]
 # Dependencies
 
 requires "nim >= 1.4.2"
-requires "https://github.com/walkre-niboshi/nim-ncurses >= 1.0.2"
+requires "ncurses >= 1.0.2"
 requires "unicodedb >= 0.10.0"
 requires "parsetoml >= 0.6.0"
 


### PR DESCRIPTION
`ncurses` package maintainer changed to [walkre-niboshi](https://github.com/walkre-niboshi).

Related https://github.com/nim-lang/packages/pull/1670