### PR TITLE
refactor: Rename to GlobalSidebar

### DIFF
--- a/changelog.d/20230425_033444_shuu.n_rename_to_global_sidebar.rst
+++ b/changelog.d/20230425_033444_shuu.n_rename_to_global_sidebar.rst
@@ -1,0 +1,35 @@
+.. _#1697: https://github.com/fox0430/moe/pull/1697
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+
+Changed
+.......
+
+- `#1697`_ Rename to GlobalSidebar
+
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20230425_033444_shuu.n_rename_to_global_sidebar.rst
+++ b/changelog.d/20230425_033444_shuu.n_rename_to_global_sidebar.rst
@@ -11,7 +11,7 @@
 Changed
 .......
 
-- `#1697`_ Rename to GlobalSidebar
+- `#1697`_ refactor: Rename to GlobalSidebar
 
 .. Deprecated
 .. ..........

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -25,7 +25,7 @@ import gapbuffer, editorview, ui, unicodeext, highlight, fileutils,
        backup, messages, commandline, register, platform, movement,
        autocomplete, suggestionwindow, filermodeutils, debugmodeutils,
        independentutils, viewhighlight, helputils, backupmanagerutils,
-       diffviewerutils, messagelog, sidebar
+       diffviewerutils, messagelog, globalsidebar
 
 # Save cursor position when a buffer for a window(file) gets closed.
 type LastCursorPosition* = object
@@ -56,7 +56,7 @@ type EditorStatus* = object
   isReadonly*: bool
   wordDictionary*: WordDictionary
   suggestionWindow*: Option[SuggestionWindow]
-  sidebar*: Option[Sidebar]
+  sidebar*: Option[GlobalSidebar]
 
 const
   tabLineWindowHeight = 1

--- a/src/moepkg/globalsidebar.nim
+++ b/src/moepkg/globalsidebar.nim
@@ -23,46 +23,47 @@ import std/sequtils
 import ui, unicodeext, highlight, color, independentutils
 
 type
-  Sidebar* = object
+  GlobalSidebar* = object
     highlight*: Highlight
     window: Window
     terminalBuffer: seq[Runes]
 
 ## Return the window position of x.
-proc x*(sidebar: Sidebar): int {.inline.} = sidebar.window.x
+proc x*(sidebar: GlobalSidebar): int {.inline.} = sidebar.window.x
 
 ## Return the window position of x.
-proc y*(sidebar: Sidebar): int {.inline.} = sidebar.window.y
+proc y*(sidebar: GlobalSidebar): int {.inline.} = sidebar.window.y
 
 ## Return the window height.
-proc height*(sidebar: Sidebar): int {.inline.} = sidebar.window.height
+proc height*(sidebar: GlobalSidebar): int {.inline.} = sidebar.window.height
 
 ## Return the window height.
-proc h*(sidebar: Sidebar): int {.inline.} = sidebar.window.height
+proc h*(sidebar: GlobalSidebar): int {.inline.} = sidebar.window.height
 
 ## Return the window width.
-proc width*(sidebar: Sidebar): int {.inline.} = sidebar.window.width
+proc width*(sidebar: GlobalSidebar): int {.inline.} = sidebar.window.width
 
 ## Return the window width.
-proc w*(sidebar: Sidebar): int {.inline.} = sidebar.window.width
+proc w*(sidebar: GlobalSidebar): int {.inline.} = sidebar.window.width
 
 ## Return the sidebar window size.
-proc size*(sidebar: Sidebar): Size {.inline.} = Size(h: sidebar.h, w: sidebar.w)
+proc size*(sidebar: GlobalSidebar): Size {.inline.} =
+  Size(h: sidebar.h, w: sidebar.w)
 
 ## Return the sidebar window position.
-proc position*(sidebar: Sidebar): Position {.inline.} =
+proc position*(sidebar: GlobalSidebar): Position {.inline.} =
   Position(y: sidebar.y, x: sidebar.x)
 
 ## Return the sidebar window rect.
-proc rect*(sidebar: Sidebar): Rect {.inline.} =
+proc rect*(sidebar: GlobalSidebar): Rect {.inline.} =
   Rect(y: sidebar.y, x: sidebar.x, h: sidebar.h, w: sidebar.w)
 
 ## Init the terminal buffer.
 ## Pad the size of the `size` with spaces.
-proc initTerminalBuffer(sidebar: var Sidebar) {.inline.} =
+proc initTerminalBuffer(sidebar: var GlobalSidebar) {.inline.} =
   sidebar.terminalBuffer = sidebar.h.newSeqWith(ru" ".repeat(sidebar.w))
 
-proc initSidebar*(rect: Rect): Sidebar =
+proc initGlobalSidebar*(rect: Rect): GlobalSidebar =
   when not defined(release):
     assert rect.y >= 0 and rect.x >= 0 and rect.h > 0 and rect.w > 0
 
@@ -79,7 +80,7 @@ proc initSidebar*(rect: Rect): Sidebar =
         lastColumn: result.terminalBuffer[0].high,
         color: EditorColorPair.defaultChar)])
 
-proc initSidebar*(): Sidebar {.inline.} =
+proc initGlobalSidebar*(): GlobalSidebar {.inline.} =
   result.window = initWindow(
     Rect(h: 1, w: 0, y: 0, x: 0),
     EditorColorPair.defaultChar)
@@ -96,7 +97,7 @@ proc initSidebar*(): Sidebar {.inline.} =
         color: EditorColorPair.defaultChar)])
 
 ## Init the sidebar highlight
-proc initHighlight*(sidebar: var Sidebar) =
+proc initHighlight*(sidebar: var GlobalSidebar) =
   sidebar.highlight = Highlight(
     colorSegments: @[
       ColorSegment(
@@ -109,7 +110,7 @@ proc initHighlight*(sidebar: var Sidebar) =
 ## Write a buffer to the terminalBuffer
 ## Cut off the buffer if longer than the window sieze.
 proc write*(
-  sidebar: var Sidebar,
+  sidebar: var GlobalSidebar,
   startPosition: Position,
   buffer: Runes,
   color: EditorColorPair = EditorColorPair.defaultChar) {.inline.} =
@@ -132,7 +133,7 @@ proc write*(
         color: color))
 
 ## Write a buffer to the terminal (ui).
-proc write(sidebar: var Sidebar) =
+proc write(sidebar: var GlobalSidebar) =
   let buf = sidebar.terminalBuffer
   var
     highlightIndex = 0
@@ -147,24 +148,24 @@ proc write(sidebar: var Sidebar) =
       sidebar.window.write(i, j, $buf[i][j], cs.color)
 
 ## Refresh the ncurses window for the sidebar.
-proc refresh(sidebar: Sidebar) {.inline.} = sidebar.window.refresh
+proc refresh(sidebar: GlobalSidebar) {.inline.} = sidebar.window.refresh
 
 ## Write buffer to the terminal and refresh.
-proc update*(sidebar: var Sidebar) =
+proc update*(sidebar: var GlobalSidebar) =
   sidebar.write
   sidebar.refresh
 
 ## Resize the sidebar window
-proc resize*(sidebar: var Sidebar, size: Size) {.inline.} =
+proc resize*(sidebar: var GlobalSidebar, size: Size) {.inline.} =
   sidebar.window.resize(size)
 
 ## Resize the sidebar window
-proc resize*(sidebar: var Sidebar, rect: Rect) {.inline.} =
+proc resize*(sidebar: var GlobalSidebar, rect: Rect) {.inline.} =
   sidebar.window.resize(rect)
 
 ## Move the sidebar window
-proc move*(sidebar: var Sidebar, position: Position) {.inline.} =
+proc move*(sidebar: var GlobalSidebar, position: Position) {.inline.} =
   sidebar.window.move(position)
 
 ## Clear the terminal buffer.
-proc clear*(sidebar: var Sidebar) {.inline.} = sidebar.initTerminalBuffer
+proc clear*(sidebar: var GlobalSidebar) {.inline.} = sidebar.initTerminalBuffer

--- a/tests/tglobalsidebar.nim
+++ b/tests/tglobalsidebar.nim
@@ -20,11 +20,11 @@
 import std/[unittest, importutils, sequtils]
 import moepkg/[independentutils, unicodeext, highlight, color]
 
-import moepkg/sidebar {.all.}
+import moepkg/globalsidebar {.all.}
 
 suite "sidebar":
-  test "initSidebar":
-    let sidebar = initSidebar(Rect(h: 1, w: 2, y: 3, x: 4))
+  test "initGlobalSidebar":
+    let sidebar = initGlobalSidebar(Rect(h: 1, w: 2, y: 3, x: 4))
 
     check sidebar.h == 1
     check sidebar.w == 2
@@ -46,7 +46,7 @@ suite "sidebar":
           color: EditorColorPair.defaultChar)])
 
   test "initHighlight":
-    var sidebar = initSidebar(Rect(h: 10, w: 10, y: 0, x: 0))
+    var sidebar = initGlobalSidebar(Rect(h: 10, w: 10, y: 0, x: 0))
     # Clear the highlight for the test.
     sidebar.highlight = Highlight(
       colorSegments: @[
@@ -69,7 +69,7 @@ suite "sidebar":
           color: EditorColorPair.defaultChar)])
 
   test "write 1":
-    var sidebar = initSidebar(Rect(h: 100, w: 100, y: 0, x: 0))
+    var sidebar = initGlobalSidebar(Rect(h: 100, w: 100, y: 0, x: 0))
 
     sidebar.write(Position(y: 0, x: 0), ru"test", EditorColorPair.reservedWord)
 
@@ -95,7 +95,7 @@ suite "sidebar":
           color: EditorColorPair.defaultChar)])
 
   test "write 2":
-    var sidebar = initSidebar(Rect(h: 100, w: 100, y: 0, x: 0))
+    var sidebar = initGlobalSidebar(Rect(h: 100, w: 100, y: 0, x: 0))
 
     sidebar.write(Position(y: 1, x: 10), ru"test", EditorColorPair.reservedWord)
 
@@ -129,28 +129,28 @@ suite "sidebar":
           color: EditorColorPair.defaultChar)])
 
   test "resize":
-    var sidebar = initSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
+    var sidebar = initGlobalSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
 
     sidebar.resize(Size(h: 2, w: 3))
 
     check sidebar.size == Size(h: 2, w: 3)
 
   test "resize 2":
-    var sidebar = initSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
+    var sidebar = initGlobalSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
 
     sidebar.resize(Rect(y: 2, x: 3, h: 4, w: 5))
 
     check sidebar.rect == Rect(y: 2, x: 3, h: 4, w: 5)
 
   test "move":
-    var sidebar = initSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
+    var sidebar = initGlobalSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
 
     sidebar.move(Position(y: 2, x: 3))
 
     check sidebar.position == Position(y: 2, x: 3)
 
   test "clear":
-    var sidebar = initSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
+    var sidebar = initGlobalSidebar(Rect(h: 1, w: 1, y: 0, x: 0))
 
     sidebar.write(Position(y: 0, x: 0), ru"a")
 


### PR DESCRIPTION
Rename `sidebar.Sidebar` to distinguish it from `editorview.Sidebar`.