### PR TITLE
[Bugfix] Always Install Latest Aeruginous Version

### DIFF
--- a/.github/workflows/comment-changes.yaml
+++ b/.github/workflows/comment-changes.yaml
@@ -53,7 +53,6 @@ jobs:
         uses: baptiste0928/cargo-install@v2
         with:
           crate: aeruginous
-          version: "^1.1.2"
 
       - name: Create commit changes
         run: |

--- a/changelog.d/20230606_133355_Kevin_Matthes_aeruginous-latest.rst
+++ b/changelog.d/20230606_133355_Kevin_Matthes_aeruginous-latest.rst
@@ -1,0 +1,7 @@
+.. _#1737:  https://github.com/fox0430/moe/pull/1737
+
+Fixed
+.....
+
+- `#1737`_ always install latest version of Aeruginous
+


### PR DESCRIPTION
The current setup of the `cargo-install` Action always grabbed statically v1.1.2 instead of fetching *at least* that version of Aeruginous.  Thus, some bugfixes would not be available.  By removing the version field, the respective latest version will be downloaded ensuring access to all improvements and fixes of this mode.  Furthermore, some obsolete dependencies of Aeruginous were removed with v2.0.0 such that the compilation in general should be faster, now.