### PR TITLE
[Enhancement] Create Module for Language Lexing Flags

### DIFF
--- a/src/moepkg/syntax/comments.nim
+++ b/src/moepkg/syntax/comments.nim
@@ -21,11 +21,13 @@
 # Resources.
 #
 
+from flags import
+  TokenizerFlag,
+  TokenizerFlags
+
 from highlite import
   GeneralTokenizer,
   TokenClass,
-  TokenizerFlag,
-  TokenizerFlags,
   eolChars
 
 

--- a/src/moepkg/syntax/flags.nim
+++ b/src/moepkg/syntax/flags.nim
@@ -1,0 +1,76 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2022 fox0430                                             #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+#
+# Type declarations.
+#
+
+type
+  ## The flags to control the behaviour of the highlighting lexer.
+  ##
+  ## Each language has different lexing requirements regarding certain aspects.
+  ## These details can be summarised by a flag representing the necessity to
+  ## respect a certain convention.
+
+  TokenizerFlag* = enum
+    hasCurlyDashComments,
+    hasCurlyDashPipeComments,
+    hasDoubleDashCaretComments,
+    hasDoubleHashBracketComments,
+    hasDoubleHashComments,
+    hasHashBracketComments,
+    hasHashComments,
+    hasNestedComments,
+    hasPreprocessor,
+    hasShebang,
+
+
+
+  ## The set of rules applying for a given language.
+  ##
+  ## For each language, a set of lexing rules can be formulated in order to
+  ## instruct the lexer appropriately.
+
+  TokenizerFlags* = set[TokenizerFlag]
+
+
+
+#
+# Global variables.
+#
+
+const
+  ## The lexing rules for Nim.
+  flagsNim*: TokenizerFlags = { hasDoubleHashBracketComments
+                              , hasDoubleHashComments
+                              , hasHashBracketComments
+                              , hasHashComments
+                              }
+
+  ## The lexing rules for Python.
+  flagsPython*: TokenizerFlags = { hasDoubleHashComments
+                                 , hasHashComments
+                                 , hasShebang
+                                 }
+
+  ## The lexing rules for YAML.
+  flagsYaml*: TokenizerFlags = { hasHashComments
+                               }
+
+#[############################################################################]#

--- a/src/moepkg/syntax/highlite.nim
+++ b/src/moepkg/syntax/highlite.nim
@@ -193,17 +193,6 @@ proc generalStrLit*(g: var GeneralTokenizer, position: int): int =
 proc isKeyword*(x: openArray[string], y: string): int =
   binarySearch(x, y)
 
-type
-  TokenizerFlag* = enum
-    hasDoubleHashBracketComments,
-    hasDoubleHashComments,
-    hasHashBracketComments,
-    hasNestedComments,
-    hasPreprocessor,
-    hasShebang,
-
-  TokenizerFlags* = set[TokenizerFlag]
-
 import syntaxc, syntaxcpp, syntaxcsharp, syntaxhaskell, syntaxjava,
        syntaxjavascript, syntaxnim, syntaxpython, syntaxrust, syntaxyaml
 proc getNextToken*(g: var GeneralTokenizer, lang: SourceLanguage) =

--- a/src/moepkg/syntax/syntaxc.nim
+++ b/src/moepkg/syntax/syntaxc.nim
@@ -31,6 +31,7 @@
 #    distribution, for details about the copyright.
 #
 
+import flags
 import highlite
 
 const

--- a/src/moepkg/syntax/syntaxcpp.nim
+++ b/src/moepkg/syntax/syntaxcpp.nim
@@ -1,3 +1,4 @@
+import flags
 import highlite, syntaxc
 
 const

--- a/src/moepkg/syntax/syntaxcsharp.nim
+++ b/src/moepkg/syntax/syntaxcsharp.nim
@@ -1,3 +1,4 @@
+import flags
 import highlite, syntaxc
 
 const

--- a/src/moepkg/syntax/syntaxnim.nim
+++ b/src/moepkg/syntax/syntaxnim.nim
@@ -35,6 +35,7 @@ import std/strutils
 from std/algorithm import binarySearch
 
 import comments
+import flags
 import highlite
 
 const
@@ -235,9 +236,7 @@ proc nimNextToken*(g: var GeneralTokenizer) =
     of ' ', '\x09'..'\x0D':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\x09'..'\x0D'}: inc(pos)
-    of '#':
-      pos = parseHashLineComment(g, pos, {hasDoubleHashBracketComments,
-          hasDoubleHashComments, hasHashBracketComments})
+    of '#': pos = parseHashLineComment(g, pos, flagsNim)
     of 'a'..'z', 'A'..'Z', '_', '\x80'..'\xFF':
       var id = ""
       while g.buf[pos] in SymChars + {'_'}:

--- a/src/moepkg/syntax/syntaxpython.nim
+++ b/src/moepkg/syntax/syntaxpython.nim
@@ -1,4 +1,5 @@
 import comments
+import flags
 import highlite
 
 const
@@ -47,8 +48,7 @@ proc pythonNextToken*(g: var GeneralTokenizer) =
     of ' ', '\x09'..'\x0D':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\x09'..'\x0D'}: inc(pos)
-    of '#':
-      pos = parseHashLineComment(g, pos, {hasShebang, hasDoubleHashComments})
+    of '#': pos = parseHashLineComment(g, pos, flagsPython)
     of 'a'..'z', 'A'..'Z', '_', '\x80'..'\xFF':
       var id = ""
       while g.buf[pos] in symChars:

--- a/src/moepkg/syntax/syntaxrust.nim
+++ b/src/moepkg/syntax/syntaxrust.nim
@@ -1,5 +1,6 @@
 import std/algorithm
 
+import flags
 import highlite
 
 const

--- a/src/moepkg/syntax/syntaxyaml.nim
+++ b/src/moepkg/syntax/syntaxyaml.nim
@@ -23,6 +23,7 @@
 # [ MIT license: http://www.opensource.org/licenses/mit-license.php ]
 
 import comments
+import flags
 import highlite
 
 proc yamlPlainStrLit(g: var GeneralTokenizer, pos: var int) =
@@ -131,7 +132,7 @@ proc yamlNextToken*(g: var GeneralTokenizer) =
     of ' ', '\t':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\t'}: inc(pos)
-    of '#': pos = parseHashLineComment(g, pos, {})
+    of '#': pos = parseHashLineComment(g, pos, flagsYaml)
     of '\n', '\r': discard
     else:
       # illegal here. just don't parse a block scalar
@@ -215,7 +216,7 @@ proc yamlNextToken*(g: var GeneralTokenizer) =
     of ' ', '\t'..'\r':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\t'..'\r'}: inc(pos)
-    of '#': pos = parseHashLineComment(g, pos, {})
+    of '#': pos = parseHashLineComment(g, pos, flagsYaml)
     of '-':
       inc(pos)
       if g.buf[pos] in {'\0', ' ', '\t'..'\r'}:
@@ -309,7 +310,7 @@ proc yamlNextToken*(g: var GeneralTokenizer) =
     of ' ', '\t'..'\r':
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\t'..'\r'}: inc(pos)
-    of '#': pos = parseHashLineComment(g, pos, {})
+    of '#': pos = parseHashLineComment(g, pos, flagsYaml)
     of '\0': g.kind = gtEof
     else:
       g.kind = gtNone


### PR DESCRIPTION
I moved the flags describing the lexing rules for the supported languages to a dedicated module.  There are going to be numerous further flags.

The preferences of a language can be summarised as a set of flags where the presence of a flag indicates a certain rule to mind.  Many steps of the syntax highlighting can be standardised using a collection of flags characterising the respective language.  In the long term, this will help to refactor the syntax highlighting.