### PR TITLE
Fix #1611

### DIFF
--- a/changelog.d/20230205_023217_shuu.n_fix_1611.rst
+++ b/changelog.d/20230205_023217_shuu.n_fix_1611.rst
@@ -1,0 +1,37 @@
+.. _#1611: https://github.com/fox0430/moe/pull/1611
+.. _#1612: https://github.com/fox0430/moe/pull/1612
+
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+
+Fixed
+.....
+
+- `#1612`_ Fix `#1611`_
+
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20230205_023217_shuu.n_fix_1611.rst
+++ b/changelog.d/20230205_023217_shuu.n_fix_1611.rst
@@ -1,4 +1,4 @@
-.. _#1611: https://github.com/fox0430/moe/pull/1611
+.. _#1611: https://github.com/fox0430/moe/issues/1611
 .. _#1612: https://github.com/fox0430/moe/pull/1612
 
 .. A new scriv changelog fragment.

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -130,6 +130,9 @@ proc commandLineLoop*(status: var EditorStatus) =
     suggestType = status.commandLine.buffer.getSuggestType
     suggestList = status.commandLine.getSuggestList(suggestType)
     if suggestList.len > 0:
+      if suggestIndex > suggestList.high:
+        suggestIndex = suggestList.high
+
       suggestWin = tryOpenSuggestWindow()
 
   if currentBufStatus.isSearchMode:


### PR DESCRIPTION
Fix a bug that calling suggestions on paths with typos can crash on opening files with `:e`.

Close #1611 