### PR TITLE
[Bugfix] Manually Update Actions' Versions (#11)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -26,9 +26,9 @@ jobs:
         nim: [ '1.6.2', 'stable', 'devel' ]
     name: Build on ${{ matrix.nim }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
       - name: Setup nim
-        uses: jiro4989/setup-nim-action@v1
+        uses: jiro4989/setup-nim-action@v1.3.64
         with:
           nim-version: ${{ matrix.nim }}
       - run: nimble build -y

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -43,23 +43,23 @@ jobs:
     env:
       NIM_VERSION: stable
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v3.1.0
     - run: |
         sudo apt-get update -yqq
         sudo apt-get install -y gcc libncursesw5-dev build-essential
     - name: Cache choosenim
       id: cache-choosenim
-      uses: actions/cache@v3
+      uses: actions/cache@v3.0.11
       with:
         path: ~/.choosenim
         key: ${{ runner.os }}-choosenim-${{ env.NIM_VERSION }}
     - name: Cache nimble
       id: cache-nimble
-      uses: actions/cache@v1
+      uses: actions/cache@v3.0.11
       with:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-${{ env.NIM_VERSION }}
-    - uses: jiro4989/setup-nim-action@v1
+    - uses: jiro4989/setup-nim-action@v1.3.64
       with:
         nim-version: ${{ env.NIM_VERSION }}
 


### PR DESCRIPTION
I am a little confused that Dependabot did not raise any update PRs, yet.  In order to ensure the CI continues to work, I updated the versions by hand to the respective latest versions.

- `setup-nim-action`:  v1.3.64 (I noticed that its maintainer creates full version tags before updating the major-only and the major-minor tags; we will get the updates faster if we focus on the full version tags.)
- `cache`:  v3.0.11 (I synchronised the versions to the very latest version.  Maybe that will cause Dependabot to start working...)
- `checkout`:  v3.1.0 (I know from my repositories that this is the latest version; I also counter-checked with the official repository.)

The CI still passes and now, also the warnings are fixed due to the updates.

@fox0430, when you navigate to this repository's Settings → Security → Code security and analysis → Dependabot version updates, is this feature enabled?  Normally, repositories with Dependabot activated have a Dependabot tab in Insights → Dependency graph but at the moment, there is no such tab for this repository...