### PR TITLE
[Bugfix] Adjust C++ Source File Extensions

### DIFF
--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -298,7 +298,7 @@ proc detectLanguage*(filename: string): SourceLanguage =
     return SourceLanguage.langNim
   of ".c", ".h":
     return SourceLanguage.langC
-  of ".cpp", "hpp", "cc":
+  of ".cpp", ".hpp", ".cc":
     return SourceLanguage.langCpp
   of ".cs":
     return SourceLanguage.langCsharp


### PR DESCRIPTION
The C++ mode did not recognise source files with the extensions `*.hpp` and `*.cc`, at the moment.  The reason therefore is that the extensions in `src/moepkg/highlight.nim`, line 301, were not prefixed with `.`.  This Pull Request fixes this issue.  Only the C++ mode was affected, all other modes have their extensions prefixed appropriately.

By the way, there are also various other common extensions for the already configured languages.  Shall I create a list of those?