### PR TITLE
dependabot: Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,5 +8,6 @@ updates:
     assignees:
       - fox0430
     commit-message:
+      prefix: "actions"
       include: scope
     target-branch: "develop"


### PR DESCRIPTION
- Add `prefix` in `#/updates/0/commit-message`