### PR TITLE
[Bugfix] Node 12 Warning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,8 +43,6 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3.3.0
-        with:
-          persist-credentials: false
 
       - name: release-bump2version-scriv
         uses: kevinmatthes/release-bump2version-scriv@v0.2.2
@@ -52,9 +50,6 @@ jobs:
           release: ${{ inputs.release }}
 
       - name: push
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+        run: git push
 
 ################################################################################

--- a/.github/workflows/scriv.yaml
+++ b/.github/workflows/scriv.yaml
@@ -32,16 +32,11 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3.3.0
-        with:
-          persist-credentials: false
 
       - name: scriv
         uses: kevinmatthes/create-scriv-fragment@v0.2.1
 
       - name: push
-        uses: ad-m/github-push-action@v0.6.0
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
+        run: git push
 
 ################################################################################

--- a/changelog.d/20230226_143830_41898282+github-actions[bot]_node_12.rst
+++ b/changelog.d/20230226_143830_41898282+github-actions[bot]_node_12.rst
@@ -1,0 +1,35 @@
+.. _#1629: https://github.com/fox0430/moe/pull/1629
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+Fixed
+.....
+
+- `#1629`_ CI:  fix warning regarding Node 12
+
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..


### PR DESCRIPTION
@fox0430

This PR fixes the warning regarding the usage of Node 12.

So far, the Scriv fragments were pushed to the repository using a certain Action which still uses the deprecated version 12 of Node.js.  Doing so triggered a warning in the Action overview.  That Action does not need to be used anymore if the settings of the other Actions in the respective workflows are adjusted appropriately.