### PR TITLE
Store the terminal size

### DIFF
--- a/changelog.d/20230115_111752_shuu.n_store_terminal_size.rst
+++ b/changelog.d/20230115_111752_shuu.n_store_terminal_size.rst
@@ -1,0 +1,6 @@
+.. _#1585: https://github.com/fox0430/moe/pull/1585
+
+Changed
+.....
+
+- `#1585`_ Store the terminal size

--- a/src/moepkg/buffermanager.nim
+++ b/src/moepkg/buffermanager.nim
@@ -1,4 +1,4 @@
-import std/[terminal, os, heapqueue]
+import std/[os, heapqueue]
 import gapbuffer, ui, editorstatus, unicodeext, window, movement, bufferstatus
 
 proc initBufferManagerBuffer*(
@@ -16,7 +16,7 @@ proc initBufferManagerBuffer*(
 
         result.add line
 
-proc deleteSelectedBuffer(status: var Editorstatus, height, width: int) =
+proc deleteSelectedBuffer(status: var Editorstatus) =
   let deleteIndex = currentMainWindowNode.currentLine
 
   var qeue = initHeapQueue[WindowNode]()
@@ -26,7 +26,7 @@ proc deleteSelectedBuffer(status: var Editorstatus, height, width: int) =
     for i in 0 ..< qeue.len:
       let node = qeue.pop
       if node.bufferIndex == deleteIndex:
-        status.closeWindow(node, height, width)
+        status.closeWindow(node)
 
       if node.child.len > 0:
         for node in node.child: qeue.push(node)
@@ -101,6 +101,6 @@ proc execBufferManagerCommand*(status: var Editorstatus, command: Runes) =
   elif key == ord('o'):
     status.openSelectedBuffer(true)
   elif key == ord('D'):
-    status.deleteSelectedBuffer(terminalHeight(), terminalWidth())
+    status.deleteSelectedBuffer
 
   if status.bufStatus.len < 2: status.exitEditor

--- a/src/moepkg/commandline.nim
+++ b/src/moepkg/commandline.nim
@@ -1,4 +1,4 @@
-import std/[terminal, sequtils]
+import std/[sequtils]
 import ui, unicodeext, color, independentutils
 
 type
@@ -35,8 +35,8 @@ proc initCommandLine*(): CommandLine =
     l = 0
     color = EditorColorPair.defaultChar
   let
-    w = terminalWidth()
-    h = terminalHeight() - 1
+    w = getTerminalWidth()
+    h = getTerminalHeight() - 1
   result.window = initWindow(h, w, t, l, color)
   result.window.setTimeout()
 

--- a/src/moepkg/commandlineutils.nim
+++ b/src/moepkg/commandlineutils.nim
@@ -1,4 +1,4 @@
-import std/[terminal, strutils, sequtils, strformat, os, algorithm, options]
+import std/[strutils, sequtils, strformat, os, algorithm, options]
 import ui, unicodeext, fileutils, color, commandline, popupwindow
 
 type
@@ -389,7 +389,6 @@ proc calcXWhenSuggestPath*(buffer, inputPath: Runes): int =
   return command.len + promptAndSpaceWidth + positionInInputPath
 
 proc calcPopUpWindowSize*(
-  terminalHeight, terminalWidth: int,
   buffer: seq[Runes]): tuple[h: int, w: int] =
 
     var maxBufferLen = 0
@@ -398,11 +397,11 @@ proc calcPopUpWindowSize*(
 
     let
       height =
-        if buffer.len > terminalHeight - 2: terminalHeight - 2
+        if buffer.len > getTerminalHeight() - 2: getTerminalHeight() - 2
         else: buffer.len
       width =
         # 2 is side spaces
-        if maxBufferLen + 2 > terminalWidth - 1: terminalWidth - 1
+        if maxBufferLen + 2 > getTerminalWidth() - 1: getTerminalWidth() - 1
         else: maxBufferLen + 2
 
     return (h: height, w: width)
@@ -414,7 +413,7 @@ proc tryOpenSuggestWindow*(): Option[Window] =
     h = 1
     w = 1
     x = 0
-    y = terminalHeight() - 1
+    y = getTerminalHeight() - 1
 
   # Use EditorStatus.popUpWindow?
   var popUpWindow = initWindow(h, w, y, x, EditorColorPair.popUpWindow)
@@ -428,18 +427,14 @@ proc updateSuggestWindow*(
   suggestIndex: int,
   commandLine: var CommandLine) =
 
-    let
-      firstArg = commandLine.buffer.firstArg
-
-      terminalHeight = terminalHeight()
-      terminalWidth = terminalWidth()
+    let firstArg = commandLine.buffer.firstArg
 
     var
       # Pop up window initial size/position
       h = 1
       w = 1
       x = 0
-      y = terminalHeight - 2
+      y = getTerminalHeight() - 2
 
     case suggestType:
       of exCommand:
@@ -457,8 +452,6 @@ proc updateSuggestWindow*(
       currentLine = some(suggestIndex)
       displayBuffer = initSuggestBuffer(suggestList, suggestType)
       winSize = calcPopUpWindowSize(
-        terminalHeight,
-        terminalWidth,
         displayBuffer)
 
     h = winSize.h
@@ -468,7 +461,6 @@ proc updateSuggestWindow*(
     suggestWin.writePopUpWindow(
       h, w,
       y, x,
-      terminalHeight, terminalWidth,
       currentLine,
       displayBuffer)
 

--- a/src/moepkg/configmode.nim
+++ b/src/moepkg/configmode.nim
@@ -1,4 +1,4 @@
-import std/[terminal, times, strutils, options]
+import std/[times, strutils, options]
 import gapbuffer, ui, editorstatus, unicodeext, window, movement, settings,
        bufferstatus, color, highlight, editor, commandline, popupwindow
 
@@ -1563,7 +1563,6 @@ proc editEnumAndBoolSettings(status: var EditorStatus,
 
     popUpWindow.writePopUpWindow(
       h, w, y, x,
-      terminalHeight(), terminalWidth(),
       some(suggestIndex),
       settingValues)
 

--- a/src/moepkg/filermode.nim
+++ b/src/moepkg/filermode.nim
@@ -1,12 +1,10 @@
-import std/[os, terminal, options]
+import std/[os, options]
 import editorstatus, ui, window, bufferstatus, unicodeext, filermodeutils, messages,
        commandline
 
 proc openNewWinAndOpenFilerOrDir(
   status: var EditorStatus,
-  filerStatus: var FilerStatus,
-  terminalHeight, terminalWidth: int) =
-
+  filerStatus: var FilerStatus) =
     let path = filerStatus.pathList[currentMainWindowNode.currentLine].path
 
     status.verticalSplitWindow
@@ -65,9 +63,7 @@ proc execFilerModeCommand*(status: var EditorStatus, command: Runes) =
       currentMainWindowNode,
       status.settings,
       currentFilerStatus.pathList.len,
-      currentFilerStatus.pathList[currentMainWindowNode.currentLine][1],
-      terminalHeight(),
-      terminalWidth())
+      currentFilerStatus.pathList[currentMainWindowNode.currentLine][1])
     currentFilerStatus.isUpdateView = true
   elif key == 'j' or isDownKey(key):
     currentFilerStatus.keyDown(currentMainWindowNode.currentLine)
@@ -98,10 +94,7 @@ proc execFilerModeCommand*(status: var EditorStatus, command: Runes) =
       status.commandLine.writeError(err)
       status.messageLog.add err
   elif key == ord('v'):
-    status.openNewWinAndOpenFilerOrDir(
-      currentFilerStatus,
-      terminalHeight(),
-      terminalWidth())
+    status.openNewWinAndOpenFilerOrDir(currentFilerStatus)
   elif isControlJ(key):
     status.movePrevWindow
   elif isControlK(key):

--- a/src/moepkg/filermodeutils.nim
+++ b/src/moepkg/filermodeutils.nim
@@ -410,8 +410,7 @@ proc writefileDetail*(
   windowNode: var WindowNode,
   settings: EditorSettings,
   numOfFile: int,
-  fileName: string,
-  terminalHeight, terminalWidth: int) =
+  fileName: string) =
 
     bufStatus.buffer = initGapBuffer[seq[Rune]]()
 
@@ -447,8 +446,8 @@ proc writefileDetail*(
     # TODO: Move
     windowNode.view = initEditorView(
       bufStatus.buffer,
-      terminalHeight - useStatusBar - 1,
-      terminalWidth - numOfFile)
+      getTerminalHeight() - useStatusBar - 1,
+      getTerminalWidth() - numOfFile)
 
     windowNode.currentLine = tmpCurrentLine
 

--- a/src/moepkg/logviewer.nim
+++ b/src/moepkg/logviewer.nim
@@ -1,8 +1,8 @@
-import std/[terminal, times]
+import std/times
 import ui, editorstatus, unicodeext, movement, bufferstatus, window
 
-proc exitLogViewer*(status: var Editorstatus, height, width: int) {.inline.} =
-  status.deleteBuffer(status.bufferIndexInCurrentWindow, height, width)
+proc exitLogViewer*(status: var Editorstatus) {.inline.} =
+  status.deleteBuffer(status.bufferIndexInCurrentWindow)
 
 proc isLogViewerCommand*(command: Runes): InputState =
   result = InputState.Invalid
@@ -44,7 +44,7 @@ proc execLogViewerCommand*(status: var EditorStatus, command: Runes) =
     elif command[0] == ord('j') or isDownKey(key):
       currentBufStatus.keyDown(currentMainWindowNode)
     elif command[0] == ord('q') or isEscKey(key):
-      status.exitLogViewer(terminalHeight(), terminalWidth())
+      status.exitLogViewer
     elif command[0] == ord('G'):
       currentBufStatus.moveToLastLine(currentMainWindowNode)
   elif command.len == 2:
@@ -97,7 +97,7 @@ proc messageLogViewer*(status: var Editorstatus) =
     elif key == ord('$') or isEndKey(key):
       currentBufStatus.moveToLastOfLine(currentMainWindowNode)
     elif key == ord('q') or isEscKey(key):
-      status.exitLogViewer(terminalHeight(), terminalWidth())
+      status.exitLogViewer
     elif key == ord('g'):
       let secondKey = getKey(currentMainWindowNode)
       if secondKey == 'g': currentBufStatus.moveToFirstLine(currentMainWindowNode)

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -1,4 +1,4 @@
-import std/[terminal, options, times]
+import std/[options, times]
 
 import editorstatus, bufferstatus, window, unicodeext, gapbuffer, ui,
        normalmode, visualmode, insertmode, autocomplete, suggestionwindow,
@@ -95,7 +95,7 @@ proc updateSuggestWindow(
       mainWindowY =
         if status.settings.tabLine.enable: 1
         else: 0
-      mainWindowHeight = status.settings.getMainWindowHeight(terminalHeight())
+      mainWindowHeight = status.settings.getMainWindowHeight
       (y, x) = suggestWin.calcSuggestionWindowPosition(
         currentMainWindowNode,
         mainWindowHeight)
@@ -103,7 +103,6 @@ proc updateSuggestWindow(
     suggestWin.writeSuggestionWindow(
       currentMainWindowNode,
       y, x,
-      terminalHeight(), terminalWidth(),
       mainWindowY,
       status.settings.statusLine.enable)
 
@@ -178,6 +177,7 @@ proc commandLineLoop*(status: var EditorStatus) =
     let key = status.getKeyFromCommandLine
 
     if isResizekey(key):
+      updateTerminalSize()
       status.resize
     elif isEscKey(key) or isControlC(key):
       isCancel = true
@@ -312,6 +312,7 @@ proc editorMainLoop*(status: var EditorStatus) =
         status.suggestionWindow.close
 
     if isResizekey(key):
+      updateTerminalSize()
       status.resize
       continue
 

--- a/src/moepkg/popupwindow.nim
+++ b/src/moepkg/popupwindow.nim
@@ -6,7 +6,6 @@ import ui, color, unicodeext
 proc writePopUpWindow*(
   popUpWindow: var Window,
   h, w, y, x: int,
-  terminalHeight, terminalWidth: int,
   currentLine: Option[int],
   buffer: seq[Runes]) =
 
@@ -17,8 +16,8 @@ proc writePopUpWindow*(
 
     # Pop up window position
     let
-      absY = y.clamp(0, terminalHeight - 1 - h)
-      absX = x.clamp(0, terminalWidth - w)
+      absY = y.clamp(0, getTerminalHeight() - 1 - h)
+      absX = x.clamp(0, getTerminalWidth() - w)
 
     popUpWindow.resize(h, w, absY, absX)
 

--- a/src/moepkg/suggestionwindow.nim
+++ b/src/moepkg/suggestionwindow.nim
@@ -287,9 +287,8 @@ proc calcSuggestionWindowPosition*(
 
 # cursorPosition is absolute y
 proc calcMaxSugestionWindowHeight(
-  y,
-  terminalHeight,
-  cursorYPosition,
+  y: int,
+  cursorYPosition: int,
   mainWindowNodeY: int,
   isEnableStatusLine: bool): int =
 
@@ -297,15 +296,14 @@ proc calcMaxSugestionWindowHeight(
   let statusLineHeight = if isEnableStatusLine: 1 else: 0
 
   if y > cursorYPosition:
-    result = (terminalHeight - 1) - cursorYPosition - commanLineHeight - statusLineHeight
+    result = (getTerminalHeight() - 1) - cursorYPosition - commanLineHeight - statusLineHeight
   else:
     result = cursorYPosition - mainWindowNodeY
 
 proc writeSuggestionWindow*(
   suggestionWindow: var SuggestionWindow,
   windowNode: WindowNode,
-  y, x,
-  terminalHeight, terminalWidth,
+  y, x: int,
   mainWindowNodeY: int,
   isEnableStatusLine: bool) =
 
@@ -315,7 +313,6 @@ proc writeSuggestionWindow*(
     (absoluteY, _) = windowNode.absolutePosition(line, column)
     maxHeight = calcMaxSugestionWindowHeight(
       y,
-      terminalHeight,
       absoluteY,
       mainWindowNodeY,
       isEnableStatusLine)
@@ -345,8 +342,6 @@ proc writeSuggestionWindow*(
     popUpWindow.width,
     popUpWindow.y,
     popUpWindow.x,
-    terminalHeight,
-    terminalWidth,
     currentLine,
     suggestionWindow.suggestoins)
 

--- a/tests/tbufferhighlight.nim
+++ b/tests/tbufferhighlight.nim
@@ -1,6 +1,6 @@
 import std/[unittest, heapqueue, options]
 import moepkg/[editorstatus, highlight, color, editorview, gapbuffer,
-               unicodeext, movement, window]
+               unicodeext, movement, window, ui]
 
 import moepkg/bufferhighlight {.all.}
 
@@ -131,7 +131,9 @@ test "Highlight of a pair of paren 4":
   status.addNewBufferInCurrentWin
   currentBufStatus.buffer = initGapBuffer(@[ru"a", ru"a)"])
   initHighlight()
-  status.resize(100, 100)
+
+  updateTerminalSize(100, 100)
+  status.resize
 
   currentBufStatus.keyDown(currentMainWindowNode)
   status.update
@@ -157,7 +159,8 @@ test "Highlight current word 2":
   status.addNewBufferInCurrentWin
   currentBufStatus.buffer = initGapBuffer(@[ru"test", ru"test"])
 
-  status.resize(100, 100)
+  updateTerminalSize(100, 100)
+  status.resize
   status.update
 
   var highlight = currentMainWindowNode.highlight
@@ -174,7 +177,8 @@ test "Highlight current word 3":
   status.addNewBufferInCurrentWin
   currentBufStatus.buffer = initGapBuffer(@[ru"[test]", ru"test"])
 
-  status.resize(100, 100)
+  updateTerminalSize(100, 100)
+  status.resize
   currentBufStatus.keyRight(currentMainWindowNode)
   status.update
 
@@ -369,7 +373,8 @@ suite "Highlight paren":
     status.addNewBufferInCurrentWin("test.nim")
     currentBufStatus.buffer = initGapBuffer(@[ru"proc test(a: string) ="])
 
-    status.resize(100, 100)
+    updateTerminalSize(100, 100)
+    status.resize
     status.update()
 
     currentMainWindowNode.currentColumn = 9
@@ -388,7 +393,8 @@ suite "Highlight paren":
     status.addNewBufferInCurrentWin("test.nim")
     currentBufStatus.buffer = initGapBuffer(@[ru"proc test(a: string) ="])
 
-    status.resize(100, 100)
+    updateTerminalSize(100, 100)
+    status.resize
     status.update()
 
     currentMainWindowNode.currentColumn = 19
@@ -408,7 +414,8 @@ suite "Update search highlight":
     status.addNewBufferInCurrentWin("test.nim")
     currentBufStatus.buffer = initGapBuffer(@[ru "abc def"])
 
-    status.resize(100, 100)
+    updateTerminalSize(100, 100)
+    status.resize
     status.update
 
     status.searchHistory = @[ru "abc"]
@@ -432,7 +439,8 @@ suite "Update search highlight":
     status.addNewBufferInCurrentWin("test.nim")
     currentBufStatus.buffer = initGapBuffer(@[ru "abc def"])
 
-    status.resize(100, 100)
+    updateTerminalSize(100, 100)
+    status.resize
     status.update
 
     status.verticalSplitWindow

--- a/tests/tdebugmode.nim
+++ b/tests/tdebugmode.nim
@@ -1,5 +1,5 @@
 import std/[unittest, os, strformat, times, options]
-import moepkg/[editorstatus, bufferstatus, gapbuffer, unicodeext]
+import moepkg/[editorstatus, bufferstatus, gapbuffer, unicodeext, ui]
 import moepkg/debugmodeutils {.all.}
 
 suite "Init debug mode buffer":
@@ -14,7 +14,8 @@ suite "Init debug mode buffer":
         currentMainWindowNode.windowIndex,
         status.settings.debugMode).toGapBuffer
 
-    status.resize(100, 100)
+    updateTerminalSize(100, 100)
+    status.resize
     status.update
 
     let correctBuf = initGapBuffer[seq[Rune]](@[

--- a/tests/teditorstatus.nim
+++ b/tests/teditorstatus.nim
@@ -1,8 +1,12 @@
 import std/[unittest, options, heapqueue, os, importutils]
-import moepkg/[editor, gapbuffer, bufferstatus, editorview, unicodeext, color,
-               highlight, window, movement]
+import moepkg/[editor, gapbuffer, bufferstatus, editorview, unicodeext, ui,
+               highlight, window, movement, ui]
 
 import moepkg/editorstatus {.all.}
+
+proc resize(status: var EditorStatus, h, w: int) =
+  updateTerminalSize(h, w)
+  status.resize
 
 suite "Add new buffer":
   test "Add 2 uffers":
@@ -384,7 +388,7 @@ test "Close window":
   status.addNewBufferInCurrentWin
   status.resize(100, 100)
   status.verticalSplitWindow
-  status.closeWindow(currentMainWindowNode, 100, 100)
+  status.closeWindow(currentMainWindowNode)
 
 test "Close window 2":
   var status = initEditorStatus()
@@ -397,7 +401,7 @@ test "Close window 2":
   status.resize(100, 100)
   status.update
 
-  status.closeWindow(currentMainWindowNode, 100, 100)
+  status.closeWindow(currentMainWindowNode)
   status.resize(100, 100)
   status.update
 
@@ -423,7 +427,7 @@ test "Close window 3":
   status.resize(100, 100)
   status.update
 
-  status.closeWindow(currentMainWindowNode, 100, 100)
+  status.closeWindow(currentMainWindowNode)
   status.resize(100, 100)
   status.update
 
@@ -450,7 +454,7 @@ test "Close window 4":
   status.resize(100, 100)
   status.update
 
-  status.closeWindow(currentMainWindowNode, 100, 100)
+  status.closeWindow(currentMainWindowNode)
   status.resize(100, 100)
   status.update
 
@@ -481,7 +485,7 @@ test "Close window 5":
   status.resize(100, 100)
   status.update
 
-  status.closeWindow(currentMainWindowNode, 100, 100)
+  status.closeWindow(currentMainWindowNode)
   status.resize(100, 100)
   status.update
 

--- a/tests/thelp.nim
+++ b/tests/thelp.nim
@@ -1,7 +1,11 @@
 import std/[unittest, strutils]
-import moepkg/[editorstatus, bufferstatus, unicodeext, gapbuffer]
+import moepkg/[editorstatus, bufferstatus, unicodeext, gapbuffer, ui]
 
 import moepkg/help {.all.}
+
+proc resize(status: var EditorStatus, h, w: int) =
+  updateTerminalSize(h, w)
+  status.resize
 
 suite "Help":
   test "Check buffer":

--- a/tests/tinsertmode.nim
+++ b/tests/tinsertmode.nim
@@ -1,8 +1,12 @@
 import std/[unittest, random, options, sequtils, sugar, importutils]
 import moepkg/[highlight, editorstatus, gapbuffer, unicodeext, editor,
-               bufferstatus, movement, autocomplete, window]
+               bufferstatus, movement, autocomplete, window, ui]
 
 import moepkg/suggestionwindow {.all.}
+
+proc resize(status: var EditorStatus, h, w: int) =
+  updateTerminalSize(h, w)
+  status.resize
 
 suite "Insert mode":
   test "Issue #474":
@@ -296,7 +300,7 @@ suite "Insert mode":
       currentMainWindowNode)
 
     let
-      mainWindowHeight = status.settings.getMainWindowHeight(100)
+      mainWindowHeight = status.settings.getMainWindowHeight
       (y, x) = suggestionWindow.get.calcSuggestionWindowPosition(
         currentMainWindowNode,
         mainWindowHeight)
@@ -307,7 +311,6 @@ suite "Insert mode":
     suggestionWindow.get.writeSuggestionWindow(
       currentMainWindowNode,
       y, x,
-      100, 100,
       mainWindowNodeY,
       isEnableStatusLine)
 
@@ -334,7 +337,7 @@ suite "Insert mode":
       currentMainWindowNode)
 
     let
-      mainWindowHeight = status.settings.getMainWindowHeight(terminalHeight)
+      mainWindowHeight = status.settings.getMainWindowHeight
       (y, x) = suggestionWindow.get.calcSuggestionWindowPosition(
         currentMainWindowNode,
         mainWindowHeight)
@@ -345,7 +348,6 @@ suite "Insert mode":
     suggestionWindow.get.writeSuggestionWindow(
       currentMainWindowNode,
       y, x,
-      100, 100,
       mainWindowNodeY,
       isEnableStatusLine)
 
@@ -373,7 +375,7 @@ suite "Insert mode":
       currentMainWindowNode)
 
     let
-      mainWindowHeight = status.settings.getMainWindowHeight(100)
+      mainWindowHeight = status.settings.getMainWindowHeight
       (y, x) = suggestionWindow.get.calcSuggestionWindowPosition(
         currentMainWindowNode,
         mainWindowHeight)
@@ -384,7 +386,6 @@ suite "Insert mode":
     suggestionWindow.get.writeSuggestionWindow(
       currentMainWindowNode,
       y, x,
-      100, 100,
       mainWindowNodeY,
       isEnableStatusLine)
 
@@ -486,14 +487,13 @@ suite "Insert mode":
 
     const mainWindowNodeY = 1
     let
-      mainWindowHeight = status.settings.getMainWindowHeight(100)
+      mainWindowHeight = status.settings.getMainWindowHeight
       (y, x) = suggestionWindow.get.calcSuggestionWindowPosition(
         currentMainWindowNode,
         mainWindowHeight)
     suggestionWindow.get.writeSuggestionWindow(
       currentMainWindowNode,
       y, x,
-      100, 100,
       mainWindowNodeY,
       status.settings.statusLine.enable)
 

--- a/tests/tlogviewer.nim
+++ b/tests/tlogviewer.nim
@@ -1,5 +1,9 @@
 import std/unittest
-import moepkg/[editorstatus, logviewer, bufferstatus, unicodeext]
+import moepkg/[editorstatus, logviewer, bufferstatus, unicodeext, ui]
+
+proc resize(status: var EditorStatus, h, w: int) =
+  updateTerminalSize(h, w)
+  status.resize
 
 suite "Log viewer":
   test "Open the log viewer (Fix #1455)":
@@ -25,8 +29,6 @@ suite "Log viewer":
     status.resize(100, 100)
     status.update
 
-    let currentBufferIndex = status.bufferIndexInCurrentWindow
-
     status.update
 
   test "Exit viewer":
@@ -36,6 +38,6 @@ suite "Log viewer":
     status.resize(100, 100)
     status.update
 
-    status.exitLogViewer(100, 100)
+    status.exitLogViewer
 
     status.resize(100, 100)

--- a/tests/tnormalmode.nim
+++ b/tests/tnormalmode.nim
@@ -5,6 +5,10 @@ import moepkg/[register, settings, editorstatus, gapbuffer, unicodeext,
 
 import moepkg/normalmode {.all.}
 
+proc resize(status: var EditorStatus, h, w: int) =
+  updateTerminalSize(h, w)
+  status.resize
+
 suite "Normal mode: Move to the right":
   test "Move tow to the right":
     var status = initEditorStatus()
@@ -16,7 +20,7 @@ suite "Normal mode: Move to the right":
 
     status.bufStatus[0].cmdLoop = 2
     const key = @[ru'l']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 2)
@@ -32,7 +36,7 @@ suite "Normal mode: Move to the left":
     status.update
 
     const key = @[ru'h']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 1)
@@ -48,7 +52,7 @@ suite "Normal mode: Move to the down":
 
     status.bufStatus[0].cmdLoop = 2
     const key = @[ru'j']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentLine == 2)
@@ -65,7 +69,7 @@ suite "Normal mode: Move to the up":
 
     status.bufStatus[0].cmdLoop = 2
     const key = @[ru'k']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentLine == 0)
@@ -81,7 +85,7 @@ suite "Normal mode: Delete current character":
 
     status.bufStatus[0].cmdLoop = 2
     const key = @[ru'x']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check status.bufStatus[0].buffer[0] == ru"c"
@@ -100,7 +104,7 @@ suite "Normal mode: Move to last of line":
     status.update
 
     const key = @[ru'$']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 2)
@@ -116,7 +120,7 @@ suite "Normal mode: Move to first of line":
     status.update
 
     const key = @[ru'0']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 0)
@@ -132,7 +136,7 @@ suite "Normal mode: Move to first non blank of line":
     status.update
 
     const key = @[ru'^']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 2)
@@ -148,12 +152,12 @@ suite "Normal mode: Move to first of previous line":
     status.update
 
     const key = @[ru'-']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
     check(currentMainWindowNode.currentLine == 1)
     check(currentMainWindowNode.currentColumn == 0)
 
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
     check(currentMainWindowNode.currentLine == 0)
     check(currentMainWindowNode.currentColumn == 0)
@@ -168,7 +172,7 @@ suite "Normal mode: Move to first of next line":
     status.update
 
     const key = @[ru'+']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentLine == 1)
@@ -184,7 +188,7 @@ suite "Normal mode: Move to last line":
     status.update
 
     const key = @[ru'G']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentLine == 2)
@@ -202,7 +206,7 @@ suite "Normal mode: Page down":
     status.update
 
     const key = @[KEY_NPAGE.toRune]
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     let
@@ -225,12 +229,12 @@ suite "Normal mode: Page up":
 
     block:
       const key = @[KEY_NPAGE.toRune]
-      status.normalCommand(key, 100, 100)
+      status.normalCommand(key)
     status.update
 
     block:
       const key = @[KEY_PPAGE.toRune]
-      status.normalCommand(key, 100, 100)
+      status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentLine == 0)
@@ -246,7 +250,7 @@ suite "Normal mode: Move to forward word":
 
     status.bufStatus[0].cmdLoop = 2
     const key = @[ru'w']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 8)
@@ -263,7 +267,7 @@ suite "Normal mode: Move to backward word":
 
     status.bufStatus[0].cmdLoop = 1
     const key = @[ru'b']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 4)
@@ -279,7 +283,7 @@ suite "Normal mode: Move to forward end of word":
 
     status.bufStatus[0].cmdLoop = 2
     const key = @[ru'e']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(currentMainWindowNode.currentColumn == 6)
@@ -294,7 +298,7 @@ suite "Normal mode: Open blank line below":
     status.update
 
     const key = @[ru'o']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].buffer.len == 2)
@@ -315,7 +319,7 @@ suite "Normal mode: Open blank line below":
     status.update
 
     const key = @[ru'O']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].buffer.len == 2)
@@ -336,7 +340,7 @@ suite "Normal mode: Add indent":
     status.update
 
     const key = @[ru'>']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].buffer[0] == ru"  a")
@@ -351,7 +355,7 @@ suite "Normal mode: Delete indent":
     status.update
 
     const key = @[ru'<']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].buffer[0] == ru"a")
@@ -366,7 +370,7 @@ suite "Normal mode: Join line":
     status.update
 
     const key = @[ru'J']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].buffer[0] == ru"ab")
@@ -381,7 +385,7 @@ suite "Normal mode: Replace mode":
     status.update
 
     const key = @[ru'R']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].mode == Mode.replace)
@@ -396,7 +400,7 @@ suite "Normal mode: Move right and enter insert mode":
     status.update
 
     const key = @[ru'a']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].mode == Mode.insert)
@@ -412,7 +416,7 @@ suite "Normal mode: Move last of line and enter insert mode":
     status.update
 
     const key = @[ru'A']
-    status.normalCommand(key, 100, 100)
+    status.normalCommand(key)
     status.update
 
     check(status.bufStatus[0].mode == Mode.insert)
@@ -432,12 +436,12 @@ suite "Normal mode: Repeat last command":
 
       check isNormalModeCommand(command) == InputState.Valid
 
-      status.normalCommand(command, 100, 100)
+      status.normalCommand(command)
       status.update
 
     block:
       const key = @[ru'.']
-      status.normalCommand(key, 100, 100)
+      status.normalCommand(key)
       status.update
 
     check(currentBufStatus.buffer.len == 1)
@@ -456,7 +460,7 @@ suite "Normal mode: Repeat last command":
 
       check isNormalModeCommand(command) == InputState.Valid
 
-      status.normalCommand(command, 100, 100)
+      status.normalCommand(command)
       status.update
 
     currentMainWindowNode.currentColumn = 0
@@ -466,12 +470,12 @@ suite "Normal mode: Repeat last command":
 
       check isNormalModeCommand(command) == InputState.Valid
 
-      status.normalCommand(command, 100, 100)
+      status.normalCommand(command)
       status.update
 
     block:
       const command = ru "."
-      status.normalCommand(command, 100, 100)
+      status.normalCommand(command)
       status.update
 
     check(currentBufStatus.buffer.len == 1)
@@ -490,7 +494,7 @@ suite "Normal mode: Repeat last command":
 
       check isNormalModeCommand(command) == InputState.Valid
 
-      status.normalCommand(command, 100, 100)
+      status.normalCommand(command)
       status.update
 
     block:
@@ -498,7 +502,7 @@ suite "Normal mode: Repeat last command":
 
       check isNormalModeCommand(command) == InputState.Valid
 
-      status.normalCommand(command, 100, 100)
+      status.normalCommand(command)
       status.update
 
     check(currentMainWindowNode.currentLine == 1)
@@ -513,7 +517,7 @@ suite "Normal mode: Delete the current line":
     status.update
 
     let command = @[ru'd', ru'd']
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 3
@@ -539,7 +543,7 @@ suite "Normal mode: Delete the line from current line to last line":
 
     check isNormalModeCommand(command) == InputState.Valid
 
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     let buffer = currentBufStatus.buffer
@@ -558,7 +562,7 @@ suite "Normal mode: Delete the line from first line to current line":
     status.update
 
     let commands = @[ru'd', ru'g', ru'g']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     let buffer = status.bufStatus[0].buffer
@@ -577,7 +581,7 @@ suite "Normal mode: Delete inside paren and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'i', ru'"']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru """abc "" "ghi""""
@@ -597,7 +601,7 @@ suite "Normal mode: Delete inside paren and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'i', ru'\'']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc '' 'ghi'"
@@ -617,7 +621,7 @@ suite "Normal mode: Delete inside paren and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'i', ru'{']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc {} {ghi}"
@@ -637,7 +641,7 @@ suite "Normal mode: Delete inside paren and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'i', ru'(']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc () (ghi)"
@@ -657,7 +661,7 @@ suite "Normal mode: Delete inside paren and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'i', ru'[']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc [] [ghi]"
@@ -677,7 +681,7 @@ suite "Normal mode: Delete current word and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'i', ru'w']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "def"
@@ -696,7 +700,7 @@ suite "Normal mode: Delete current word and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'i', ru'w']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru""
@@ -717,7 +721,7 @@ suite "Normal mode: Delete inside paren":
     status.update
 
     let commands = @[ru'd', ru'i', ru'"']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru """abc "" "ghi""""
@@ -736,7 +740,7 @@ suite "Normal mode: Delete inside paren":
     status.update
 
     let commands = @[ru'd', ru'i', ru'\'']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc '' 'ghi'"
@@ -755,7 +759,7 @@ suite "Normal mode: Delete inside paren":
     status.update
 
     let commands = @[ru'd', ru'i', ru'{']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc {} {ghi}"
@@ -774,7 +778,7 @@ suite "Normal mode: Delete inside paren":
     status.update
 
     let commands = @[ru'd', ru'i', ru'(']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc () (ghi)"
@@ -793,7 +797,7 @@ suite "Normal mode: Delete inside paren":
     status.update
 
     let commands = @[ru'd', ru'i', ru'[']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "abc [] [ghi]"
@@ -812,7 +816,7 @@ suite "Normal mode: Delete current word":
     status.update
 
     let commands = @[ru'd', ru'i', ru'w']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru "def"
@@ -830,7 +834,7 @@ suite "Normal mode: Delete current word":
     status.update
 
     let commands = @[ru'd', ru'i', ru'w']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru""
@@ -849,7 +853,7 @@ suite "Normal mode: Delete current character and enter insert mode":
     status.update
 
     let commands = @[ru's']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"bc"
@@ -867,7 +871,7 @@ suite "Normal mode: Delete current character and enter insert mode":
     status.update
 
     let commands = @[ru's']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer.len == 3
@@ -887,7 +891,7 @@ suite "Normal mode: Delete current character and enter insert mode":
 
     currentBufStatus.cmdLoop = 3
     let commands = @[ru's']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"def"
@@ -904,7 +908,7 @@ suite "Normal mode: Delete current character and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'l']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"bc"
@@ -920,7 +924,7 @@ suite "Normal mode: Delete current character and enter insert mode":
     status.update
 
     let commands = @[ru'c', ru'l']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer.len == 3
@@ -941,7 +945,7 @@ suite "Normal mode: Yank lines":
     status.update
 
     let commands = @[ru'y', ru'{']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.isLine
@@ -958,7 +962,7 @@ suite "Normal mode: Yank lines":
     status.update
 
     let commands = @[ru'y', ru'{']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.isLine
@@ -974,7 +978,7 @@ suite "Normal mode: Yank lines":
     status.update
 
     let commands = @[ru'y', ru'}']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.isLine
@@ -990,7 +994,7 @@ suite "Normal mode: Yank lines":
     status.update
 
     let commands = @[ru'y', ru'}']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.isLine
@@ -1007,7 +1011,7 @@ suite "Normal mode: Yank lines":
     status.update
 
     let commands = @[ru'y', ru'y']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.isLine
@@ -1023,7 +1027,7 @@ suite "Normal mode: Yank lines":
     status.update
 
     let commands = @[ru'Y']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.isLine
@@ -1040,7 +1044,7 @@ suite "Normal mode: Delete the characters from current column to end of line":
     status.update
 
     let commands = @[ru'd', ru'$']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"abc"
@@ -1058,7 +1062,7 @@ suite "Normal mode: delete from the beginning of the line to current column":
     status.update
 
     let commands = @[ru'd', ru'0']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"fgh"
@@ -1072,7 +1076,7 @@ suite "Normal mode: Yank string":
     currentBufStatus.buffer = initGapBuffer(@[ru"abcdefgh"])
 
     let commands = @[ru'y', ru'l']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.buffer[0] == ru"a"
@@ -1084,7 +1088,7 @@ suite "Normal mode: Yank string":
 
     currentBufStatus.cmdLoop = 3
     let commands = @[ru'y', ru'l']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.buffer[0] == ru"abc"
@@ -1096,7 +1100,7 @@ suite "Normal mode: Yank string":
 
     currentBufStatus.cmdLoop = 10
     let commands = @[ru'y', ru'l']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister.buffer[0] == ru"abcde"
@@ -1109,7 +1113,7 @@ suite "Normal mode: Cut character before cursor":
     currentMainWindowNode.currentColumn = 1
 
     let commands = @[ru'X']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"bcde"
@@ -1124,7 +1128,7 @@ suite "Normal mode: Cut character before cursor":
 
     currentBufStatus.cmdLoop = 3
     let commands = @[ru'X']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"de"
@@ -1137,7 +1141,7 @@ suite "Normal mode: Cut character before cursor":
     currentBufStatus.buffer = initGapBuffer(@[ru"abcde"])
 
     let commands = @[ru'X']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"abcde"
@@ -1151,7 +1155,7 @@ suite "Normal mode: Cut character before cursor":
     currentMainWindowNode.currentColumn = 1
 
     let commands = @[ru'd', ru'h']
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer[0] == ru"bcde"
@@ -1165,7 +1169,7 @@ suite "Add buffer to the register":
     currentBufStatus.buffer = initGapBuffer(@[ru"abcde"])
 
     let commands = ru "\"ayl"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1177,7 +1181,7 @@ suite "Add buffer to the register":
     currentBufStatus.buffer = initGapBuffer(@[ru"abcde"])
 
     let commands = ru "\"a2yl"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1189,7 +1193,7 @@ suite "Add buffer to the register":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc def"])
 
     let commands = ru "\"ayw"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1201,7 +1205,7 @@ suite "Add buffer to the register":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc def"])
 
     let commands = ru "\"a2yw"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1213,7 +1217,7 @@ suite "Add buffer to the register":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     let commands = ru "\"ayy"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1225,7 +1229,7 @@ suite "Add buffer to the register":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     let commands = ru "\"a2yy"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1237,7 +1241,7 @@ suite "Add buffer to the register":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     let commands = ru "\"a2yy"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1251,7 +1255,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let commands = ru "\"ay}"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1265,7 +1269,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let commands = ru "\"add"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1284,7 +1288,7 @@ suite "Add buffer to the register":
     status.update
 
     let commands = ru "\"ay{"
-    status.normalCommand(commands, 100, 100)
+    status.normalCommand(commands)
     status.update
 
     check status.registers.noNameRegister == Register(
@@ -1298,7 +1302,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"adw"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1315,7 +1319,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"ad$"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 2
@@ -1334,7 +1338,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"ad0"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1352,7 +1356,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"adG"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1370,7 +1374,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"adgg"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1388,7 +1392,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"ad{"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 2
@@ -1405,7 +1409,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"ad}"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 2
@@ -1424,7 +1428,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"adi["
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1442,7 +1446,7 @@ suite "Add buffer to the register":
     status.resize(100, 100)
 
     let command = ru "\"adh"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1475,7 +1479,7 @@ suite "Normal mode: Yank and delete words":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc def ghi"])
 
     const command = ru"dw"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1491,7 +1495,7 @@ suite "Normal mode: Yank and delete words":
 
     const command = ru"dw"
     currentBufStatus.cmdLoop = 2
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
     status.update
 
     check currentBufStatus.buffer.len == 1
@@ -1507,7 +1511,7 @@ suite "Editor: Yank characters in the current line":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc def", ru "ghi"])
 
     const command = ru "cc"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 2
     check currentBufStatus.buffer[0] == ru ""
@@ -1522,7 +1526,7 @@ suite "Editor: Yank characters in the current line":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc def", ru "ghi"])
 
     const command = ru "S"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 2
     check currentBufStatus.buffer[0] == ru ""
@@ -1538,7 +1542,7 @@ suite "Normal mode: Open the blank line below and enter insert mode":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc"])
 
     const command = ru "o"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 2
     check currentBufStatus.buffer[0] == ru "abc"
@@ -1553,7 +1557,7 @@ suite "Normal mode: Open the blank line below and enter insert mode":
 
     const command = ru "o"
     currentBufStatus.cmdLoop = 3
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 2
     check currentBufStatus.buffer[0] == ru "abc"
@@ -1569,7 +1573,7 @@ suite "Normal mode: Open the blank line above and enter insert mode":
 
     const command = ru "O"
     currentBufStatus.cmdLoop = 1
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 2
     check currentBufStatus.buffer[0] == ru ""
@@ -1584,7 +1588,7 @@ suite "Normal mode: Open the blank line above and enter insert mode":
 
     const command = ru "O"
     currentBufStatus.cmdLoop = 3
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 2
     check currentBufStatus.buffer[0] == ru ""
@@ -1600,7 +1604,7 @@ suite "Normal mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc"])
 
     const command = ru "i"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.mode == Mode.normal
 
@@ -1611,7 +1615,7 @@ suite "Normal mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc"])
 
     const command = ru "I"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.mode == Mode.normal
 
@@ -1622,7 +1626,7 @@ suite "Normal mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc"])
 
     const command = ru "o"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.mode == Mode.normal
 
@@ -1636,7 +1640,7 @@ suite "Normal mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc"])
 
     const command = ru "O"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.mode == Mode.normal
 
@@ -1650,7 +1654,7 @@ suite "Normal mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc"])
 
     const command = ru "R"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.mode == Mode.normal
 
@@ -1661,7 +1665,7 @@ suite "Normal mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru "abc"])
 
     const command = ru "dd"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == ru "abc"
@@ -1678,7 +1682,7 @@ suite "Normal mode: Run command when Readonly mode":
     status.registers.addRegister(ru "def", settings)
 
     const command = ru "p"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == ru "abc"
@@ -1692,7 +1696,7 @@ suite "Normal mode: Move to the next any character on the current line":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "fc"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1708,7 +1712,7 @@ suite "Normal mode: Move to the next any character on the current line":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "fi"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1724,7 +1728,7 @@ suite "Normal mode: Move to the next any character on the current line":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "fz"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1743,7 +1747,7 @@ suite "Normal mode: Move to forward word in the current line":
     currentMainWindowNode.currentColumn = buffer.high
 
     const command = ru "Fe"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1761,7 +1765,7 @@ suite "Normal mode: Move to forward word in the current line":
     currentMainWindowNode.currentColumn = buffer.high
 
     const command = ru "Fz"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1778,7 +1782,7 @@ suite "Normal mode: Move to the left of the next any character":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "tf"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1794,7 +1798,7 @@ suite "Normal mode: Move to the left of the next any character":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "tz"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1813,7 +1817,7 @@ suite "Normal mode: Move to the right of the back character":
     currentMainWindowNode.currentColumn = buffer.high
 
     const command = ru "Te"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1829,7 +1833,7 @@ suite "Normal mode: Move to the right of the back character":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "Tz"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1846,7 +1850,7 @@ suite "Normal mode: Yank characters to any character":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "ytd"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1862,7 +1866,7 @@ suite "Normal mode: Yank characters to any character":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "ytd"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1878,7 +1882,7 @@ suite "Normal mode: Yank characters to any character":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "ytd"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1894,7 +1898,7 @@ suite "Normal mode: Yank characters to any character":
     currentMainWindowNode.currentColumn = 3
 
     const command = ru "ytd"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1910,7 +1914,7 @@ suite "Normal mode: Yank characters to any character":
     currentMainWindowNode.currentColumn = buffer.high
 
     const command = ru "ytd"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer
@@ -1926,7 +1930,7 @@ suite "Normal mode: Delete characters to any characters and Enter insert mode":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "cfd"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == ru ""
@@ -1944,7 +1948,7 @@ suite "Normal mode: Delete characters to any characters and Enter insert mode":
     currentBufStatus.buffer = initGapBuffer(@[buffer])
 
     const command = ru "cfz"
-    status.normalCommand(command, 100, 100)
+    status.normalCommand(command)
 
     check currentBufStatus.buffer.len == 1
     check currentBufStatus.buffer[0] == buffer

--- a/tests/tquittest1.nim
+++ b/tests/tquittest1.nim
@@ -6,4 +6,4 @@ test "Quit command":
   status.addNewBufferInCurrentWin
 
   const command = @[ru"q"]
-  status.exModeCommand(command, 100, 100)
+  status.exModeCommand(command)

--- a/tests/tquittest2.nim
+++ b/tests/tquittest2.nim
@@ -7,4 +7,4 @@ test "Open buffer manager":
   startUi()
 
   const command = @[ru"buf"]
-  status.exModeCommand(command, 100, 100)
+  status.exModeCommand(command)

--- a/tests/tquittest3.nim
+++ b/tests/tquittest3.nim
@@ -7,4 +7,4 @@ test "Force quit command":
 
   status.bufStatus[0].countChange = 1
   const command = @[ru"q!"]
-  status.exModeCommand(command, 100, 100)
+  status.exModeCommand(command)

--- a/tests/tquittest4.nim
+++ b/tests/tquittest4.nim
@@ -1,11 +1,13 @@
 import std/unittest
-import moepkg/[editorstatus, unicodeext, exmode]
+import moepkg/[editorstatus, unicodeext, exmode, ui]
 
 test "All buffer quit command":
   var status = initEditorStatus()
   status.addNewBufferInCurrentWin
   status.verticalSplitWindow
-  status.resize(100, 100)
+
+  updateTerminalSize(100, 100)
+  status.resize
 
   const command = @[ru"qa"]
-  status.exModeCommand(command, 100, 100)
+  status.exModeCommand(command)

--- a/tests/tquittest5.nim
+++ b/tests/tquittest5.nim
@@ -9,4 +9,4 @@ test "All buffer force quit command":
   status.verticalSplitWindow
 
   const command = @[ru"qa!"]
-  status.exModeCommand(command, 100, 100)
+  status.exModeCommand(command)

--- a/tests/tvisualmode.nim
+++ b/tests/tvisualmode.nim
@@ -1,12 +1,16 @@
 import std/[unittest, osproc]
 import moepkg/[highlight, independentutils, editorstatus, gapbuffer, unicodeext,
-               bufferstatus, movement, editor]
+               bufferstatus, movement, editor, ui]
 
 import moepkg/visualmode {.all.}
 import moepkg/platform {.all.}
 
 proc isXselAvailable(): bool {.inline.} =
   execCmdExNoOutput("xset q") == 0 and execCmdExNoOutput("xsel --version") == 0
+
+proc resize(status: var EditorStatus, h, w: int) =
+  updateTerminalSize(h, w)
+  status.resize
 
 suite "Visual mode: Delete buffer":
   test "Delete buffer 1":


### PR DESCRIPTION
Add `ui.terminalSize`.
Minor performance improvements.
Enables robust testing in headless environments.