### PR TITLE
Fixed:  crash due to typo in example configuration

### DIFF
--- a/changelog.d/20230707_150125_Kevin_Matthes_term-defaut-bg.rst
+++ b/changelog.d/20230707_150125_Kevin_Matthes_term-defaut-bg.rst
@@ -1,0 +1,7 @@
+.. _#1750:  https://github.com/fox0430/moe/pull/1750
+
+Fixed
+.....
+
+- `#1750`_ crash due to typo in example configuration
+

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -329,7 +329,7 @@ commandLine = "#ffffff"
 commandLineBg = "#000000"
 
 errorMessage = "#ff0000"
-errorMessageBg = "termDefautBg"
+errorMessageBg = "termDefaultBg"
 
 searchResult = "#ffffff"
 searchResultBg = "#ff0000"


### PR DESCRIPTION
There is a small typo in the example configuration which causes the editor to crash.  This PR fixes that typo.