### PR TITLE
[Enhancement] Maintain Comment Parsing Logic (#10)

### DIFF
--- a/src/moepkg/syntax/comments.nim
+++ b/src/moepkg/syntax/comments.nim
@@ -1,0 +1,233 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2022 fox0430                                             #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+#
+# Resources.
+#
+
+from highlite import
+  GeneralTokenizer,
+  TokenClass,
+  TokenizerFlag,
+  TokenizerFlags,
+  eolChars
+
+
+
+#
+# Procedures.
+#
+
+## Proceed until the end of the current line.
+
+proc endLine(tokeniser: GeneralTokenizer, initialPosition: int): int =
+  var position = initialPosition
+
+  while tokeniser.buf[position] notin eolChars:
+    inc position
+
+  result = position
+
+
+
+## Parse a nested comment, introduced by two hash characters.
+##
+## This comment begins with ``##[`` and is ended by ``]##``.  These comments
+## can be nested.
+##
+## Languages like Nim support this type.
+
+proc parseDoubleHashBracketComment(tokeniser: var GeneralTokenizer,
+    initialPosition: int): int =
+  var position = initialPosition
+
+  if tokeniser.buf[position] == '[':
+    var depth = 0
+    tokeniser.kind = gtStringLit
+
+    while true:
+      case tokeniser.buf[position]
+      of '\0':
+        break
+
+      of '#':
+        inc position
+
+        if tokeniser.buf[position] == '#':
+          inc position
+
+          if tokeniser.buf[position] == '[':
+            inc depth
+            inc position
+
+      of ']':
+        inc position
+
+        if tokeniser.buf[position] == '#':
+          inc position
+
+          if tokeniser.buf[position] == '#':
+            inc position
+
+            if depth == 0:
+              break
+            else:
+              dec depth
+
+      else:
+        inc position
+
+  result = position
+
+
+
+## Parse a line introduced by two hash characters.
+##
+## This comment type is opened by ``##`` and automatically ended by the end of
+## the respective line.
+##
+## Languages like Nim use this comment type for documentation comments.
+
+proc parseDoubleHashLine(tokeniser: var GeneralTokenizer, initialPosition: int,
+    nested: bool): int =
+  var position = initialPosition
+
+  if tokeniser.buf[position] == '#':
+    tokeniser.kind = gtStringLit
+    inc position
+
+    if tokeniser.buf[position] == '[' and nested:
+      position = parseDoubleHashBracketComment(tokeniser, position)
+    else:
+      position = endLine(tokeniser, position)
+
+  result = position
+
+
+
+## Parse a nested comment.
+##
+## This comment type begins with ``#[`` and ends with ``]#``.  These comments
+## can be nested within each other.
+##
+## Languages like Nim support this type.
+
+proc parseHashBracketComment(tokeniser: var GeneralTokenizer,
+    initialPosition: int): int =
+  var position = initialPosition
+
+  if tokeniser.buf[position] == '[':
+    var depth = 0
+    tokeniser.kind = gtLongComment
+
+    while true:
+      case tokeniser.buf[position]
+      of '\0':
+        break
+
+      of '#':
+        inc position
+
+        if tokeniser.buf[position] == '[':
+          inc depth
+          inc position
+
+      of ']':
+        inc position
+
+        if tokeniser.buf[position] == '#':
+          inc position
+
+          if depth == 0:
+            break
+          else:
+            dec depth
+
+      else:
+        inc position
+
+  result = position
+
+
+
+## Parse a shebang line.
+##
+## The shebang is special line on UNIX systems which is used to choose the
+## appropriate interpreter for the given script.  By convention, it is always
+## the first line of a script.  It is only relevant for just-in-time (JIT)
+## compiled languages.
+##
+## A shebang always starts with ``#!`` and is ended automatically by the end of
+## the line.  Due to the first character being the line comment trigger, the
+## shebang will be ignored on platforms which do not support shebangs.
+
+proc parseShebangLine(tokeniser: var GeneralTokenizer,
+    initialPosition: int): int =
+  var position = initialPosition
+
+  if tokeniser.buf[position] == '!':
+    tokeniser.kind = gtPreprocessor
+    position = endLine(tokeniser, position)
+
+  result = position
+
+
+
+## Parse a line comment, opened by a single hash character.
+##
+## This comment type starts with a ``#`` and lasts until the end of the line.
+##
+## Every language with line comments introduced by ``#`` should enter the
+## comment parsing by this procedure as a redirection will take place in case
+## that the current line is actually another comment type.
+
+proc parseHashLineComment*(tokeniser: var GeneralTokenizer,
+    initialPosition: int, flags: TokenizerFlags): int =
+  var position = initialPosition
+
+  if tokeniser.buf[position] == '#':
+    tokeniser.kind = gtComment
+    inc position
+
+    case tokeniser.buf[position]
+    of '#':
+      if hasDoubleHashComments in flags:
+        position = parseDoubleHashLine(tokeniser, position,
+            hasDoubleHashBracketComments in flags)
+      else:
+        position = endLine(tokeniser, position)
+
+    of '[':
+      if hasHashBracketComments in flags:
+        position = parseHashBracketComment(tokeniser, position)
+      else:
+        position = endLine(tokeniser, position)
+
+    of '!':
+      if hasShebang in flags:
+        position = parseShebangLine(tokeniser, position)
+      else:
+        position = endLine(tokeniser, position)
+
+    else:
+      position = endLine(tokeniser, position)
+
+  result = position
+
+#[############################################################################]#

--- a/src/moepkg/syntax/highlite.nim
+++ b/src/moepkg/syntax/highlite.nim
@@ -101,6 +101,9 @@ type
     langYaml,
 
 const
+  ## Characters ending a line.
+  eolChars*: set[char] = {'\0', '\n', '\r'}
+
   sourceLanguageToStr*: array[SourceLanguage, string] = [ "none",
     "C",
     "C++",
@@ -192,7 +195,13 @@ proc isKeyword*(x: openArray[string], y: string): int =
 
 type
   TokenizerFlag* = enum
-    hasPreprocessor, hasNestedComments
+    hasDoubleHashBracketComments,
+    hasDoubleHashComments,
+    hasHashBracketComments,
+    hasNestedComments,
+    hasPreprocessor,
+    hasShebang,
+
   TokenizerFlags* = set[TokenizerFlag]
 
 import syntaxc, syntaxcpp, syntaxcsharp, syntaxhaskell, syntaxjava,

--- a/src/moepkg/syntax/syntaxpython.nim
+++ b/src/moepkg/syntax/syntaxpython.nim
@@ -1,3 +1,4 @@
+import comments
 import highlite
 
 const
@@ -47,10 +48,7 @@ proc pythonNextToken*(g: var GeneralTokenizer) =
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\x09'..'\x0D'}: inc(pos)
     of '#':
-      g.kind = gtComment
-      inc(pos)
-      if g.buf[pos] == '!': g.kind = gtPreprocessor
-      while not (g.buf[pos] in {'\0', '\x0A', '\x0D'}): inc(pos)
+      pos = parseHashLineComment(g, pos, {hasShebang, hasDoubleHashComments})
     of 'a'..'z', 'A'..'Z', '_', '\x80'..'\xFF':
       var id = ""
       while g.buf[pos] in symChars:
@@ -107,5 +105,5 @@ proc pythonNextToken*(g: var GeneralTokenizer) =
         g.kind = gtNone
   g.length = pos - g.pos
   if g.kind != gtEof and g.length <= 0:
-    assert false, "haskellToken: produced an empty token"
+    assert false, "pythonNextToken: produced an empty token"
   g.pos = pos


### PR DESCRIPTION
This PR maintains the comment parsing logic.  The logic is now outsourced into a dedicated module to enhance both its re-usability and maintainability.  The behaviour is controlled by flags which can be set per language.

As discussed in #161, documentation comments are now rendered in a different colour as they are different from ordinary comments.  I set it to the colour of string literals, initially, but changing this is very simple.

I wired up the new logic for both Python and Nim.