### PR TITLE
Fix #1679

### DIFF
--- a/changelog.d/20230319_030509_shuu.n_fix_1679.rst
+++ b/changelog.d/20230319_030509_shuu.n_fix_1679.rst
@@ -1,0 +1,36 @@
+.. _#1679: https://github.com/fox0430/moe/issues/1679
+.. _#1680: https://github.com/fox0430/moe/pull/1680
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+
+Fixed
+.....
+
+- `#1680`_: Fix `#1679`_
+
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -137,12 +137,15 @@ proc writeMessageFailedBuildOnSave*(commandLine: var CommandLine) =
 
 proc writeNotEditorCommandError*(
   commandLine: var CommandLine,
-  command: seq[Runes]) =
-    var cmd = ""
-    for i in 0 ..< command.len: cmd = cmd & $command[i] & " "
-    let mess = fmt"Error: Not an editor command: {cmd}"
+  command: Runes) =
+    let mess = fmt"Error: Not an editor command: {command}"
     commandLine.writeMessageOnCommandLine(mess, EditorColorPair.errorMessage)
     addMessageLog mess
+
+proc writeNotEditorCommandError*(
+  commandLine: var CommandLine,
+  command: seq[Runes]) {.inline.} =
+    commandLine.writeNotEditorCommandError(command.join(ru" "))
 
 proc writeMessageSaveFile*(
   commandLine: var CommandLine,


### PR DESCRIPTION
Fixed a bug that caused no error message when running an invalid ex command.

Close #1679 