### PR TITLE
feat: Add Background build on save support

### DIFF
--- a/changelog.d/20230711_131847_GitHub_Actions_background-build-on-save.rst
+++ b/changelog.d/20230711_131847_GitHub_Actions_background-build-on-save.rst
@@ -1,0 +1,7 @@
+.. _#:  https://github.com/fox0430/moe/pull/
+
+Added
+.....
+
+- `#1759`_ feat: Add Background build on save support
+

--- a/changelog.d/20230711_131847_GitHub_Actions_background-build-on-save.rst
+++ b/changelog.d/20230711_131847_GitHub_Actions_background-build-on-save.rst
@@ -1,4 +1,4 @@
-.. _#:  https://github.com/fox0430/moe/pull/
+.. _#1759:  https://github.com/fox0430/moe/pull/1759
 
 Added
 .....

--- a/src/moepkg/backgroundprocess.nim
+++ b/src/moepkg/backgroundprocess.nim
@@ -1,0 +1,78 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[osproc, strformat]
+import pkg/results
+
+type
+  BackgroundProcess* = object
+    process: Process
+
+  StartProcessResult* = Result[BackgroundProcess, string]
+
+proc isRunning*(bp: BackgroundProcess): bool {.inline.} = bp.process.running
+
+proc isFinish*(bp: BackgroundProcess): bool {.inline.} = not bp.process.running
+
+proc cancel*(bp: var BackgroundProcess) = bp.process.terminate
+
+proc kill*(bp: var BackgroundProcess) = bp.process.kill
+
+proc close(bp: var BackgroundProcess) = bp.process.close
+
+proc startBackgroundProcess*(
+  command: string,
+  args: seq[string],
+  workingDir: string = ""): StartProcessResult =
+    ## Start the passed command in a new process and return BackgroundProcess.
+
+    const
+      Env = nil
+      Options = {poUsePath, poDaemon, poStdErrToStdOut}
+
+    var process: Process
+    try:
+      process = startProcess(command, workingDir, args, Env, Options)
+    except OSError as e:
+      return StartProcessResult.err fmt"Failed to create a background process: {e.msg}"
+
+    return StartProcessResult.ok BackgroundProcess(process: process)
+
+proc result*(bp: var BackgroundProcess): Result[seq[string], string] =
+  ## Return results (Stdout) the BackgroundProcess and close the process.
+  if bp.isRunning:
+    return Result[seq[string], string].err "BackgroundProcess is still running"
+
+  let (output, exitCode) = bp.process.readLines
+  bp.close
+
+  if exitCode == 0:
+    return Result[seq[string], string].ok output
+  else:
+    return Result[seq[string], string].err fmt"BackgroundProcess is failed: {output}"
+
+proc waitFor*(bp: var BackgroundProcess, timeout: int = -1): Result[seq[string], string] =
+  let exitCode = bp.process.waitForExit
+  if 0 == exitCode:
+    let (output, _) = bp.process.readLines
+    bp.close
+    return Result[seq[string], string].ok output
+  else:
+    bp.close
+    return Result[seq[string], string].err fmt"Failed to the background process: {$exitCode}"

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -26,39 +26,44 @@ import gapbuffer, editorview, ui, unicodeext, highlight, fileutils,
        backup, messages, commandline, register, platform, movement,
        autocomplete, suggestionwindow, filermodeutils, debugmodeutils,
        independentutils, viewhighlight, helputils, backupmanagerutils,
-       diffviewerutils, messagelog, globalsidebar
+       diffviewerutils, messagelog, globalsidebar, build
 
-# Save cursor position when a buffer for a window(file) gets closed.
-type LastCursorPosition* = object
-  path: seq[Rune]
-  line: int
-  column: int
+type
+  LastCursorPosition* = object
+    ## Save cursor position when a buffer for a window(file) gets closed.
+    path: Runes
+    line: int
+    column: int
 
-type EditorStatus* = object
-  bufStatus*: seq[BufferStatus]
-  filerStatuses: seq[FilerStatus]
-  prevBufferIndex*: int
-  searchHistory*: seq[Runes]
-  exCommandHistory*: seq[Runes]
-  normalCommandHistory*: seq[seq[Rune]]
-  registers*: Registers
-  settings*: EditorSettings
-  mainWindow*: MainWindow
-  statusLine*: seq[StatusLine]
-  timeConfFileLastReloaded*: DateTime
-  currentDir: seq[Rune]
-  commandLine*: CommandLine
-  tabWindow*: Window
-  popupWindow*: Window
-  lastOperatingTime*: DateTime
-  autoBackupStatus*: AutoBackupStatus
-  isSearchHighlight*: bool
-  lastPosition*: seq[LastCursorPosition]
-  isReadonly*: bool
-  wordDictionary*: WordDictionary
-  suggestionWindow*: Option[SuggestionWindow]
-  sidebar*: Option[GlobalSidebar]
-  colorMode*: ColorMode
+  BackgroundTasks* = object
+    build*: seq[BuildProcess]
+
+  EditorStatus* = object
+    bufStatus*: seq[BufferStatus]
+    filerStatuses: seq[FilerStatus]
+    prevBufferIndex*: int
+    searchHistory*: seq[Runes]
+    exCommandHistory*: seq[Runes]
+    normalCommandHistory*: seq[Runes]
+    registers*: Registers
+    settings*: EditorSettings
+    mainWindow*: MainWindow
+    statusLine*: seq[StatusLine]
+    timeConfFileLastReloaded*: DateTime
+    currentDir: Runes
+    commandLine*: CommandLine
+    tabWindow*: Window
+    popupWindow*: Window
+    lastOperatingTime*: DateTime
+    autoBackupStatus*: AutoBackupStatus
+    isSearchHighlight*: bool
+    lastPosition*: seq[LastCursorPosition]
+    isReadonly*: bool
+    wordDictionary*: WordDictionary
+    suggestionWindow*: Option[SuggestionWindow]
+    sidebar*: Option[GlobalSidebar]
+    colorMode*: ColorMode
+    backgroundTasks*: BackgroundTasks
 
 const
   tabLineWindowHeight = 1
@@ -607,13 +612,10 @@ proc updateLogViewerBuffer(
   if logs.len > 0 and logs[0].len > 0:
     bufStatus.buffer = logs.toGapBuffer
 
-proc updateLogViewerHighlight(buffer: string): Highlight =
+proc initLogViewerHighlight(buffer: string): Highlight =
   if buffer.len > 0:
-    const emptyReservedWord: seq[ReservedWord] = @[]
-    return initHighlight(
-      buffer,
-      emptyReservedWord,
-      SourceLanguage.langNone)
+    const EmptyReservedWord: seq[ReservedWord] = @[]
+    return buffer.initHighlight(EmptyReservedWord, SourceLanguage.langNone)
 
 proc updateSuggestWindow(status: var EditorStatus) =
   let
@@ -631,10 +633,40 @@ proc updateSuggestWindow(status: var EditorStatus) =
     mainWindowY,
     status.settings.statusLine.enable)
 
+proc checkBackgroundBuild(status: var EditorStatus) =
+  var i = 0
+  while i < status.backgroundTasks.build.len:
+    template p(): var BuildProcess =
+      status.backgroundTasks.build[i]
+
+    if not p.isFinish:
+      i.inc
+    else:
+      let r = p.result
+      if r.isOk:
+        addMessageLog r.get.toSeqRunes
+        status.commandLine.writeMessageSuccessBuildOnSave(
+          p.filePath,
+          status.settings.notification)
+      else:
+        addMessageLog r.error.toRunes
+        status.commandLine.writeMessageFailedBuildOnSave(p.filePath)
+
+      status.backgroundTasks.build.delete i
+
+proc checkBackgroundTasks(status: var EditorStatus) =
+  ## Check if background processes for builds are finished and if there are finished,
+  ## do the next process and delete from `status.backgroundTasks`.
+
+  if status.backgroundTasks.build.len > 0:
+    status.checkBackgroundBuild
+
 ## Update all views, highlighting, cursor, etc.
 proc update*(status: var EditorStatus) =
   # Disable the cursor while updating.
   setCursor(false)
+
+  status.checkBackgroundTasks
 
   let settings = status.settings
 
@@ -673,7 +705,7 @@ proc update*(status: var EditorStatus) =
     settings.syntax)
 
   # Set editor Color Pair for current line highlight.
-  # New color pairs are set to Number larger than the maximum value of EditorColorPiar.
+  # New color pairs are set to number larger than the maximum value of EditorColorPiarIndex.
   var currentLineColorPair: int = ord(EditorColorPairIndex.high) + 1
 
   var queue = initHeapQueue[WindowNode]()
@@ -714,15 +746,17 @@ proc update*(status: var EditorStatus) =
         var highlight = node.highlight
 
         ## Update highlights
-        # TODO: Fix condition
+        # TODO: Fix conditions
         if bufStatus.isLogViewerMode:
-          highlight = updateLogViewerHighlight($buffer)
-        elif bufStatus.isFilerMode and status.filerStatuses[bufStatus.filerStatusIndex.get].isUpdateView:
-          highlight = status.filerStatuses[bufStatus.filerStatusIndex.get].initFilerHighlight(
-            buffer,
-            node.currentLine)
+          highlight = initLogViewerHighlight($buffer)
         elif bufStatus.isDiffViewerMode:
           highlight = bufStatus.buffer.toRunes.initDiffViewerHighlight
+        elif bufStatus.isFilerMode and
+             status.filerStatuses[bufStatus.filerStatusIndex.get].isUpdateView:
+               highlight = initFilerHighlight(
+                 status.filerStatuses[bufStatus.filerStatusIndex.get],
+                 buffer,
+                 node.currentLine)
         elif bufStatus.isEditMode:
           highlight.updateHighlight(
             bufStatus,

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -116,26 +116,19 @@ proc writeMessageAutoSave*(
     if settings.logNotifications and settings.autoSaveLogNotify:
       addMessageLog mess
 
-proc writeMessageBuildOnSave*(
-  commandLine: var CommandLine,
-  settings: NotificationSettings) =
-    const mess = "Build on save..."
-    if settings.screenNotifications and settings.buildOnSaveScreenNotify:
-      commandLine.writeMessageOnCommandLine(mess)
-    if settings.logNotifications and settings.buildOnSaveLogNotify:
-      addMessageLog mess
-
 proc writeMessageSuccessBuildOnSave*(
   commandLine: var CommandLine,
+  path: Runes,
   settings: NotificationSettings) =
-    const mess = "Build successful, file saved"
+
+    let mess = fmt"Build on save successful: {$path}"
     if settings.screenNotifications and settings.buildOnSaveScreenNotify:
       commandLine.writeMessageOnCommandLine(mess)
     if settings.logNotifications and settings.buildOnSaveLogNotify:
       addMessageLog mess
 
-proc writeMessageFailedBuildOnSave*(commandLine: var CommandLine) =
-  const mess = "Build failed"
+proc writeMessageFailedBuildOnSave*(commandLine: var CommandLine, path: Runes) =
+  let mess = fmt"Build failed: {$path}"
   commandLine.writeMessageOnCommandLine(mess)
   addMessageLog mess
 
@@ -153,12 +146,24 @@ proc writeNotEditorCommandError*(
 
 proc writeMessageSaveFile*(
   commandLine: var CommandLine,
-  filename: seq[Rune],
+  filename: Runes,
   settings: NotificationSettings) =
+
     let mess = fmt"Saved {filename}"
     if settings.screenNotifications and settings.saveScreenNotify:
       commandLine.writeMessageOnCommandLine(mess)
     if settings.logNotifications and settings.saveLogNotify:
+      addMessageLog mess
+
+proc writeMessageSaveFileAndStartBuild*(
+  commandLine: var CommandLine,
+  filename: Runes,
+  settings: NotificationSettings) =
+
+    let mess = fmt"Saved {filename} and start build..."
+    if settings.screenNotifications and settings.buildOnSaveScreenNotify:
+      commandLine.writeMessageOnCommandLine(mess)
+    if settings.logNotifications and settings.buildOnSaveLogNotify:
       addMessageLog mess
 
 proc writeNoBufferDeletedError*(commandLine: var CommandLine) =

--- a/src/moepkg/unicodeext.nim
+++ b/src/moepkg/unicodeext.nim
@@ -279,6 +279,10 @@ proc toRunes*(s: seq[string]): Runes =
 
 proc toRunes*(r: Rune): Runes {.inline.} = @[r]
 
+proc toSeqRunes*(s: seq[string]): seq[Runes] =
+  for l in s:
+    result.add l.toRunes
+
 proc startsWith*(runes1, runes2: seq[Rune]): bool =
   result = true
   for i in 0 ..< min(runes1.len, runes2.len):

--- a/src/moepkg/windownode.nim
+++ b/src/moepkg/windownode.nim
@@ -403,6 +403,16 @@ proc absolutePosition*(
 
     return (y, x)
 
+proc moveCursor*(node: var WindowNode, line, column: int) =
+  if node.window.isSome:
+    node.currentLine = line
+    node.currentColumn = column
+    node.window.get.move(line, column)
+
+proc moveCursor*(node: var WindowNode) =
+  if node.window.isSome:
+    node.window.get.move(node.currentLine, node.currentColumn)
+
 proc refreshWindow*(node: var WindowNode) {.inline.} =
   if node.window.isSome: node.window.get.refresh
 

--- a/tests/tbackgoundprocess.nim
+++ b/tests/tbackgoundprocess.nim
@@ -1,0 +1,130 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, os, options]
+import pkg/results
+
+import moepkg/backgroundprocess {.all.}
+
+suite "BackgroundTask: isFinish":
+  test "Return true":
+    const
+      Command = "/bin/sh"
+      Args = @["-c", "sleep 0"]
+    var bp = startBackgroundProcess(Command, Args).get
+
+    # Wait just in case
+    sleep 100
+
+    let isFinish = bp.isFinish
+
+    bp.close
+
+    check isFinish
+
+  test "Return false":
+    const
+      Command = "/bin/sh"
+      Args = @["-c", "sleep 0.5"]
+    var bp = startBackgroundProcess(Command, Args).get
+
+    let isFinish = bp.isFinish
+
+    bp.close
+
+    # Wait just in case
+    sleep 100
+
+    check not isFinish
+
+suite "BackgroundTask: cancel":
+  test"Cancel background process":
+    const
+      Command = "/bin/sh"
+      Args = @["-c", "sleep 0.5"]
+    var bp = startBackgroundProcess(Command, Args).get
+
+    bp.cancel
+
+    # Wait just in case
+    sleep 100
+
+    check not bp.isRunning
+
+suite "BackgroundTask: kill":
+  test"Kill background process":
+    const
+      Command = "/bin/sh"
+      Args = @["-c", "sleep 0.5"]
+    var bp = startBackgroundProcess(Command, Args).get
+
+    bp.kill
+
+    # Wait just in case
+    sleep 100
+
+    check not bp.isRunning
+
+suite "BackgroundTask: Run background process":
+  test "Exec '/bin/sh -c echo 1'":
+    var
+      bp: Option[BackgroundProcess]
+      output: seq[string]
+
+    for _ in 0 .. 50:
+      if bp.isNone:
+        const
+          Command = "/bin/sh"
+          Args = @["-c", "echo 1"]
+        bp = startBackgroundProcess(Command, Args).get.some
+      elif bp.get.isFinish:
+        output = bp.get.result.get
+        break
+      else:
+        sleep 100
+
+    check @["1"] == output
+
+  test "Exec '/bin/sh -c echo 1; echo 2'":
+    var
+      bp: Option[BackgroundProcess]
+      output: seq[string]
+
+    for _ in 0 .. 50:
+      if bp.isNone:
+        const
+          Command = "/bin/sh"
+          Args = @["-c", "echo 1; echo 2"]
+        bp = startBackgroundProcess(Command, Args).get.some
+      elif bp.get.isFinish:
+        output = bp.get.result.get
+        break
+      else:
+        sleep 100
+
+    check @["1", "2"] == output
+
+  test "Exec '/bin/sh -c sleep 1; echo 1' and waitFor":
+    const
+      Command = "/bin/sh"
+      Args = @["-c", "sleep 0.5; echo 1"]
+    var bp = startBackgroundProcess(Command, Args).get
+
+    check @["1"] == bp.waitFor.get
+    check not bp.isRunning


### PR DESCRIPTION
Runs the build in the background at the save file. This prevents the editor from stopping.

Close #1157 