### PR TITLE
[Enhancement] Apply Quick Filter for Keep a Changelog

### DIFF
--- a/.github/workflows/comment-changes.yaml
+++ b/.github/workflows/comment-changes.yaml
@@ -57,11 +57,11 @@ jobs:
         run: |
           aeruginous comment-changes \
             -d : \
+            -k \
             -n 1 \
             -o changelog.d/ \
             -l \#${{ github.event.pull_request.number }} \
-            -t https://github.com/fox0430/moe/pull/${{ github.event.pull_request.number }} \
-            -c Added -c Changed -c Deprecated -c Fixed -c Removed -c Security
+            -t https://github.com/fox0430/moe/pull/${{ github.event.pull_request.number }}
           git add changelog.d/
           git commit -m 'Create summary of recent changes'
           git push

--- a/changelog.d/20230527_191147_Kevin_Matthes_keep-a-changelog-quick-filter.rst
+++ b/changelog.d/20230527_191147_Kevin_Matthes_keep-a-changelog-quick-filter.rst
@@ -1,0 +1,7 @@
+.. _#1730:  https://github.com/fox0430/moe/pull/1730
+
+Changed
+.......
+
+- `#1730`_ apply quick filter for Keep a Changelog
+


### PR DESCRIPTION
Aeruginous v1.1.2 now has a quick filter for Keep a Changelog categories.  This quick filter replaces the current solution of manually spelling out all categories' names which might easily lead to mistakes.

I added the quick filter call to the application in the workflow and removed the manual category setup.  I put the quick filter option to the second position to sort the options by alphabet (`-l` can be considered belonging to `-t`).  Furthermore, I adjusted the file extension to `yaml` as all other YAML files in this repository have this extension, as well.