### PR TITLE
feat: Add a CLI option for init the config file

### DIFF
--- a/changelog.d/20230505_052950_shuu.n_add_init_option_for_config.rst
+++ b/changelog.d/20230505_052950_shuu.n_add_init_option_for_config.rst
@@ -1,0 +1,37 @@
+.. _#1706: https://github.com/fox0430/moe/issues/1706
+.. _#1707: https://github.com/fox0430/moe/pull/1707
+
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+
+Added
+.....
+
+- `#1707`_ feat: Add a CLI option for init the config file (`#1706`_)
+
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/src/moepkg/cmdlineoption.nim
+++ b/src/moepkg/cmdlineoption.nim
@@ -18,7 +18,7 @@
 #[############################################################################]#
 
 import std/[parseopt, pegs, os, strformat]
-import logger
+import logger, settings
 
 type CmdParsedList* = object
   path*: seq[string]
@@ -69,6 +69,7 @@ Usage:
 Arguments:
   -R               Readonly mode
   --log            Start logger
+  --init           Create/Overwrite the default configuration file
   -h, --help       Print this help
   -v, --version    Print version
 """
@@ -85,6 +86,24 @@ proc writeCmdLineError(kind: CmdLineKind, arg: string) =
 
   echo fmt"Unknown option argument: {optionStr}{arg}"
   echo """Pelase check "moe -h""""
+  quit()
+
+## Create/Overwrite the default configuration file and quit.
+proc initDefaultConfigFile() =
+  const
+    configFileDir = getHomeDir() / ".config/moe/"
+    configFilePath = configFileDir & "moerc.toml"
+
+  let tomlStr = genDefaultTomlConfigStr()
+
+  try:
+    createDir(configFileDir)
+    writeFile(configFilePath, tomlStr)
+  except CatchableError as e:
+    echo fmt"Failed to init the default configuration file: {e.msg}"
+
+  echo fmt"The default configuration file has been created to {configFilePath}"
+
   quit()
 
 proc parseCommandLineOption*(line: seq[string]): CmdParsedList =
@@ -104,6 +123,7 @@ proc parseCommandLineOption*(line: seq[string]): CmdParsedList =
       of cmdLongOption:
         case key:
           of "log": initLogger()
+          of "init": initDefaultConfigFile()
           of "version": writeVersion()
           of "help": writeHelp()
           else: writeCmdLineError(kind, key)

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -897,7 +897,7 @@ proc writeConfigurationFile(status: var EditorStatus) =
     configFileDir = getHomeDir() / ".config/moe/"
     configFilePath = configFileDir & "moerc.toml"
 
-  let buffer = status.settings.generateTomlConfigStr
+  let buffer = status.settings.genTomlConfigStr
 
   if fileExists(configFilePath):
     status.commandLine.writePutConfigFileAlreadyExistError

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -2296,8 +2296,8 @@ proc loadSettingFile*(): EditorSettings =
   else:
     return parseSettingsFile(toml)
 
-# Generate a string of the configuration file of  TOML.
-proc generateTomlConfigStr*(settings: EditorSettings): string =
+# Generate a string of the configuration file of TOML.
+proc genTomlConfigStr*(settings: EditorSettings): string =
   proc addLine(buf: var string, str: string) {.inline.} = buf &= "\n" & str
 
   result = "[Standard]"
@@ -2613,3 +2613,7 @@ proc generateTomlConfigStr*(settings: EditorSettings): string =
   result.addLine fmt "currentSetting = \"{$theme.currentSetting}\""
   result.addLine fmt "currentSettingBg = \"{$theme.currentSettingBg}\""
   result.addLine fmt "currentLineBg = \"{$theme.currentLineBg}\""
+
+# Generate a string of the default TOML configuration.
+proc genDefaultTomlConfigStr*(): string {.inline.} =
+  initEditorSettings().genTomlConfigStr

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -611,11 +611,21 @@ suite "Configuration example":
 
     check toml.validateTomlConfig == none(InvalidItem)
 
-suite "Generate toml config":
+suite "Generate toml current config":
   test "Generate current config":
     let
       settings = initEditorSettings()
-      str = settings.generateTomlConfigStr
+      str = settings.genTomlConfigStr
+
+      toml = parsetoml.parseString(str)
+      result = toml.validateTomlConfig
+
+    check result == none(InvalidItem)
+
+suite "Generate toml default config":
+  test "Generate current config":
+    let
+      str = genDefaultTomlConfigStr()
 
       toml = parsetoml.parseString(str)
       result = toml.validateTomlConfig


### PR DESCRIPTION
- Add `--init` CLI option
- Create/Overwrite the default configuration file and exit

Close #1706 

@kevinmatthes I implementd #1706. Do you have any requests?