### PR TITLE
Fix #1660 and #1665

### DIFF
--- a/changelog.d/20230314_060052_shuu.n_fix_ls_command.rst
+++ b/changelog.d/20230314_060052_shuu.n_fix_ls_command.rst
@@ -1,0 +1,37 @@
+.. _#1660: https://github.com/fox0430/moe/issues/1660
+.. _#1665: https://github.com/fox0430/moe/issues/1665
+.. _#1666: https://github.com/fox0430/moe/pull/1666
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+
+Fixed
+.....
+
+- `#1666`_ Fix `#1660`_ and `Fix#1665`_
+
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -1181,14 +1181,15 @@ proc listAllBufferCommand(status: var EditorStatus) =
     setCursor(false)
     let key = getKey(currentMainWindowNode)
     if isResizeKey(key): status.resize
-    elif key.int == 0: discard
+    elif key == ERR_KEY: discard
     else: break
 
   status.settings.view.currentLineNumber = swapCurrentLineNumStting
   status.changeCurrentBuffer(swapCurrentBufferIndex)
   status.deleteBufferStatusCommand(status.bufStatus.high)
-
   status.commandLine.clear
+
+  currentBufStatus.isUpdate = true
 
 proc replaceBuffer(status: var EditorStatus, command: seq[Rune]) =
   let replaceInfo = parseReplaceCommand(command)


### PR DESCRIPTION
- #1660: Fix a bug that highlights broken after :ls command.
- #1665: Fix a bug that the buffer list closes on its own (:ls command).

Close #1660 
Close #1665 