### PR TITLE
feat: Add `colorMode` setting

### DIFF
--- a/changelog.d/20230707_171241_GitHub_Actions_add-color-mode-setting.rst
+++ b/changelog.d/20230707_171241_GitHub_Actions_add-color-mode-setting.rst
@@ -1,0 +1,7 @@
+.. _#1752:  https://github.com/fox0430/moe/pull/1752
+
+Added
+.....
+
+- `#1752`_ feat: Add `colorMode` setting
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -160,6 +160,12 @@ default is false
 liveReloadOfFile
 ```
 
+Terminal color mode (string) `none` or `8` or `16` or `256` or `24bit`
+defualt is "24bit"
+```
+colorMode
+```
+
 ### Clipboard table
 Enable/Disable system clipboard (bool)  
 default is true

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -54,6 +54,8 @@ smoothScrollSpeed = 15
 
 liveReloadOfFile = false
 
+colorMode = "24bit"
+
 [Clipboard]
 enable = true
 

--- a/src/moe.nim
+++ b/src/moe.nim
@@ -70,7 +70,8 @@ proc initEditor(): EditorStatus =
 
   block initColors:
     # TODO: Show error messages when failing to the load VSCode theme.
-    let r = result.settings.editorColorTheme.initEditrorColor(result.colorMode)
+    let r = result.settings.editorColorTheme.initEditrorColor(
+      result.settings.colorMode)
     if r.isErr:
       exitUi()
       echo r.error

--- a/src/moepkg/configmode.nim
+++ b/src/moepkg/configmode.nim
@@ -50,6 +50,7 @@ type standardTableNames {.pure.} = enum
   smoothScroll
   smoothScrollSpeed
   liveReloadOfFile
+  colorMode
 
 type clipboardTableNames {.pure.} = enum
   enable
@@ -192,6 +193,13 @@ proc getCursorTypeSettingValues(currentVal: CursorType): seq[seq[Rune]] =
     if $cursorType != $currentVal:
       result.add ru $cursorType
 
+proc getColorModeSettingValues(currentVal: ColorMode): seq[Runes] =
+  result.add currentVal.toConfigStr.toRunes
+  const ConfigVals = @["none", "8", "16", "256", "24bit"]
+  for c in ConfigVals:
+    if c != currentVal.toConfigStr:
+      result.add c.toRunes
+
 proc getStandardTableSettingValues(settings: EditorSettings,
                                    name: string): seq[seq[Rune]] =
   if name == "theme":
@@ -206,6 +214,8 @@ proc getStandardTableSettingValues(settings: EditorSettings,
   elif name == "insertModeCursor":
       let currentCursorType = settings.insertModeCursor
       result = getCursorTypeSettingValues(currentCursorType)
+  elif name == "colorMode":
+    result = settings.colorMode.getColorModeSettingValues
   else:
     var currentVal: bool
 
@@ -716,6 +726,8 @@ proc changeStandardTableSetting(settings: var EditorSettings,
       settings.smoothScroll = parseBool(settingVal)
     of "liveReloadOfFile":
       settings.liveReloadOfFile = parseBool(settingVal)
+    of "colorMode":
+      settings.colorMode = parseColorMode(settingVal).get
     else:
       discard
 
@@ -1743,6 +1755,8 @@ proc initStandardTableBuffer(settings: EditorSettings): seq[seq[Rune]] =
         result.add(ru nameStr & space & $settings.smoothScrollSpeed)
       of "liveReloadOfFile":
         result.add(ru nameStr & space & $settings.liveReloadOfFile)
+      of "colorMode":
+        result.add(ru nameStr & space & settings.colorMode.toConfigStr)
 
 proc initClipBoardTableBuffer(settings: ClipboardSettings): seq[seq[Rune]] =
   result.add(ru"ClipBoard")

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -58,7 +58,6 @@ type EditorStatus* = object
   wordDictionary*: WordDictionary
   suggestionWindow*: Option[SuggestionWindow]
   sidebar*: Option[GlobalSidebar]
-  colorMode*: ColorMode
 
 const
   tabLineWindowHeight = 1
@@ -83,8 +82,6 @@ proc initEditorStatus*(): EditorStatus =
       l = 0
       color = EditorColorPairIndex.default
     result.tabWindow = initWindow(h, w, t, l, color.int16)
-
-  result.colorMode = checkColorSupportedTerminal()
 
 template currentBufStatus*: var BufferStatus =
   mixin status
@@ -730,7 +727,7 @@ proc update*(status: var EditorStatus) =
             status.isSearchHighlight,
             status.searchHistory,
             settings,
-            status.colorMode)
+            status.settings.colorMode)
 
         # TODO: Fix condition. Will use a flag.
         if not bufStatus.isFilerMode:
@@ -766,7 +763,7 @@ proc update*(status: var EditorStatus) =
             buffer,
             highlight,
             settings.editorColorTheme,
-            status.colorMode,
+            status.settings.colorMode,
             node.currentLine,
             selectedRange,
             currentLineColorPair)
@@ -1057,7 +1054,8 @@ proc changeTheme*(status: var EditorStatus) =
       status.commandLine.writeError(
         fmt"Error: Failed to switch to VSCode theme: {vsCodeTheme.error}")
 
-  let r = status.settings.editorColorTheme.initEditrorColor(status.colorMode)
+  let r = status.settings.editorColorTheme.initEditrorColor(
+    status.settings.colorMode)
   if r.isErr:
     exitUi()
     echo r.error

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -1195,7 +1195,7 @@ proc listAllBufferCommand(status: var EditorStatus) =
     status.isSearchHighlight,
     status.searchHistory,
     status.settings,
-    status.colorMode)
+    status.settings.colorMode)
 
   while true:
     status.update

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -106,7 +106,7 @@ proc searchNextOccurrence(status: var EditorStatus, keyword: seq[Rune]) =
     status.isSearchHighlight,
     status.searchHistory,
     status.settings,
-    status.colorMode)
+    status.settings.colorMode)
 
   status.bufStatus[currentBufferIndex].keyRight(currentMainWindowNode)
 
@@ -141,7 +141,7 @@ proc searchNextOccurrenceReversely(status: var EditorStatus, keyword: seq[Rune])
     status.isSearchHighlight,
     status.searchHistory,
     status.settings,
-    status.colorMode)
+    status.settings.colorMode)
 
   currentMainWindowNode.keyLeft
 
@@ -922,7 +922,7 @@ proc openBlankLineAboveAndEnterInsertMode(status: var EditorStatus) =
     status.isSearchHighlight,
     status.searchHistory,
     status.settings,
-    status.colorMode)
+    status.settings.colorMode)
 
   status.changeModeToInsertMode
 

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -213,6 +213,7 @@ type
     smoothScroll*: bool
     smoothScrollSpeed*: int
     liveReloadOfFile*: bool
+    colorMode*: ColorMode
     clipboard*: ClipboardSettings
     buildOnSave*: BuildOnSaveSettings
     filer*: FilerSettings
@@ -414,6 +415,7 @@ proc initEditorSettings*(): EditorSettings =
   result.popupWindowInExmode = true
   result.smoothScroll = true
   result.smoothScrollSpeed = 15
+  result.colorMode = checkColorSupportedTerminal()
   result.clipboard = initClipboardSettings()
   result.buildOnSave = BuildOnSaveSettings()
   result.filer = initFilerSettings()
@@ -1007,6 +1009,21 @@ proc loadVSCodeTheme*(): Result[ColorTheme, string] =
 
   return Result[ColorTheme, string].err fmt"Failed to load VSCode theme: Could not find files for the current theme"
 
+proc parseColorMode*(str: string): Result[ColorMode, string] =
+  case str:
+    of "none":
+      return Result[ColorMode, string].ok ColorMode.none
+    of "8":
+      return Result[ColorMode, string].ok ColorMode.c8
+    of "16":
+      return Result[ColorMode, string].ok ColorMode.c16
+    of "256":
+      return Result[ColorMode, string].ok ColorMode.c256
+    of "24bit":
+      return Result[ColorMode, string].ok ColorMode.c24bit
+    else:
+      return Result[ColorMode, string].err "Invalid value"
+
 proc parseSettingsFile*(settings: TomlValueRef): EditorSettings =
   result = initEditorSettings()
 
@@ -1093,6 +1110,9 @@ proc parseSettingsFile*(settings: TomlValueRef): EditorSettings =
 
     if settings["Standard"].contains("smoothScrollSpeed"):
       result.smoothScrollSpeed = settings["Standard"]["smoothScrollSpeed"].getInt()
+
+    if settings["Standard"].contains("colorMode"):
+      result.colorMode = settings["Standard"]["colorMode"].getStr.parseColorMode.get
 
     if settings["Standard"].contains("liveReloadOfFile"):
       result.liveReloadOfFile = settings["Standard"]["liveReloadOfFile"].getBool()
@@ -2009,6 +2029,9 @@ proc validateStandardTable(table: TomlValueRef): Option[InvalidItem] =
             break
         if not correctValue:
           return some(InvalidItem(name: $key, val: $val))
+      of "colorMode":
+        if val.getStr.parseColorMode.isErr:
+          return some(InvalidItem(name: $key, val: $val))
       else:
         return some(InvalidItem(name: $key, val: $val))
 
@@ -2402,6 +2425,14 @@ proc loadSettingFile*(): EditorSettings =
   else:
     return parseSettingsFile(toml)
 
+proc toConfigStr*(colorMode: ColorMode): string =
+  case colorMode:
+    of ColorMode.none: "none"
+    of ColorMode.c8: "8"
+    of ColorMode.c16: "16"
+    of ColorMode.c256: "256"
+    of ColorMode.c24bit: "24bit"
+
 ## Generate a string of the configuration file of TOML.
 proc genTomlConfigStr*(settings: EditorSettings): string =
   proc addLine(buf: var string, str: string) {.inline.} = buf &= "\n" & str
@@ -2433,6 +2464,7 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
   result.addLine fmt "smoothScroll = {$settings.smoothScroll }"
   result.addLine fmt "smoothScrollSpeed = {$settings.smoothScrollSpeed}"
   result.addLine fmt "liveReloadOfFile = {$settings.liveReloadOfFile}"
+  result.addLine fmt "colorMode = \"{settings.colorMode.toConfigStr}\""
 
   result.addLine ""
 

--- a/src/moepkg/ui.nim
+++ b/src/moepkg/ui.nim
@@ -58,7 +58,7 @@ type
 
   ColorMode* {.pure.} = enum
     # No color support
-    None = 1
+    none = 1
     # 8 colors
     c8 = 8
     # 16 colors
@@ -156,7 +156,7 @@ proc setTimeout*(win: var Window, time: int = 100) {.inline.} =
 ## Check "$COLORTERM" first, then check "tput colors" if it fails.
 ## Return ColorMode.None if unknown color support.
 proc checkColorSupportedTerminal*(): ColorMode =
-  result = ColorMode.None
+  result = ColorMode.none
 
   block checkColorTerm:
     let cmdResult = execCmdEx("echo $COLORTERM")
@@ -176,13 +176,13 @@ proc checkColorSupportedTerminal*(): ColorMode =
       try:
         num = output.parseInt
       except ValueError:
-        return ColorMode.None
+        return ColorMode.none
 
       case num:
         of 8: return ColorMode.c8
         of 16: return ColorMode.c16
         of 256: return ColorMode.c256
-        else: return ColorMode.None
+        else: return ColorMode.none
 
 proc startUi*() =
   # Not start when running unit tests

--- a/src/moepkg/visualmode.nim
+++ b/src/moepkg/visualmode.nim
@@ -517,7 +517,7 @@ proc exitVisualMode(status: var EditorStatus) =
       status.isSearchHighlight,
       status.searchHistory,
       status.settings,
-      status.colorMode)
+      status.settings.colorMode)
 
     status.changeModeToNormalMode
 

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -755,6 +755,17 @@ suite "Config mode: Get standard table setting values":
 
     checkBoolSettingValue(default, values)
 
+  test "Get colorMode values":
+    var status = initEditorStatus()
+
+    var settings = status.settings
+    settings.colorMode = ColorMode.c24bit
+
+    const Name = "colorMode"
+    let values = settings.getStandardTableSettingValues(Name)
+
+    check values == @[ru"24bit", ru"none", ru"8", ru"16", ru"256"]
+
   test "Set invalid name":
     var status = initEditorStatus()
     let settings = status.settings
@@ -1740,6 +1751,29 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.smoothScroll
 
+  test "Chaging colorMode":
+    var settings = initEditorSettings()
+
+    settings.colorMode = ColorMode.c24bit
+    settings.changeStandardTableSetting("colorMode", "none")
+    check ColorMode.none == settings.colorMode
+
+    settings.colorMode = ColorMode.c24bit
+    settings.changeStandardTableSetting("colorMode", "8")
+    check ColorMode.c8 == settings.colorMode
+
+    settings.colorMode = ColorMode.c24bit
+    settings.changeStandardTableSetting("colorMode", "16")
+    check ColorMode.c16 == settings.colorMode
+
+    settings.colorMode = ColorMode.c24bit
+    settings.changeStandardTableSetting("colorMode", "256")
+    check ColorMode.c256 == settings.colorMode
+
+    settings.colorMode = ColorMode.none
+    settings.changeStandardTableSetting("colorMode", "24bit")
+    check ColorMode.c24bit == settings.colorMode
+
   test "Set invalid value":
     var settings = initEditorSettings()
 
@@ -2423,3 +2457,24 @@ suite "Config mode: Get BuildOnSave table setting type":
 
     const settingType = getSettingType(table, name)
     check settingType == SettingType.None
+
+suite "Config mode: getColorModeSettingValues":
+  test "Current mode is ColorMode.none":
+    check @[ru"none", ru"8", ru"16", ru"256", ru"24bit"] ==
+      ColorMode.none.getColorModeSettingValues
+
+  test "Current mode is ColorMode.c8":
+    check @[ru"8", ru"none", ru"16", ru"256", ru"24bit"] ==
+      ColorMode.c8.getColorModeSettingValues
+
+  test "Current mode is ColorMode.c16":
+    check @[ru"16", ru"none", ru"8", ru"256", ru"24bit"] ==
+      ColorMode.c16.getColorModeSettingValues
+
+  test "Current mode is ColorMode.c256":
+    check @[ru"256", ru"none", ru"8", ru"16", ru"24bit"] ==
+      ColorMode.c256.getColorModeSettingValues
+
+  test "Current mode is ColorMode.c24bit":
+    check @[ru"24bit", ru"none", ru"8", ru"16", ru"256"] ==
+      ColorMode.c24bit.getColorModeSettingValues

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -62,7 +62,8 @@ suite "Config mode: Init buffer":
                      ru "  autoDeleteParen                false",
                      ru "  smoothScroll                   true",
                      ru "  smoothScrollSpeed              15",
-                     ru "  liveReloadOfFile               false"]
+                     ru "  liveReloadOfFile               false",
+                     ru "  colorMode                      24bit"]
 
     for index, line in buffer:
       check sample[index] == line

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -33,6 +33,8 @@ suite "Config mode: Start configuration mode":
 suite "Config mode: Init buffer":
   test "Init standard table buffer":
     var status = initEditorStatus()
+    status.settings.colorMode = ColorMode.c24bit
+
     let buffer = status.settings.initStandardTableBuffer
 
     const sample = @[ru "Standard",

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -50,6 +50,7 @@ const TomlStr = """
   autoDeleteParen = false
   smoothScroll = false
   smoothScrollSpeed = 1
+  colorMode = "none"
 
   [Clipboard]
   enable = false
@@ -344,6 +345,7 @@ suite "Parse configuration file":
     check not settings.autoDeleteParen
     check not settings.smoothScroll
     check settings.smoothScrollSpeed == 1
+    check settings.colorMode == ColorMode.none
 
     check not settings.clipboard.enable
     check settings.clipboard.toolOnLinux == ClipboardToolOnLinux.xclip

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -499,6 +499,50 @@ suite "Parse configuration file":
     check settings.clipboard.enable
     check settings.clipboard.toolOnLinux == ClipboardToolOnLinux.wlClipboard
 
+  test "Parse color Mode setting 1":
+    const str = """
+      [Standard]
+      colorMode = "none"
+    """
+
+    let toml = parsetoml.parseString(str)
+    let settings = parseSettingsFile(toml)
+
+    check ColorMode.none == settings.colorMode
+
+  test "Parse color Mode setting 2":
+    const str = """
+      [Standard]
+      colorMode = "8"
+    """
+
+    let toml = parsetoml.parseString(str)
+    let settings = parseSettingsFile(toml)
+
+    check ColorMode.c8 == settings.colorMode
+
+  test "Parse color Mode setting 3":
+    const str = """
+      [Standard]
+      colorMode = "256"
+    """
+
+    let toml = parsetoml.parseString(str)
+    let settings = parseSettingsFile(toml)
+
+    check ColorMode.c256  == settings.colorMode
+
+  test "Parse color Mode setting 4":
+    const str = """
+      [Standard]
+      colorMode = "24bit"
+    """
+
+    let toml = parsetoml.parseString(str)
+    let settings = parseSettingsFile(toml)
+
+    check ColorMode.c24bit == settings.colorMode
+
 suite "Validate toml config":
   test "Except for success":
     let toml = parsetoml.parseString(TomlStr)
@@ -595,3 +639,35 @@ suite "Error message":
       errorMessage = result.get.toValidateErrorMessage
 
     check errorMessage == """(name: test, val: test1 = "test1" test2 = "test2")"""
+
+suite "parseColorMode":
+  test "none":
+    check ColorMode.none == "none".parseColorMode.get
+
+  test "c8":
+    check ColorMode.c8 == "8".parseColorMode.get
+
+  test "c16":
+    check ColorMode.c16 == "16".parseColorMode.get
+
+  test "c256":
+    check ColorMode.c256 == "256".parseColorMode.get
+
+  test "c24bit":
+    check ColorMode.c24bit == "24bit".parseColorMode.get
+
+suite "toConfigStr":
+  test "from ColorMode.none":
+    check "none" == ColorMode.none.toConfigStr
+
+  test "from ColorMode.c8":
+    check "8" == ColorMode.c8.toConfigStr
+
+  test "from ColorMode.c16":
+    check "16" == ColorMode.c16.toConfigStr
+
+  test "from ColorMode.c256":
+    check "256" == ColorMode.c256.toConfigStr
+
+  test "from ColorMode.c24bit":
+    check "24bit" == ColorMode.c24bit.toConfigStr

--- a/tests/tviewhighlight.nim
+++ b/tests/tviewhighlight.nim
@@ -25,7 +25,7 @@ test "Highlight current word 1":
     currentBufStatus,
     currentMainWindowNode,
     status.settings.editorColorTheme,
-    status.colorMode)
+    status.settings.colorMode)
 
   check(highlight[0].color == EditorColorPairIndex.default)
   check(highlight[1].color == EditorColorPairIndex.currentWord)
@@ -44,7 +44,7 @@ test "Highlight current word 2":
     currentBufStatus,
     currentMainWindowNode,
     status.settings.editorColorTheme,
-    status.colorMode)
+    status.settings.colorMode)
 
   check(highlight[0].color == EditorColorPairIndex.default)
   check(highlight[1].color == EditorColorPairIndex.currentWord)
@@ -64,7 +64,7 @@ test "Highlight current word 3":
     currentBufStatus,
     currentMainWindowNode,
     status.settings.editorColorTheme,
-    status.colorMode)
+    status.settings.colorMode)
 
   check(highlight[0].color == EditorColorPairIndex.default)
   check(highlight[1].color == EditorColorPairIndex.currentWord)
@@ -199,7 +199,7 @@ suite "Highlight trailing spaces":
       status.isSearchHighlight,
       status.searchHistory,
       status.settings,
-      status.colorMode)
+      status.settings.colorMode)
 
     updateTerminalSize(100, 100)
     status.resize
@@ -226,7 +226,7 @@ suite "Highlight trailing spaces":
       status.isSearchHighlight,
       status.searchHistory,
       status.settings,
-      status.colorMode)
+      status.settings.colorMode)
 
     check(highlight[0].color == EditorColorPairIndex.default)
     check(highlight[0].firstColumn == 0)
@@ -256,7 +256,7 @@ suite "Highlight trailing spaces":
       status.isSearchHighlight,
       status.searchHistory,
       status.settings,
-      status.colorMode)
+      status.settings.colorMode)
 
     check(highlight[0].color == EditorColorPairIndex.default)
     check(highlight[0].firstColumn == 0)
@@ -677,7 +677,7 @@ suite "Update search highlight":
       status.isSearchHighlight,
       status.searchHistory,
       status.settings,
-      status.colorMode)
+      status.settings.colorMode)
 
     check highlight.len == 3
     check highlight[0].color == EditorColorPairIndex.searchResult
@@ -714,7 +714,7 @@ suite "Update search highlight":
             status.isSearchHighlight,
             status.searchHistory,
             status.settings,
-            status.colorMode)
+            status.settings.colorMode)
 
           check highlight.len == 3
           check highlight[0].color == EditorColorPairIndex.searchResult


### PR DESCRIPTION
Add a setting for what color mode to use.

- Add `colorMode` to Standard table
- `none` or `8`  or `16` or `256` or `24bit`
 