### PR TITLE
[Bugfix] Fix Odd Edge Case of Markdown Comments

### DIFF
--- a/changelog.d/20230226_163119_41898282+github-actions[bot]_markdown_comments.rst
+++ b/changelog.d/20230226_163119_41898282+github-actions[bot]_markdown_comments.rst
@@ -1,0 +1,35 @@
+.. _#1630: https://github.com/fox0430/moe/pull/1630
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+Fixed
+.....
+
+- `#1630`_ syntax highlighting:  odd edge case of Markdown comments
+
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/src/moepkg/syntax/lexer.nim
+++ b/src/moepkg/syntax/lexer.nim
@@ -276,7 +276,8 @@ proc lexSharp*(lexer: var GeneralTokenizer, position: int,
                 inc result
 
                 if lexer.buf[result] == '-':
-                  inc result
+                  while lexer.buf[result] == '-':
+                    inc result
 
                   if lexer.buf[result] == '>':
                     inc result


### PR DESCRIPTION
@fox0430

There is a literally odd edge case of Markdown comments:  `--->` for termination.  By now, the lexer demands an even number of dashes for a Markdown comment to terminate.  But in practice, there might also be odd numbers of dashes to end a long Markdown comment.  This PR fixes this problem.

For illustration of the bug, please create a Markdown file, say, `test.md`, and add the following lines to it:

```markdown
<!--->...
<!---->...
<!----->...
```

The current version of Moe will consider the first and third lines unterminated while actually, only the first one is.  By adding one further dash (`-`) before the `>` in line three, the comment will be terminated.  Each subsequent dash will toggle the comment termination of the third line, indicated by the highlighting colour of the three dots at the end of each line.