### PR TITLE
[Security] Reduce GitHub Action Permissions (#1)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,9 @@ on:
       - '*.md'
       - 'documents/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -15,6 +15,9 @@ on:
       - '*.md'
       - 'documents/**'
 
+permissions:
+  contents: read
+
 jobs:
   skip:
     runs-on: ubuntu-latest
@@ -60,7 +63,7 @@ jobs:
       with:
         nim-version: ${{ env.NIM_VERSION }}
 
-    - name: Install integtation tools
+    - name: Install integration tools
       run: |
         # shpec
         sudo sh -c "`curl -L https://raw.githubusercontent.com/rylnd/shpec/master/install.sh`"
@@ -74,5 +77,5 @@ jobs:
     - name: Install moe
       run: nimble install --verbose -Y
 
-    - name: Run integtation test
+    - name: Run integration test
       run: shpec ./shpec.sh


### PR DESCRIPTION
Hello, @fox0430!

Thank you for your work on this editor!

When I explored the repository, I noticed that the CI has too high permissions, at the moment.  For instance, it is allowed to create, merge and / or reject Pull Requests.  I assume that this is not the intended configuration.  Thus, I reduced the permissions to a sane minimum (and fixed two minor typos I found in the configuration files).  The CI still works and succeeds.

[The official GitHub documentation on Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions) recommends to grant the Action -- or, more precisely, its token -- only the very least permissions it requires to succeed.  This is important as the access token which is uniquely created for each Action run could be read out in the worst case and be used for authentication as long as the Action runs.  The granted permissions allow for the corresponding changes on the repository.  Please consult the referenced documentation for more details.

Please consider to accept to accept this Pull Request as it fixes a serious security issue.