### PR TITLE
[Enhancement] Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: '00:00'
+    assignees:
+      - fox0430
+    commit-message:
+      include: scope


### PR DESCRIPTION
This Pull Request introduces an initial configuration for Dependabot and thereby fixes #1516.  The initial configuration is as follows:

* Dependabot will check for updates each day, 00.00 UTC.
* The commits authored by Dependabot will include the new version numbers.  This is useful for documentation and future reference.
* Dependabot will assign @fox0430 on each Pull Request.  This allows for email replies with instructions for Dependabot.

In order to instruct Dependabot to merge something, you need to end a Markdown paragraph with a mention of Dependabot and the appropriate instruction.  The three most important are self-explanatory:

* `@dependabot squash and merge`
* `@dependabot rebase`
* `@dependabot merge`

Each Pull Request always contains a quick reference of all available commands, just expand the respective section in the initial comment.

Important:  some email-providers seem to reject subsequent messages with the same content.  Thus, the Dependabot instructions may need to differ; just append some dummy text to ensure the email to be sent.  Example:

```
Hello!

@dependabot merge

Thanks!
```