### PR TITLE
[Bugfix] Adjust Python Syntax Highlighting (#7)

### DIFF
--- a/src/moepkg/syntax/syntaxpython.nim
+++ b/src/moepkg/syntax/syntaxpython.nim
@@ -1,4 +1,4 @@
-import highlite, syntaxc
+import highlite
 
 const
   pythonKeywords* = ["False", "None", "True", "and", "as", "assert", "async",
@@ -8,4 +8,104 @@ const
     "while", "with", "yield"]
 
 proc pythonNextToken*(g: var GeneralTokenizer) =
-  clikeNextToken(g, pythonKeywords, {})
+  const
+    hexChars = {'0'..'9', 'A'..'F', 'a'..'f'}
+    octChars = {'0'..'7'}
+    binChars = {'0'..'1'}
+    symChars = {'A'..'Z', 'a'..'z', '0'..'9', '_', '\x80'..'\xFF'}
+  var pos = g.pos
+  g.start = g.pos
+  if g.state == gtStringLit:
+    g.kind = gtStringLit
+    while true:
+      case g.buf[pos]
+      of '\\':
+        g.kind = gtEscapeSequence
+        inc(pos)
+        case g.buf[pos]
+        of 'x', 'X':
+          inc(pos)
+          if g.buf[pos] in hexChars: inc(pos)
+          if g.buf[pos] in hexChars: inc(pos)
+        of '0'..'9':
+          while g.buf[pos] in {'0'..'9'}: inc(pos)
+        of '\0':
+          g.state = gtNone
+        else: inc(pos)
+        break
+      of '\0', '\x0D', '\x0A':
+        g.state = gtNone
+        break
+      of '\"':
+        inc(pos)
+        g.state = gtNone
+        break
+      else: inc(pos)
+  else:
+    case g.buf[pos]
+    of ' ', '\x09'..'\x0D':
+      g.kind = gtWhitespace
+      while g.buf[pos] in {' ', '\x09'..'\x0D'}: inc(pos)
+    of '#':
+      g.kind = gtComment
+      inc(pos)
+      if g.buf[pos] == '!': g.kind = gtPreprocessor
+      while not (g.buf[pos] in {'\0', '\x0A', '\x0D'}): inc(pos)
+    of 'a'..'z', 'A'..'Z', '_', '\x80'..'\xFF':
+      var id = ""
+      while g.buf[pos] in symChars:
+        add(id, g.buf[pos])
+        inc(pos)
+      if isKeyword(pythonKeywords, id) >= 0: g.kind = gtKeyword
+      else: g.kind = gtIdentifier
+    of '0':
+      inc(pos)
+      case g.buf[pos]
+      of 'b', 'B':
+        inc(pos)
+        while g.buf[pos] in binChars: inc(pos)
+        if g.buf[pos] in {'A'..'Z', 'a'..'z'}: inc(pos)
+      of 'x', 'X':
+        inc(pos)
+        while g.buf[pos] in hexChars: inc(pos)
+        if g.buf[pos] in {'A'..'Z', 'a'..'z'}: inc(pos)
+      of '0'..'7':
+        inc(pos)
+        while g.buf[pos] in octChars: inc(pos)
+        if g.buf[pos] in {'A'..'Z', 'a'..'z'}: inc(pos)
+      else:
+        pos = generalNumber(g, pos)
+        if g.buf[pos] in {'A'..'Z', 'a'..'z'}: inc(pos)
+    of '1'..'9':
+      pos = generalNumber(g, pos)
+      if g.buf[pos] in {'A'..'Z', 'a'..'z'}: inc(pos)
+    of '\"', '\'':
+      inc(pos)
+      g.kind = gtStringLit
+      while true:
+        case g.buf[pos]
+        of '\0':
+          break
+        of '\"', '\'':
+          inc(pos)
+          break
+        of '\\':
+          g.state = g.kind
+          break
+        else: inc(pos)
+    of '(', ')', '[', ']', '{', '}', ':', ',', ';', '.':
+      inc(pos)
+      g.kind = gtPunctuation
+    of '\0':
+      g.kind = gtEof
+    else:
+      if g.buf[pos] in OpChars:
+        g.kind = gtOperator
+        while g.buf[pos] in OpChars: inc(pos)
+      else:
+        inc(pos)
+        g.kind = gtNone
+  g.length = pos - g.pos
+  if g.kind != gtEof and g.length <= 0:
+    assert false, "haskellToken: produced an empty token"
+  g.pos = pos


### PR DESCRIPTION
As discussed in #161, I adjusted the Python syntax highlighting regarding the comments.

- Line comments are now recognised as such.
- Python's nested comments are unbound literal string constants, no changes were necessary.
- The Python shebang is an important line for UNIX systems.  I turned it into a preprocessor directive for highlighting.