### PR TITLE
[Changed] Haskell Comment Lexing Logic (#18)

### DIFF
--- a/.github/workflows/cff.yaml
+++ b/.github/workflows/cff.yaml
@@ -1,6 +1,9 @@
 name: CFF
 
 on:
+  pull_request:
+    paths:
+      - CITATION.cff
   push:
     paths:
       - CITATION.cff

--- a/changelog.d/20221202_004331_kevin.matthes_lexer_curly_squash.rst
+++ b/changelog.d/20221202_004331_kevin.matthes_lexer_curly_squash.rst
@@ -1,0 +1,6 @@
+.. _#1547: https://github.com/fox0430/moe/pull/1547
+
+Changed
+.......
+
+- `#1547`_ syntax highlighting:  Haskell comment lexing logic

--- a/src/moepkg/syntax/flags.nim
+++ b/src/moepkg/syntax/flags.nim
@@ -67,6 +67,7 @@ const
                                   , hasDoubleDashCaretComments
                                   , hasDoubleDashComments
                                   , hasNestedComments
+                                  , hasPreprocessor
                                   }
 
   ## The lexing rules for Nim.

--- a/src/moepkg/syntax/lexer.nim
+++ b/src/moepkg/syntax/lexer.nim
@@ -29,6 +29,9 @@ from highlite import
   GeneralTokenizer,
   TokenClass
 
+from lexer/curlyopenlexer import
+  lexCurlyDashComment
+
 from lexer/endlexer import
   endLine
 
@@ -40,6 +43,27 @@ from lexer/hashlexer import
 #
 # Procedures.
 #
+
+## Lex an opening curly bracket (``{``).
+##
+## Depending on the respective language's lexing rules, determined by its flags,
+## an opening curly bracket can be either a punctuation mark or the introduction
+## of a nested comment.
+
+proc lexCurlyOpen*(lexer: var GeneralTokenizer, position: int,
+    flags: TokenizerFlags): int =
+  result = position
+
+  if lexer.buf[result] == '{':
+    lexer.kind = gtPunctuation
+    inc result
+
+    if lexer.buf[result] == '-':
+      if hasCurlyDashComments in flags:
+        lexer.kind = gtLongComment
+        result = lexCurlyDashComment(lexer, result, flags)
+
+
 
 ## Lex a dash character (``-``).
 ##

--- a/src/moepkg/syntax/lexer/curlyopenlexer.nim
+++ b/src/moepkg/syntax/lexer/curlyopenlexer.nim
@@ -1,0 +1,145 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2022 fox0430                                             #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+#
+# Resources.
+#
+
+from ../flags import
+  TokenizerFlag,
+  TokenizerFlags
+
+from ../highlite import
+  GeneralTokenizer,
+  TokenClass
+
+
+
+#
+# Procedures.
+#
+
+## Lex a curly dash preprocessor instruction.
+##
+## This comment type starts with ``{-#`` and ends with ``#-}``.  Some languages
+## allow for nesting.
+##
+## Languages supporting this type are:
+##
+## - Haskell
+
+proc lexCurlyDashPreprocessor(lexer: GeneralTokenizer, position: int,
+    nested: bool): int =
+  var depth = 0
+  result = position
+
+  if lexer.buf[result] == '#':
+    inc result
+
+    while true:
+      case lexer.buf[result]
+      of '\0':
+        break
+
+      of '#':
+        inc result
+
+        if lexer.buf[result] == '-':
+          inc result
+
+          if lexer.buf[result] == '}':
+            inc result
+
+            if depth == 0:
+              break
+            elif nested:
+              dec depth
+
+      of '{':
+        inc result
+
+        if lexer.buf[result] == '-':
+          inc result
+
+          if lexer.buf[result] == '#':
+            inc result
+
+            if nested:
+              inc depth
+      else:
+        inc result
+
+
+
+## Lex a curly dash comment.
+##
+## This comment type starts with ``{-`` and ends with ``-}``.  Some languages
+## allow for nesting.
+##
+## Languages supporting this type are:
+##
+## - Haskell
+
+proc lexCurlyDashComment*(lexer: var GeneralTokenizer, position: int,
+    flags: TokenizerFlags): int =
+  let nested = hasNestedComments in flags
+  var depth = 0
+  result = position
+
+  if lexer.buf[result] == '-':
+    inc result
+
+    if lexer.buf[result] == '#' and hasPreprocessor in flags:
+      lexer.kind = gtPreprocessor
+      result = lexCurlyDashPreprocessor(lexer, result, nested)
+    else:
+      if lexer.buf[result] == '|':
+        if hasCurlyDashPipeComments in flags:
+          lexer.kind = gtStringLit
+          inc result
+
+      while true:
+        case lexer.buf[result]
+        of '\0':
+          break
+
+        of '-':
+          inc result
+
+          if lexer.buf[result] == '}':
+            inc result
+
+            if depth == 0:
+              break
+            elif nested:
+              dec depth
+
+        of '{':
+          inc result
+
+          if lexer.buf[result] == '-':
+            inc result
+
+            if nested:
+              inc depth
+
+        else:
+          inc result
+
+#[############################################################################]#

--- a/src/moepkg/syntax/lexer/hashlexer.nim
+++ b/src/moepkg/syntax/lexer/hashlexer.nim
@@ -49,7 +49,8 @@ from ../highlite import
 ##
 ## - Nim
 
-proc lexDoubleHashBracketComment(lexer: GeneralTokenizer, position: int, nested: bool): int =
+proc lexDoubleHashBracketComment(lexer: GeneralTokenizer, position: int,
+    nested: bool): int =
   var depth = 0
   result = position
 
@@ -105,7 +106,8 @@ proc lexDoubleHashBracketComment(lexer: GeneralTokenizer, position: int, nested:
 ##
 ## - Nim
 
-proc lexDoubleHashLineComment(lexer: GeneralTokenizer, position: int, flags: TokenizerFlags): int =
+proc lexDoubleHashLineComment(lexer: GeneralTokenizer, position: int,
+    flags: TokenizerFlags): int =
   result = position
 
   if lexer.buf[result] == '#':
@@ -131,7 +133,8 @@ proc lexDoubleHashLineComment(lexer: GeneralTokenizer, position: int, flags: Tok
 ##
 ## - Nim
 
-proc lexHashBracketComment(lexer: GeneralTokenizer, position: int, nested: bool): int =
+proc lexHashBracketComment(lexer: GeneralTokenizer, position: int,
+    nested: bool): int =
   var depth = 0
   result = position
 

--- a/src/moepkg/syntax/syntaxhaskell.nim
+++ b/src/moepkg/syntax/syntaxhaskell.nim
@@ -66,35 +66,7 @@ proc haskellNextToken*(g: var GeneralTokenizer) =
       g.kind = gtWhitespace
       while g.buf[pos] in {' ', '\x09'..'\x0D'}: inc(pos)
     of '-': pos = lexDash(g, pos, flagsHaskell)
-    of '{':
-      inc(pos)
-      if g.buf[pos] == '-':
-        g.kind = gtLongComment
-        var nested = 0
-        inc(pos)
-        if g.buf[pos] == '#':
-          g.kind = gtPreprocessor
-        while true:
-          case g.buf[pos]
-          of '#':
-            inc(pos)
-            if g.buf[pos] == '-' and g.kind == gtPreprocessor:
-              inc (pos)
-              if g.buf[pos] == '}':
-                inc (pos)
-                if nested == 0: break
-          of '-':
-            inc(pos)
-            if g.buf[pos] == '}':
-              inc(pos)
-              if nested == 0: break
-          of '}':
-            inc(pos)
-            if g.buf[pos] == '*': inc(pos)
-          of '\0':
-            break
-          else: inc(pos)
-      else: g.kind = gtPunctuation
+    of '{': pos = lexCurlyOpen(g, pos, flagsHaskell)
     of 'a'..'z', 'A'..'Z', '_', '\x80'..'\xFF':
       var id = ""
       while g.buf[pos] in symChars:

--- a/src/moepkg/syntax/syntaxnim.nim
+++ b/src/moepkg/syntax/syntaxnim.nim
@@ -83,7 +83,7 @@ const
     "FloatOverflowError", "FloatUnderflowError", "FloatingPointError",
     "FlushFile", "GC_Strategy", "GC_disable", "GC_disableMarkAnd", "GC_enable",
     "GC_enableMarkAndSweep", "GC_fullCollect", "GC_getStatistics", "GC_ref",
-    "GC_setStrategy","GC_unref", "IOEffect", "IOError", "IndexError",
+    "GC_setStrategy", "GC_unref", "IOEffect", "IOError", "IndexError",
     "KeyError", "LibHandle", "LibraryError", "Msg", "Natural", "NimNode",
     "OSError", "ObjectAssignmentError", "ObjectConversionError", "OpenFile",
     "Ordinal", "OutOfMemError", "OverflowError", "PFloat32", "PFloat64",
@@ -95,15 +95,16 @@ const
     "StackOverflowError", "Sweep", "SystemError", "TFrame", "THINSTANCE",
     "TResult", "TaintedString", "TimeEffect", "Utf16Char", "ValueError",
     "WideCString", "WriteIOEffect", "abs", "add", "addQuitProc", "alloc",
-    "alloc0", "array", "assert", "autoany", "bool", "byte", "card","cchar",
+    "alloc0", "array", "assert", "autoany", "bool", "byte", "card", "cchar",
     "cdouble", "cfloat", "char", "chr", "cint", "clong", "clongdouble",
     "clonglong", "copy", "copyMem", "countdown", "countup", "cpuEndian",
     "cschar", "cshort", "csize", "cstring", "cstringArray", "cuchar", "cuint",
     "culong", "culonglong", "cushort", "dbgLineHook", "dealloc", "dec",
     "defined", "echo", "equalMem", "equalmem", "excl", "expr", "fileHandle",
     "find", "float", "float32", "float64", "getCurrentException", "getFilePos",
-    "getFileSize", "getFreeMem", "getOccupiedMem", "getRefcount","getTotalMem",
-    "guarded","high", "hostCPU", "hostOS", "inc", "incl", "inf", "int", "int16",
+    "getFileSize", "getFreeMem", "getOccupiedMem", "getRefcount", "getTotalMem",
+    "guarded", "high", "hostCPU", "hostOS", "inc", "incl", "inf", "int",
+    "int16",
     "int32", "int64", "int8", "isNil", "items", "len", "lines", "low", "max",
     "min", "moveMem", "movemem", "nan", "neginf", "new", "newSeq", "newString",
     "newseq", "newstring", "nimMajor", "nimMinor", "nimPatch", "nimVersion",
@@ -134,7 +135,8 @@ const
     "memfiles", "mimetypes", "monotimes", "mysql", "nativesockets", "net",
     "odbcsql", "oids", "openssl", "options", "os", "osproc", "packages",
     "packedsets", "parsecfg", "parsecsv", "parsejson", "parseopt", "parsesql",
-    "parseutils", "parsexml", "pcre", "pegs", "posix", "posix_utils", "postgres",
+    "parseutils", "parsexml", "pcre", "pegs", "posix", "posix_utils",
+    "postgres",
     "punycode", "random", "rationals", "rdstdin", "re", "registry", "rlocks",
     "ropes", "rst", "rstast", "rstgen", "segfaults", "selectors", "sequtils",
     "sets", "setutils", "sha1", "sharedlist", "sharedtables", "smtp",
@@ -343,7 +345,7 @@ proc nimNextToken*(g: var GeneralTokenizer) =
         g.kind = gtOperator
         while g.buf[pos] in OpChars: inc(pos)
         let ep = pos
-        if sp + 1 == ep  and g.buf[sp] == '*' and g.buf[ep] == '(' :
+        if sp + 1 == ep and g.buf[sp] == '*' and g.buf[ep] == '(':
           g.kind = gtSpecialVar
       else:
         inc(pos)


### PR DESCRIPTION
This PR brings some enhancements as well as some bugfixes.

- The CFF validator now also runs on PRs.
- Some source files were formatted by `nimpretty`.
- Haskell is now also highlighted with respect to its nested comments and multi-line documentation comments.