### PR TITLE
[Documentation] Add Rust Book to List of References

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,3 +1,22 @@
+######################## GNU General Public License 3.0 ########################
+##                                                                            ##
+## Copyright (C) 2017─2022 fox0430                                            ##
+##                                                                            ##
+## This program is free software: you can redistribute it and/or modify       ##
+## it under the terms of the GNU General Public License as published by       ##
+## the Free Software Foundation, either version 3 of the License, or          ##
+## (at your option) any later version.                                        ##
+##                                                                            ##
+## This program is distributed in the hope that it will be useful,            ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of             ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              ##
+## GNU General Public License for more details.                               ##
+##                                                                            ##
+## You should have received a copy of the GNU General Public License          ##
+## along with this program.  If not, see <https://www.gnu.org/licenses/>.     ##
+##                                                                            ##
+################################################################################
+
 # Parser settings.
 cff-version: 1.2.0
 message: Please cite this software using these information.
@@ -32,3 +51,25 @@ license: GPL-3.0
 repository-code: https://github.com/fox0430/moe
 title: moe
 url: https://editor.moe
+
+# References.
+references:
+  - abstract: Covers Rust 2018
+    authors:
+      - family-names: Klabnik
+        given-names: Steve
+      - family-names: Nichols
+        given-names: Carol
+    isbn: 978-1-7185-0044-0
+    languages:
+      - en
+    pages: 526
+    publisher:
+      city: San Francisco
+      country: US
+      name: No Starch Press
+    title: The Rust Programming Language
+    type: book
+    year: 2018
+
+################################################################################


### PR DESCRIPTION
This PR adds a first reference to the CITATION.cff.

CFF allows for the creation of a list of references.  I added the book I consulted as Rust language reference when working on #1531 there.  Furthermore, I put the GPL-3.0 license header at the file's beginning.