### PR TITLE
[Enhancement] Create Bug Report Form

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 ######################## GNU General Public License 3.0 ########################
 ##                                                                            ##
-## Copyright (C) 2017─2023 fox0430                                            ##
+## Copyright (C) 2017─2023 Shuhei Nogawa                                      ##
 ##                                                                            ##
 ## This program is free software: you can redistribute it and/or modify       ##
 ## it under the terms of the GNU General Public License as published by       ##
@@ -11,7 +11,7 @@
 ## but WITHOUT ANY WARRANTY; without even the implied warranty of             ##
 ## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              ##
 ## GNU General Public License for more details.                               ##
-##                                                                          gk ##
+##                                                                            ##
 ## You should have received a copy of the GNU General Public License          ##
 ## along with this program.  If not, see <https://www.gnu.org/licenses/>.     ##
 ##                                                                            ##

--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,120 @@
+######################## GNU General Public License 3.0 ########################
+##                                                                            ##
+## Copyright (C) 2017─2023 Shuhei Nogawa                                      ##
+##                                                                            ##
+## This program is free software: you can redistribute it and/or modify       ##
+## it under the terms of the GNU General Public License as published by       ##
+## the Free Software Foundation, either version 3 of the License, or          ##
+## (at your option) any later version.                                        ##
+##                                                                            ##
+## This program is distributed in the hope that it will be useful,            ##
+## but WITHOUT ANY WARRANTY; without even the implied warranty of             ##
+## MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the              ##
+## GNU General Public License for more details.                               ##
+##                                                                            ##
+## You should have received a copy of the GNU General Public License          ##
+## along with this program.  If not, see <https://www.gnu.org/licenses/>.     ##
+##                                                                            ##
+################################################################################
+
+name: Bug Report
+description: Outline a bug.
+title: '[Bug Report] <Bug Report Title>'
+labels:
+  - bug
+assignees:
+  - fox0430
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for using Moe and reporting a bug you noticed!  Please fill
+        out this form in order to help the maintainers and contributors to fix
+        this issue.
+  - type: dropdown
+    attributes:
+      label: Version
+      description: |
+        Please specify the version of the software in which the bug occurred.
+      options:
+        - Nightly
+        - v0.3.0
+        - v0.2.8.0
+        - v0.2.7.0
+        - v0.2.6.1
+        - v0.2.6.0
+        - v0.2.5.1
+        - v0.2.5.0
+        - v0.2.4.1
+        - v0.2.4
+        - v0.2.3.1
+        - v0.2.3
+        - v0.2.2.1
+        - v0.2.2
+        - v0.2.1
+        - v0.2.0.2
+        - v0.2.0.1
+        - v0.2.0
+        - v0.1.9
+        - v0.1.8
+        - v0.1.7
+        - v0.1.6
+        - v0.1.5
+        - v0.1.4
+        - v0.1.3
+        - v0.1.2
+        - v0.1.1
+        - v0.1.0
+        - v0.0.90
+        - v0.0.84
+        - v0.0.83
+        - v0.0.82
+        - v0.0.81
+        - v0.0.80
+        - v0.0.70
+        - v0.0.61
+        - v0.0.60
+        - v0.0.50
+        - v0.0.40
+        - v0.0.35
+        - v0.0.3
+        - v0.0.2
+        - v0.0.1
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Category
+      description: |
+        Please choose the category which describes best the bug to be reported.
+      options:
+        - Major — The software does not fulfill the task it is designed for.
+        - Minor — The software basically does what it should do but there might
+          be improvements.
+        - Typo — There is a spelling mistake or something similar.
+        - Visual ─ Output is hardly readable or not uniformly formatted.
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: Please describe how the bug is triggered or when it occurs.
+      placeholder: |
+        1. Step one
+        2. Step two
+        3. Step three
+        ...
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Detailed Description
+      description: |
+        Please describe the bug in detail.  This is only required if the issue
+        title is not alredy descriptive enough.  However, further details may be
+        given by additional comments on this issue after its creation.
+      placeholder: Detailed description of the bug
+    validations:
+      required: false
+
+################################################################################

--- a/changelog.d/20230315_163326_41898282+github-actions[bot]_bug_report_forms.rst
+++ b/changelog.d/20230315_163326_41898282+github-actions[bot]_bug_report_forms.rst
@@ -1,0 +1,35 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. _#1670: https://github.com/fox0430/moe/pull/1670
+Added
+.....
+
+- `#1670`_ repository:  add bug report form
+
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..


### PR DESCRIPTION
@fox0430

This PR adds a GitHub Issue Form for bug reports.  GitHub Issue Forms are useful to handle common issue types, such as bug reports and feature requests.  I added the versions based on the tags of this repository.  The version "Nightly" means a build from the latest repository state.  Sometimes, the title suffices to describe the bug, so I made the detailed description optional.  I made you the default assignee in order to ensure that you will receive a notification about the new bug report.

I also noticed typos in the license header of the CODEOWNERS, so I fixed them.