### PR TITLE
[Enhancement] Wire Up New Comment Logic for YAML

### DIFF
--- a/src/moepkg/syntax/syntaxyaml.nim
+++ b/src/moepkg/syntax/syntaxyaml.nim
@@ -22,6 +22,7 @@
 #
 # [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
 
+import comments
 import highlite
 
 proc yamlPlainStrLit(g: var GeneralTokenizer, pos: var int) =
@@ -130,9 +131,7 @@ proc yamlNextToken*(g: var GeneralTokenizer) =
     of ' ', '\t':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\t'}: inc(pos)
-    of '#':
-      g.kind = gtComment
-      while g.buf[pos] notin {'\0', '\n', '\r'}: inc(pos)
+    of '#': pos = parseHashLineComment(g, pos, {})
     of '\n', '\r': discard
     else:
       # illegal here. just don't parse a block scalar
@@ -216,10 +215,7 @@ proc yamlNextToken*(g: var GeneralTokenizer) =
     of ' ', '\t'..'\r':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\t'..'\r'}: inc(pos)
-    of '#':
-      g.kind = gtComment
-      inc(pos)
-      while g.buf[pos] notin {'\0', '\n', '\r'}: inc(pos)
+    of '#': pos = parseHashLineComment(g, pos, {})
     of '-':
       inc(pos)
       if g.buf[pos] in {'\0', ' ', '\t'..'\r'}:
@@ -313,9 +309,7 @@ proc yamlNextToken*(g: var GeneralTokenizer) =
     of ' ', '\t'..'\r':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\t'..'\r'}: inc(pos)
-    of '#':
-      g.kind = gtComment
-      while g.buf[pos] notin {'\0', '\n', '\r'}: inc(pos)
+    of '#': pos = parseHashLineComment(g, pos, {})
     of '\0': g.kind = gtEof
     else:
       g.kind = gtNone


### PR DESCRIPTION
This is the change to the YAML comments I announced in #1400.

In the next days, I am going to contribute further changes to the comment parsing logic, sometimes without activating them.  These changes are in preparation of adding the corresponding languages.  At the moment, I am rewriting the Haskell comments.