### PR TITLE
[Enhancement] Add Further File Extensions

### DIFF
--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -296,30 +296,30 @@ proc indexOf*(highlight: Highlight, row, column: int): int =
 
 proc detectLanguage*(filename: string): SourceLanguage =
   # TODO: use settings file
-  let extention = filename.splitFile.ext
-  case extention:
-  of ".nim", ".nimble", ".nims":
-    return SourceLanguage.langNim
-  of ".c", ".h":
+  case filename.splitFile.ext:
+  of ".c", ".dox", ".h", ".i":
     return SourceLanguage.langC
-  of ".cpp", ".hpp", ".cc":
+  of ".C", ".CPP", ".H", ".HPP", ".c++", ".cc", ".cp", ".cpp", ".cxx", ".h++",
+     ".hh", ".hp", ".hpp", ".hxx", ".ii", ".tcc":
     return SourceLanguage.langCpp
   of ".cs":
     return SourceLanguage.langCsharp
-  of ".hs":
+  of ".cabal", ".hs":
     return SourceLanguage.langHaskell
   of ".java":
     return SourceLanguage.langJava
-  of ".yaml", ".yml":
-    return SourceLanguage.langYaml
-  of ".py":
-    return SourceLanguage.langPython
-  of ".js":
+  of ".js", ".ts":
     return SourceLanguage.langJavaScript
-  of ".sh", ".bash":
-    return SourceLanguage.langShell
-  of ".md":
+  of ".markdown", ".md":
     return SourceLanguage.langMarkDown
+  of ".nim", ".nimble", ".nims":
+    return SourceLanguage.langNim
+  of ".py", ".pyw", ".pyx":
+    return SourceLanguage.langPython
+  of ".bash", ".sh":
+    return SourceLanguage.langShell
+  of ".cff", ".yaml", ".yml":
+    return SourceLanguage.langYaml
   else:
     return SourceLanguage.langNone
 


### PR DESCRIPTION
This Pull Request adds all file extensions discussed in #1523.  This will fix #1523.

- In addition to the named ones, I also added the `*.cabal` file format to Haskell.  Cabal is for Haskell what Nimble is for Nim.
- I applied a functional programming style for the matching against the extensions.
- I sorted all patterns and extensions by their ASCII code.  This shall make adding new extensions and patterns easier.