### PR TITLE
[Enhancement] Update Years in Copyright Lines to 2023

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,6 +1,6 @@
 ######################## GNU General Public License 3.0 ########################
 ##                                                                            ##
-## Copyright (C) 2017─2022 fox0430                                            ##
+## Copyright (C) 2017─2023 fox0430                                            ##
 ##                                                                            ##
 ## This program is free software: you can redistribute it and/or modify       ##
 ## it under the terms of the GNU General Public License as published by       ##

--- a/.github/workflows/scriv.yaml
+++ b/.github/workflows/scriv.yaml
@@ -1,6 +1,6 @@
 ######################## GNU General Public License 3.0 ########################
 ##                                                                            ##
-## Copyright (C) 2017─2022 fox0430                                            ##
+## Copyright (C) 2017─2023 fox0430                                            ##
 ##                                                                            ##
 ## This program is free software: you can redistribute it and/or modify       ##
 ## it under the terms of the GNU General Public License as published by       ##

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 .. --------------------- GNU General Public License 3.0 --------------------- ..
 ..                                                                            ..
-.. Copyright (C) 2017─2022 fox0430                                            ..
+.. Copyright (C) 2017─2023 fox0430                                            ..
 ..                                                                            ..
 .. This program is free software: you can redistribute it and/or modify       ..
 .. it under the terms of the GNU General Public License as published by       ..

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,6 +1,6 @@
 ######################## GNU General Public License 3.0 ########################
 ##                                                                            ##
-## Copyright (C) 2017─2022 fox0430                                            ##
+## Copyright (C) 2017─2023 fox0430                                            ##
 ##                                                                            ##
 ## This program is free software: you can redistribute it and/or modify       ##
 ## it under the terms of the GNU General Public License as published by       ##

--- a/changelog.d/20230131_211124_41898282+github-actions[bot]_update_copyright_years_squash.rst
+++ b/changelog.d/20230131_211124_41898282+github-actions[bot]_update_copyright_years_squash.rst
@@ -1,0 +1,35 @@
+.. _#1601: https://github.com/fox0430/moe/pull/1601
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+Changed
+.......
+
+- `#1601`_ documentation:  update years in copyright lines to 2023
+
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/src/moepkg/syntax/flags.nim
+++ b/src/moepkg/syntax/flags.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2022 fox0430                                             #
+#  Copyright (C) 2017─2023 fox0430                                             #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #

--- a/src/moepkg/syntax/lexer.nim
+++ b/src/moepkg/syntax/lexer.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2022 fox0430                                             #
+#  Copyright (C) 2017─2023 fox0430                                             #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #

--- a/src/moepkg/syntax/lexer/curlyopenlexer.nim
+++ b/src/moepkg/syntax/lexer/curlyopenlexer.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2022 fox0430                                             #
+#  Copyright (C) 2017─2023 fox0430                                             #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #

--- a/src/moepkg/syntax/lexer/endlexer.nim
+++ b/src/moepkg/syntax/lexer/endlexer.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2022 fox0430                                             #
+#  Copyright (C) 2017─2023 fox0430                                             #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #

--- a/src/moepkg/syntax/lexer/hashlexer.nim
+++ b/src/moepkg/syntax/lexer/hashlexer.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2022 fox0430                                             #
+#  Copyright (C) 2017─2023 fox0430                                             #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #

--- a/src/moepkg/syntax/syntaxmarkdown.nim
+++ b/src/moepkg/syntax/syntaxmarkdown.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2022 fox0430                                             #
+#  Copyright (C) 2017─2023 fox0430                                             #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #


### PR DESCRIPTION
@fox0430

This PR updates the copyright years in the respective files to the present year.

GPL-3.0 requires the source code files to start with a license header.  I added it to some files I newly created in the last year when I originally introduced them.  Due to now 2023 being the present, the copyright lines thus need to be updated.