### PR TITLE
[Fixed] CFF Release Date Update Only on Top Level (#20)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: cff
         run: |
           sed \
-            's/date-released: ....-..-../date-released: '`date +%F`'/g' \
+            's/^date-released: ....-..-../date-released: '`date +%F`'/g' \
             CITATION.cff >> tmp
           mv tmp CITATION.cff
 

--- a/changelog.d/20221204_220450_kevin.matthes_cff_release_date_squash.rst
+++ b/changelog.d/20221204_220450_kevin.matthes_cff_release_date_squash.rst
@@ -1,0 +1,6 @@
+.. _#1551: https://github.com/fox0430/moe/pull/1551
+
+Fixed
+.....
+
+- `#1551`_ CI:  CFF release date update only on top level


### PR DESCRIPTION
@fox0430

This PR fixes a bug concerning the CFF release date update on release.

The previous regex would have updated ***all*** release dates to the present day which would have destroyed software references in the references section.  This PR fixes this issue by only updating the release date located at the top level of the YAML structure.