### PR TITLE
[Bugfix] Fix Obsolete Conversions and Most Redundant Imports (#3)

### DIFF
--- a/src/moepkg/editorview.nim
+++ b/src/moepkg/editorview.nim
@@ -223,8 +223,8 @@ proc writeCurrentLine(win: var Window,
     block:
       let
         fg = colors[0]
-        bg = if colors[1] == theme.EditorColor.editorBg:
-               theme.EditorColor.currentLineBg
+        bg = if colors[1] == theme.editorBg:
+               theme.currentLineBg
              else:
                colors[1]
 
@@ -237,8 +237,8 @@ proc writeCurrentLine(win: var Window,
     # Write spaces after text in the current line
     block:
       let
-        fg = theme.EditorColor.defaultChar
-        bg = theme.EditorColor.currentLineBg
+        fg = theme.defaultChar
+        bg = theme.currentLineBg
 
       setColorPair(currentLineColorPair, fg, bg)
     let

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -2085,7 +2085,7 @@ proc validateDebugTable(table: TomlValueRef): Option[InvalidItem] =
         return some(InvalidItem(name: $key, val: $val))
 
 proc validateThemeTable(table: TomlValueRef): Option[InvalidItem] =
-  let editorColors = ColorThemeTable[ColorTheme.config].EditorColor
+  let editorColors = ColorThemeTable[ColorTheme.config]
   for key, val in table.getTable:
     case key:
       of "baseTheme":

--- a/tests/tautocomplete.nim
+++ b/tests/tautocomplete.nim
@@ -1,6 +1,4 @@
-import std/[unittest, sugar, sequtils, macros, options]
-import moepkg/unicodeext
-
+import std/[unittest, macros]
 include moepkg/autocomplete
 
 const code = ru"""proc fibonacci(n: int): int =

--- a/tests/tbackup.nim
+++ b/tests/tbackup.nim
@@ -1,5 +1,4 @@
-import std/[unittest, times, os, json, oids, sequtils]
-import moepkg/unicodeext
+import std/[unittest]
 include moepkg/backup
 
 suite "Backup: createDir":

--- a/tests/tbackupmanager.nim
+++ b/tests/tbackupmanager.nim
@@ -1,5 +1,4 @@
-import std/[unittest, os, oids, json, strformat]
-import moepkg/[unicodeext, settings, editorstatus, backup]
+import std/[unittest, oids]
 include moepkg/backupmanager
 
 template writeBackupInfoJson(backupDir, sourceFilePath: string) =

--- a/tests/tcommandview.nim
+++ b/tests/tcommandview.nim
@@ -1,5 +1,4 @@
-import std/[unittest, os, strutils]
-import moepkg/unicodeext
+import std/[unittest]
 include moepkg/[commandview, commandviewutils, editorstatus]
 
 suite "commandview: getCandidatesFilePath":

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -1,6 +1,4 @@
 import std/[unittest, macros, strformat, os]
-import moepkg/[editorstatus, gapbuffer, bufferstatus, unicodeext]
-
 include moepkg/configmode
 
 suite "Config mode: Start configuration mode":

--- a/tests/tdebugmode.nim
+++ b/tests/tdebugmode.nim
@@ -1,6 +1,4 @@
-import std/[unittest, strformat, os]
-import moepkg/[editorstatus, unicodeext, bufferstatus]
-
+import std/[unittest, os]
 include moepkg/debugmode
 
 suite "Init debug mode buffer":

--- a/tests/teditor.nim
+++ b/tests/teditor.nim
@@ -1,5 +1,4 @@
 import std/[unittest, macros]
-import moepkg/register
 include moepkg/[editor, editorstatus, ui, platform, independentutils]
 
 proc isXselAvailable(): bool {.inline.} =

--- a/tests/teditorstatus.nim
+++ b/tests/teditorstatus.nim
@@ -1,9 +1,5 @@
 import std/unittest
-import moepkg/[ui, highlight, editorview, gapbuffer, unicodeext,
-               editor, window, color, bufferstatus, settings]
-
-from moepkg/movement import keyDown, keyRight
-
+import moepkg/[editor]
 include moepkg/editorstatus
 
 template initHighlight() =

--- a/tests/tfilermode.nim
+++ b/tests/tfilermode.nim
@@ -1,7 +1,4 @@
-import std/[unittest, os, algorithm, strutils]
-import moepkg/[filermode, editorstatus, highlight, color, bufferstatus,
-               unicodeext, gapbuffer]
-
+import std/[unittest]
 include moepkg/filermode
 
 proc getCurrentFiles(path: string): seq[string] =

--- a/tests/thelp.nim
+++ b/tests/thelp.nim
@@ -1,7 +1,4 @@
 import std/[unittest, strutils]
-import moepkg/[editorstatus, gapbuffer, unicodeext, movement, window,
-               bufferstatus]
-
 include moepkg/help
 
 suite "Help":

--- a/tests/thighlight_private.nim
+++ b/tests/thighlight_private.nim
@@ -1,5 +1,4 @@
-import std/[unittest, sequtils]
-
+import std/[unittest]
 include moepkg/highlight
 
 const reservedWords = @[

--- a/tests/tinsertmode.nim
+++ b/tests/tinsertmode.nim
@@ -1,5 +1,5 @@
-import std/[unittest, options, sequtils, sugar, random]
-import moepkg/[editorstatus, gapbuffer, unicodeext, highlight, settings]
+import std/[unittest, random]
+import moepkg/[highlight]
 include moepkg/[insertmode, suggestionwindow]
 
 suite "Insert mode":

--- a/tests/tnormalmode.nim
+++ b/tests/tnormalmode.nim
@@ -1,8 +1,6 @@
 import std/unittest
 import ncurses
-import moepkg/[editorstatus, gapbuffer, unicodeext, editor, bufferstatus,
-               register, settings]
-
+import moepkg/[register, settings]
 include moepkg/normalmode
 
 suite "Normal mode: Move to the right":

--- a/tests/tregister.nim
+++ b/tests/tregister.nim
@@ -1,5 +1,5 @@
-import std/[unittest, options]
-import moepkg/[unicodeext, settings]
+import std/[unittest]
+import moepkg/[unicodeext]
 include moepkg/[register]
 
 suite "Register: Add a buffer to the no name register":

--- a/tests/treplacemode.nim
+++ b/tests/treplacemode.nim
@@ -1,5 +1,5 @@
 import std/unittest
-import moepkg/[editorstatus, bufferstatus, unicodeext]
+import moepkg/[unicodeext]
 include moepkg/replacemode
 
 template recordCurrentPosition() =

--- a/tests/tsearch.nim
+++ b/tests/tsearch.nim
@@ -1,6 +1,4 @@
 import std/unittest
-import moepkg/editorstatus
-
 include moepkg/[search, searchutils]
 
 suite "search.nim: searchLine":

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -1,6 +1,4 @@
-import std/[unittest, options, strutils]
-import moepkg/[color, ui, highlight, unicodeext]
-
+import std/[unittest]
 include moepkg/settings
 
 const tomlStr = """

--- a/tests/tsuggestwindow.nim
+++ b/tests/tsuggestwindow.nim
@@ -1,5 +1,4 @@
-import std/[unittest, macros, options, critbits, strutils]
-import moepkg/[unicodeext, editorstatus, gapbuffer]
+import std/[unittest, critbits]
 include moepkg/suggestionwindow
 
 suite "suggestionwindow: buildSuggestionWindow":

--- a/tests/tvisualmode.nim
+++ b/tests/tvisualmode.nim
@@ -1,6 +1,5 @@
-import std/[unittest, osproc]
-import moepkg/[editorstatus, gapbuffer, unicodeext, highlight, movement, bufferstatus,
-               register]
+import std/[unittest]
+import moepkg/[highlight]
 include moepkg/[visualmode, platform, independentutils]
 
 proc isXselAvailable(): bool {.inline.} =


### PR DESCRIPTION
> This Pull Request is related to #1514.

As discussed in #1514, this Pull Request fixes all obsolete conversions and most of the redundant imports.  Exactly 50 redundant imports are not obviously resolvable as they are introduced due to the inclusion (`include`) of the respective source files.  Resolving them requires major changes in the design, thus, I focused on those redundancies which were obvious.

Despite 1 left occurrence, I also resolved all `[UnusedImport]`s.  The sole one left is the import of `strformat` in `highlight.nim` which is only found during the build.  Thus, the source files including / importing `highlight.nim` need to import `strformat` on demand.  This should be subject to another Pull Request as it can be combined with further changes to the design.

I only removed the imports but the list brackets are still present, this is, for instance,

```nim
import std/[unittest]
```

@fox0430, shall I tidy this up or is this style okay?  I decided to leave it that way in case further packages of the same namespace need to be included.