### PR TITLE
[Bugfix] Fix #1555

### DIFF
--- a/changelog.d/20230524_210000_GitHub_Actions_fix#1555.rst
+++ b/changelog.d/20230524_210000_GitHub_Actions_fix#1555.rst
@@ -1,0 +1,2 @@
+.. 1727:  https://github.com/fox0430/moe/pull/1727
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -87,19 +87,19 @@ default is false
 disableChangeCursor
 ```
 
-Set cursor shape of the terminal emulator you are using (String) ```"blinkBlock"``` or ```"blinkIbeam"``` or ```noneBlinkBlock``` or ```noneBlinkIbeam```  
-default is ```"blinkBlock"```
+Set cursor shape of the terminal emulator you are using (String) ```"terminalDefault"``` or ```"blinkBlock"``` or ```"blinkIbeam"``` or ```noneBlinkBlock``` or ```noneBlinkIbeam```  
+default is ```"terminalDefault"```
 ```
 defaultCursor
 ```
 
-Set cursor shape in normal mode (String) ```"blinkBlock"``` or ```"blinkIbeam"``` or ```noneBlinkBlock``` or ```noneBlinkIbeam```  
+Set cursor shape in normal mode (String) ```"terminalDefault"``` or ```"blinkBlock"``` or ```"blinkIbeam"``` or ```noneBlinkBlock``` or ```noneBlinkIbeam```  
 default is ```"blinkBlock"```
 ```
 normalModeCursor
 ```
 
-Set cursor shape in insert mode (String) ```"blinkBlock"``` or ```"blinkIbeam"``` or ```noneBlinkBlock``` or ```noneBlinkIbeam```  
+Set cursor shape in insert mode (String) ```"terminalDefault"``` or ```"blinkBlock"``` or ```"blinkIbeam"``` or ```noneBlinkBlock``` or ```noneBlinkIbeam```  
 default is ```"blinkIbeam"```
 
 ```

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -30,7 +30,7 @@ smartcase = true
 
 disableChangeCursor = false
 
-defaultCursor = "blinkBlock"
+defaultCursor = "terminalDefault"
 
 normalModeCursor = "blinkBlock"
 

--- a/src/moe.nim
+++ b/src/moe.nim
@@ -83,6 +83,8 @@ proc initEditor(): EditorStatus =
 
   disableControlC()
 
+  setBlinkingBlockCursor()
+
 proc main() =
   var status = initEditor()
 

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -168,10 +168,14 @@ proc turnOffHighlighting*(status: var EditorStatus) =
   status.isSearchHighlight = false
   status.update
 
+proc changeModeToNormalMode(status: var EditorStatus) =
+  status.changeMode(Mode.normal)
+  setBlinkingBlockCursor()
+
 proc writeFileAndExit(status: var EditorStatus) =
   if currentBufStatus.path.len == 0:
     status.commandLine.writeNoFileNameError
-    status.changeMode(Mode.normal)
+    status.changeModeToNormalMode
   else:
     try:
       saveFile(currentBufStatus.path,

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -407,8 +407,7 @@ proc initEditorSettings*(): EditorSettings =
   result.tabStop = 2
   result.ignorecase = true
   result.smartcase = true
-  # defaultCursor is terminal default curosr shape
-  result.defaultCursor = CursorType.blinkBlock
+  result.defaultCursor = CursorType.terminalDefault
   result.normalModeCursor = CursorType.blinkBlock
   result.insertModeCursor = CursorType.blinkIbeam
   result.autoSaveInterval = 5

--- a/src/moepkg/ui.nim
+++ b/src/moepkg/ui.nim
@@ -117,7 +117,7 @@ proc changeCursorType*(cursorType: CursorType) =
     of terminalDefault: setTerminalDefaultCursor()
     of blinkBlock: setBlinkingBlockCursor()
     of noneBlinkBlock: setNoneBlinkingBlockCursor()
-    of blinkIbeam: setBkinkingIbeamCursor()
+    of blinkIbeam: setBlinkingIbeamCursor()
     of noneBlinkIbeam: setNoneBlinkingIbeamCursor()
 
 proc disableControlC*() {.inline.} =

--- a/src/moepkg/ui.nim
+++ b/src/moepkg/ui.nim
@@ -82,7 +82,7 @@ proc getTerminalHeight*(): int = terminalSize.h
 
 proc getTerminalWidth*(): int = terminalSize.w
 
-proc setBkinkingIbeamCursor*() {.inline.} =
+proc setBlinkingIbeamCursor*() {.inline.} =
   when not defined unitTest:
     # Don't change when running unit tests
     discard execShellCmd("printf '\e[5 q'")

--- a/src/moepkg/ui.nim
+++ b/src/moepkg/ui.nim
@@ -17,12 +17,12 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[strformat, osproc, strutils, os, terminal]
+import std/[strformat, osproc, strutils, terminal]
 import pkg/ncurses
 import unicodeext, color, independentutils
 
 when not defined unitTest:
-  import std/posix
+  import std/[posix, os]
 
 type
   Attribute* = enum
@@ -39,10 +39,11 @@ type
     #chartext = A_CHAR_TEXT
 
   CursorType* = enum
-    blinkBlock = 0
-    noneBlinkBlock = 1
-    blinkIbeam = 2
-    noneBlinkIbeam = 3
+    terminalDefault
+    blinkBlock
+    noneBlinkBlock
+    blinkIbeam
+    noneBlinkIbeam
 
   Window* = ref object
     cursesWindow*: PWindow
@@ -81,22 +82,43 @@ proc getTerminalHeight*(): int = terminalSize.h
 
 proc getTerminalWidth*(): int = terminalSize.w
 
-proc setBkinkingIbeamCursor*() {.inline.} = discard execShellCmd("printf '\e[5 q'")
+proc setBkinkingIbeamCursor*() {.inline.} =
+  when not defined unitTest:
+    # Don't change when running unit tests
+    discard execShellCmd("printf '\e[5 q'")
 
-proc setNoneBlinkingIbeamCursor*() {.inline.} = discard execShellCmd("printf '\e[6 q'")
+proc setNoneBlinkingIbeamCursor*() {.inline.} =
+  when not defined unitTest:
+    # Don't change when running unit tests
+    discard execShellCmd("printf '\e[6 q'")
 
-proc setBlinkingBlockCursor*() {.inline.} = discard execShellCmd("printf '\e[1 q'")
+proc setBlinkingBlockCursor*() {.inline.} =
+  when not defined unitTest:
+    # Don't change when running unit tests
+    discard execShellCmd("printf '\e[1 q'")
 
-proc setNoneBlinkingBlockCursor*() {.inline.} = discard execShellCmd("printf '\e[2 q'")
+proc setNoneBlinkingBlockCursor*() {.inline.} =
+  when not defined unitTest:
+    # Don't change when running unit tests
+    discard execShellCmd("printf '\e[2 q'")
 
-proc unhideCursor*() {.inline.} = discard execShellCmd("printf '\e[?25h'")
+proc setTerminalDefaultCursor*() {.inline.} =
+  when not defined unitTest:
+    # Don't change when running unit tests
+    discard execShellCmd("printf '\x1B[0 q'")
+
+proc unhideCursor*() {.inline.} =
+  when not defined unitTest:
+    # Don't change when running unit tests
+    discard execShellCmd("printf '\e[?25h'")
 
 proc changeCursorType*(cursorType: CursorType) =
   case cursorType
-  of blinkBlock: setBlinkingBlockCursor()
-  of noneBlinkBlock: setNoneBlinkingBlockCursor()
-  of blinkIbeam: setBkinkingIbeamCursor()
-  of noneBlinkIbeam: setNoneBlinkingIbeamCursor()
+    of terminalDefault: setTerminalDefaultCursor()
+    of blinkBlock: setBlinkingBlockCursor()
+    of noneBlinkBlock: setNoneBlinkingBlockCursor()
+    of blinkIbeam: setBkinkingIbeamCursor()
+    of noneBlinkIbeam: setNoneBlinkingIbeamCursor()
 
 proc disableControlC*() {.inline.} =
   setControlCHook(proc() {.noconv.} = pressCtrlC = true)

--- a/src/moepkg/visualmode.nim
+++ b/src/moepkg/visualmode.nim
@@ -505,6 +505,10 @@ proc insertCharBlock(
                                       c)
     windowNode.currentLine = beforeLine
 
+proc changeModeToNormalMode(status: var EditorStatus) =
+  setBlinkingBlockCursor()
+  status.changeMode(Mode.normal)
+
 proc exitVisualMode(status: var EditorStatus) =
     var highlight = currentMainWindowNode.highlight
     highlight.updateHighlight(
@@ -514,7 +518,7 @@ proc exitVisualMode(status: var EditorStatus) =
       status.searchHistory,
       status.settings)
 
-    status.changeMode(Mode.normal)
+    status.changeModeToNormalMode
 
 proc visualCommand(
   status: var EditorStatus,

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -51,7 +51,7 @@ suite "Config mode: Init buffer":
                      ru "  ignorecase                     true",
                      ru "  smartcase                      true",
                      ru "  disableChangeCursor            false",
-                     ru "  defaultCursor                  blinkBlock",
+                     ru "  defaultCursor                  terminalDefault",
                      ru "  normalModeCursor               blinkBlock",
                      ru "  insertModeCursor               blinkIbeam",
                      ru "  autoSave                       false",
@@ -504,8 +504,12 @@ suite "Config mode: Get standard table setting values":
     const name = "defaultCursor"
     let values = settings.getStandardTableSettingValues(name)
 
-    check values == @[ru "blinkBlock", ru "noneBlinkBlock", ru "blinkIbeam",
-                      ru "noneBlinkIbeam"]
+    check values == @[
+      ru"terminalDefault",
+      ru"blinkBlock",
+      ru"noneBlinkBlock",
+      ru"blinkIbeam",
+      ru"noneBlinkIbeam"]
 
   test "Get normalModeCursor values":
     var status = initEditorStatus()
@@ -514,8 +518,12 @@ suite "Config mode: Get standard table setting values":
     const name ="normalModeCursor"
     let values = settings.getStandardTableSettingValues(name)
 
-    check values == @[ru "blinkBlock", ru "noneBlinkBlock", ru "blinkIbeam",
-                      ru "noneBlinkIbeam"]
+    check values == @[
+      ru"blinkBlock",
+      ru"terminalDefault",
+      ru"noneBlinkBlock",
+      ru"blinkIbeam",
+      ru"noneBlinkIbeam"]
 
   test "Get insertModeCursor values":
     var status = initEditorStatus()
@@ -524,8 +532,12 @@ suite "Config mode: Get standard table setting values":
     const name = "insertModeCursor"
     let values = settings.getStandardTableSettingValues(name)
 
-    check values == @[ru "blinkIbeam", ru "blinkBlock", ru "noneBlinkBlock",
-                      ru "noneBlinkIbeam"]
+    check values == @[
+      ru"blinkIbeam",
+      ru"terminalDefault",
+      ru"blinkBlock",
+      ru"noneBlinkBlock",
+      ru"noneBlinkIbeam"]
 
   test "Get number values":
     var status = initEditorStatus()


### PR DESCRIPTION
Restore the cursor shape when quitting moe using `x1B[0 q`.

This solution is incomplete and I don't know how many terminals support it. It's maybe not possible at the moment to restore the terminal cursor shape in all environments.
