### PR TITLE
Add log support

### DIFF
--- a/src/moepkg/cmdlineoption.nim
+++ b/src/moepkg/cmdlineoption.nim
@@ -1,4 +1,5 @@
 import std/[parseopt, pegs, os, strformat]
+import logger
 
 type CmdParsedList* = object
   path*: seq[string]
@@ -37,6 +38,7 @@ Usage:
 
 Arguments:
   -R               Readonly mode
+  --log            Start logger
   -h, --help       Print this help
   -v, --version    Print version
 """
@@ -71,6 +73,7 @@ proc parseCommandLineOption*(line: seq[string]): CmdParsedList =
           else: writeCmdLineError(kind, key)
       of cmdLongOption:
         case key:
+          of "log": initLogger()
           of "version": writeVersion()
           of "help": writeHelp()
           else: writeCmdLineError(kind, key)

--- a/src/moepkg/logger.nim
+++ b/src/moepkg/logger.nim
@@ -1,0 +1,13 @@
+import std/[logging, os, times]
+
+proc defaultFilePath(): string =
+  let cacheDir = getCacheDir() / "moe/logs"
+  createDir(cacheDir)
+
+  return cacheDir / $getTime() & ".log"
+
+proc initLogger*() =
+  let path = defaultFilePath()
+
+  var fileLog = newFileLogger(path, levelThreshold=lvlDebug)
+  addHandler(fileLog)


### PR DESCRIPTION
## Overview

Add `--log` option.

Log is created in `XDG_CACHE_HOME/moe/logs`.