### PR TITLE
Disable auto backups by default

### DIFF
--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -320,7 +320,7 @@ currentWord
 ### AutoBackup table
 
 Enable/Disable automatic backups (bool)  
-default is ture  
+default is false
 ```
 enable
 ```

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -116,7 +116,7 @@ currentWord = true
 
 [AutoBackup]
 
-enable = true
+enable = false
 
 # 10 second
 idleTime = 10

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -272,7 +272,6 @@ proc initQuickRunSettings(): QuickRunSettings =
   result.timeout = 30
 
 proc initAutoBackupSettings(): AutoBackupSettings =
-  result.enable = true
   result.interval = 5 # 5 minutes
   result.idleTime = 10 # 10 seconds
   result.dirToExclude = @[ru"/etc"]

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -123,7 +123,7 @@ suite "Config mode: Init buffer":
     let buffer = status.settings.autoBackupSettings.initAutoBackupTableBuffer
 
     const sample = @[ru "AutoBackup",
-                     ru "  enable                         true",
+                     ru "  enable                         false",
                      ru "  idleTime                       10",
                      ru "  interval                       5",
                      ru "  backupDir                      ",


### PR DESCRIPTION
Temporarily disabled by default.
Re-enable after changing the default backup dir.

Ref: #1504 