### PR TITLE
repo: Remove default titles from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -19,7 +19,7 @@
 
 name: Bug Report
 description: Outline a bug.
-title: '[Bug Report] <Bug Report Title>'
+title: ''
 labels:
   - bug
 body:

--- a/.github/ISSUE_TEMPLATE/enhance.yaml
+++ b/.github/ISSUE_TEMPLATE/enhance.yaml
@@ -19,7 +19,7 @@
 
 name: Enhancement
 description: Enhancement.
-title: '[Enhancement] <Title>'
+title: ''
 labels:
   - enhancement
 body:

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -19,7 +19,7 @@
 
 name: Feature Request
 description: Feature request.
-title: '[Feature] <Title>'
+title: ''
 labels:
   - feature
 body:

--- a/changelog.d/20230712_202903_GitHub_Actions_fix-issue-template-titles.rst
+++ b/changelog.d/20230712_202903_GitHub_Actions_fix-issue-template-titles.rst
@@ -1,0 +1,7 @@
+.. _#1761:  https://github.com/fox0430/moe/pull/1761
+
+Changed
+.......
+
+- `#1761`_ repo: Remove default titles from issue templates
+


### PR DESCRIPTION
Remove default titles because it is identifiable by labels.