### PR TITLE
refactor: Replace include with all pragma

### DIFF
--- a/changelog.d/20230114_051311_shuu.n_replace_include_with_all_pragma.rst
+++ b/changelog.d/20230114_051311_shuu.n_replace_include_with_all_pragma.rst
@@ -1,0 +1,6 @@
+.. _#1578: https://github.com/fox0430/moe/pull/1578
+
+Fixed
+.......
+
+- `#1578`_ refactor: Replace include with all pragama

--- a/tests/tautocomplete.nim
+++ b/tests/tautocomplete.nim
@@ -1,5 +1,10 @@
-import std/[unittest, macros]
-include moepkg/autocomplete
+import std/[unittest, macros, sequtils, sugar, critbits, options]
+import moepkg/unicodeext
+import moepkg/syntax/[highlite, syntaxc, syntaxcpp, syntaxcsharp, syntaxhaskell,
+                      syntaxjava, syntaxjavascript, syntaxnim, syntaxpython,
+                      syntaxrust]
+
+import moepkg/autocomplete {.all.}
 
 const code = ru"""proc fibonacci(n: int): int =
   if n == 0: return 0
@@ -53,7 +58,6 @@ suite "autocomplete: extractNeighborWord":
 suite "autocomplete: collectSuggestions":
   test "Case 1":
     var dictionary: WordDictionary
-    const allWords = @["proc", "pass", "parse", "paste", "pop", "path"]
     dictionary.addWordToDictionary(code)
 
     dictionary.incNumOfUsed("proc".toRunes)

--- a/tests/tbackup.nim
+++ b/tests/tbackup.nim
@@ -1,5 +1,7 @@
-import std/[unittest]
-include moepkg/backup
+import std/[unittest, times, os, json, oids]
+import moepkg/unicodeext
+
+import moepkg/backup {.all.}
 
 suite "Backup: createDir":
   test "createDir":

--- a/tests/tbackupmanager.nim
+++ b/tests/tbackupmanager.nim
@@ -1,5 +1,7 @@
-import std/[unittest, oids]
-include moepkg/backupmanager
+import std/[unittest, oids, os, json, strformat]
+import moepkg/[unicodeext, editorstatus, bufferstatus, backup, gapbuffer]
+
+import moepkg/backupmanager {.all.}
 
 template writeBackupInfoJson(backupDir, sourceFilePath: string) =
   let jsonNode = %* { "path": sourceFilePath }

--- a/tests/tclipboard.nim
+++ b/tests/tclipboard.nim
@@ -1,18 +1,8 @@
-import std/unittest
-import moepkg/[settings, unicodeext, register, clipboard]
-include moepkg/[platform, independentutils]
+import std/[unittest, osproc]
+import moepkg/[settings, unicodeext, clipboard]
 
-proc initRegister(
-  buffer: seq[Rune],
-  settings: EditorSettings): Registers {.compiletime.} =
-
-  result.addRegister(buffer, settings)
-
-proc initRegister(
-  buffer: seq[seq[Rune]],
-  settings: EditorSettings): Registers {.compiletime.} =
-
-  result.addRegister(buffer, settings)
+import moepkg/platform {.all.}
+import moepkg/independentutils {.all.}
 
 proc isXselAvailable(): bool {.inline.} =
   execCmdExNoOutput("xset q") == 0 and execCmdExNoOutput("xsel --version") == 0

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -1,5 +1,8 @@
 import std/[unittest, macros, strformat, os]
-include moepkg/configmode
+import moepkg/[unicodeext, editorstatus, bufferstatus, gapbuffer, settings,
+               color, ui]
+
+import moepkg/configmode {.all.}
 
 suite "Config mode: Start configuration mode":
   test "Init configuration mode buffer":

--- a/tests/teditor.nim
+++ b/tests/teditor.nim
@@ -1,11 +1,14 @@
-import std/[unittest, macros]
-include moepkg/[editor, editorstatus, ui, platform, independentutils]
+import std/[unittest, macros, osproc]
+import moepkg/[independentutils, gapbuffer, unicodeext, bufferstatus,
+               editorstatus, settings, register]
+import moepkg/syntax/highlite
+
+import moepkg/editor {.all.}
+import moepkg/ui {.all.}
+import moepkg/platform {.all.}
 
 proc isXselAvailable(): bool {.inline.} =
   execCmdExNoOutput("xset q") == 0 and execCmdExNoOutput("xsel --version") == 0
-
-proc isXclipAvailable(): bool {.inline.} =
-  execCmdExNoOutput("xset q") == 0 and execCmdExNoOutput("xclip -version") == 0
 
 proc sourceLangToStr(lang: SourceLanguage): string =
   case lang:

--- a/tests/teditorstatus.nim
+++ b/tests/teditorstatus.nim
@@ -1,6 +1,8 @@
-import std/unittest
-import moepkg/[editor]
-include moepkg/editorstatus
+import std/[unittest, options, heapqueue, os, importutils]
+import moepkg/[editor, gapbuffer, bufferstatus, editorview, unicodeext, color,
+               highlight, window, movement]
+
+import moepkg/editorstatus {.all.}
 
 template initHighlight() =
   currentMainWindowNode.highlight = initHighlight(
@@ -916,6 +918,8 @@ suite "editorstatus: Updates/Restore the last cursor postion":
     currentMainWindowNode.currentColumn = 1
 
     status.updateLastCursorPostion
+
+    privateAccess(status.lastPosition[0].type)
 
     check status.lastPosition[0].path == absolutePath("test.nim").ru
     check status.lastPosition[0].line == 1

--- a/tests/tfilermode.nim
+++ b/tests/tfilermode.nim
@@ -1,6 +1,7 @@
-import std/[unittest, strutils, algorithm]
-import moepkg/settings
-include moepkg/[filermodeutils]
+import std/[unittest, strutils, algorithm, os]
+import moepkg/[unicodeext, bufferstatus, gapbuffer, color, window, highlight]
+
+import moepkg/filermodeutils {.all.}
 
 proc getCurrentFiles(path: string): seq[string] =
   var

--- a/tests/thelp.nim
+++ b/tests/thelp.nim
@@ -1,5 +1,7 @@
 import std/[unittest, strutils]
-include moepkg/help
+import moepkg/[editorstatus, bufferstatus, unicodeext, gapbuffer]
+
+import moepkg/help {.all.}
 
 suite "Help":
   test "Check buffer":

--- a/tests/thighlight_private.nim
+++ b/tests/thighlight_private.nim
@@ -1,5 +1,7 @@
-import std/[unittest]
-include moepkg/highlight
+import std/[unittest, sequtils]
+import moepkg/color
+
+import moepkg/highlight {.all.}
 
 const reservedWords = @[
   ReservedWord(word: "TODO", color: EditorColorPair.reservedWord),

--- a/tests/tinsertmode.nim
+++ b/tests/tinsertmode.nim
@@ -1,6 +1,8 @@
-import std/[unittest, random]
-import moepkg/[highlight]
-include moepkg/[insertmode, suggestionwindow]
+import std/[unittest, random, options, sequtils, sugar, importutils]
+import moepkg/[highlight, editorstatus, gapbuffer, unicodeext, editor,
+               bufferstatus, movement, autocomplete, window]
+
+import moepkg/suggestionwindow {.all.}
 
 suite "Insert mode":
   test "Issue #474":
@@ -494,6 +496,8 @@ suite "Insert mode":
       100, 100,
       mainWindowNodeY,
       status.settings.statusLine.enable)
+
+    privateAccess(suggestionWindow.get.type)
 
     check suggestionWindow.get.popUpWindow.y == 2
     check suggestionWindow.get.popUpWindow.height == terminalHeight - 4

--- a/tests/tnormalmode.nim
+++ b/tests/tnormalmode.nim
@@ -1,7 +1,9 @@
 import std/unittest
-import ncurses
-import moepkg/[register, settings]
-include moepkg/normalmode
+import pkg/ncurses
+import moepkg/[register, settings, editorstatus, gapbuffer, unicodeext,
+               bufferstatus, ui]
+
+import moepkg/normalmode {.all.}
 
 suite "Normal mode: Move to the right":
   test "Move tow to the right":

--- a/tests/tregister.nim
+++ b/tests/tregister.nim
@@ -1,6 +1,7 @@
-import std/[unittest]
-import moepkg/[unicodeext]
-include moepkg/[register]
+import std/[unittest, options]
+import moepkg/[unicodeext, settings]
+
+import moepkg/register {.all.}
 
 suite "Register: Add a buffer to the no name register":
   test "Add a string to the no name register":
@@ -146,7 +147,6 @@ suite "Register: Add a buffer to the number register":
     var registers: Registers
     let settings = initEditorSettings()
 
-    const number = 0
     registers.addRegister(@[ru "abc"], settings)
 
     const
@@ -166,7 +166,6 @@ suite "Register: Add a buffer to the number register":
 suite "Register: Search a register by name":
   test "Search a register by name":
     var registers: Registers
-    let settings = initEditorSettings()
     const
       r1 = Register(buffer: @[ru "abc"], name: "a")
       r2 = Register(buffer: @[ru "def"], name: "b")
@@ -179,7 +178,6 @@ suite "Register: Search a register by name":
 
   test "Search a register by number string":
     var registers: Registers
-    let settings = initEditorSettings()
     const
       r1 = Register(buffer: @[ru "abc"], name: "a")
       r2 = Register(buffer: @[ru "def"], name: "b")
@@ -194,7 +192,6 @@ suite "Register: Search a register by name":
 
   test "Return empty":
     var registers: Registers
-    let settings = initEditorSettings()
     const
       r1 = Register(buffer: @[ru "abc"], name: "a")
       r2 = Register(buffer: @[ru "def"], name: "b")

--- a/tests/treplacemode.nim
+++ b/tests/treplacemode.nim
@@ -1,5 +1,7 @@
 import std/unittest
-include moepkg/replacemode
+import moepkg/[editorstatus, gapbuffer, bufferstatus, unicodeext, editor]
+
+import moepkg/replacemode {.all.}
 
 template recordCurrentPosition() =
   currentBufStatus.buffer.beginNewSuitIfNeeded

--- a/tests/tsearch.nim
+++ b/tests/tsearch.nim
@@ -1,5 +1,7 @@
 import std/unittest
-include moepkg/[search, searchutils]
+import moepkg/[unicodeext, editorstatus, gapbuffer]
+
+import moepkg/searchutils {.all.}
 
 suite "search.nim: searchLine":
   test "searchLine":

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -1,5 +1,8 @@
-import std/[unittest]
-include moepkg/settings
+import std/[unittest, options]
+import pkg/parsetoml
+import moepkg/[color, unicodeext, ui]
+
+import moepkg/settings {.all.}
 
 const tomlStr = """
   [Standard]

--- a/tests/tsuggestwindow.nim
+++ b/tests/tsuggestwindow.nim
@@ -1,6 +1,7 @@
-import std/[unittest, critbits]
-import moepkg/editorstatus
-include moepkg/suggestionwindow
+import std/[unittest, critbits, importutils, options]
+import moepkg/[editorstatus, gapbuffer, unicodeext]
+
+import moepkg/suggestionwindow {.all.}
 
 suite "suggestionwindow: buildSuggestionWindow":
   test "Case 1":
@@ -25,6 +26,8 @@ suite "suggestionwindow: buildSuggestionWindow":
       currentMainWindowNode)
 
     check suggestionWin.isSome
+
+    privateAccess(suggestionWin.get.type)
 
     check suggestionWin.get.wordDictionary.len == 4
 
@@ -58,6 +61,8 @@ suite "suggestionwindow: buildSuggestionWindow":
       currentMainWindowNode)
 
     check suggestionWin.isSome
+
+    privateAccess(suggestionWin.get.type)
 
     check suggestionWin.get.wordDictionary.len == 0
 

--- a/tests/tvisualmode.nim
+++ b/tests/tvisualmode.nim
@@ -1,6 +1,9 @@
-import std/[unittest]
-import moepkg/[highlight, independentutils]
-include moepkg/[visualmode, platform]
+import std/[unittest, osproc]
+import moepkg/[highlight, independentutils, editorstatus, gapbuffer, unicodeext,
+               bufferstatus, movement, editor]
+
+import moepkg/visualmode {.all.}
+import moepkg/platform {.all.}
 
 proc isXselAvailable(): bool {.inline.} =
   execCmdExNoOutput("xset q") == 0 and execCmdExNoOutput("xsel --version") == 0


### PR DESCRIPTION
Replace `include` with `{.all.}` and use `std/importutils.privateAccess`