### PR TITLE
feat: Add color settings for the git changed line view

### DIFF
--- a/changelog.d/20230716_170036_GitHub_Actions_add-settings-for-changedlines.rst
+++ b/changelog.d/20230716_170036_GitHub_Actions_add-settings-for-changedlines.rst
@@ -1,0 +1,7 @@
+.. _#1767:  https://github.com/fox0430/moe/pull/1767
+
+Added
+.....
+
+- `#1767`_ feat: Add color settings for the git changed line view
+

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -396,3 +396,10 @@ configModeCurrentLine = "#ffffff"
 configModeCurrentLineBg = "#008080"
 
 currentLineBg = "#444444"
+
+sidebarGitAddedSign = "#008000"
+sidebarGitAddedSignBg = "#000000"
+sidebarGitDeletedSign = "#ff0000"
+sidebarGitDeletedSignBg = "#000000"
+sidebarGitChangedSign = "#ffff00"
+sidebarGitChangedSignBg = "#000000"

--- a/src/moepkg/color.nim
+++ b/src/moepkg/color.nim
@@ -489,6 +489,14 @@ type
     # highlight curent line background
     currentLineBg
 
+    # Side bar
+    sidebarGitAddedSign
+    sidebarGitAddedSignBg
+    sidebarGitDeletedSign
+    sidebarGitDeletedSignBg
+    sidebarGitChangedSign
+    sidebarGitChangedSignBg
+
   EditorColorPairIndex* {.pure.} = enum
     # Cannot use 0 in Ncurses color pair.
     default = 1
@@ -577,6 +585,11 @@ type
     configModeCurrentLine
     # highlight curent line background
     currentLineBg
+
+    # Side bar
+    sidebarGitAddedSign
+    sidebarGitDeletedSign
+    sidebarGitChangedSign
 
   Color* = object
     index*: EditorColorIndex
@@ -1102,7 +1115,32 @@ const
       foreground: DefaultForegroundColor,
       background: Color(
         index: EditorColorIndex.currentLineBg,
-        rgb: "#444444".hexToRgb.get))
+        rgb: "#444444".hexToRgb.get)),
+
+    # Side bar
+    EditorColorPairIndex.sidebarGitAddedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitAddedSign,
+        rgb: "#008000".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitAddedSignBg,
+        rgb: "#000000".hexToRgb.get)),
+
+    EditorColorPairIndex.sidebarGitDeletedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitDeletedSign,
+        rgb: "#ff0000".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitDeletedSignBg,
+        rgb: "#000000".hexToRgb.get)),
+
+    EditorColorPairIndex.sidebarGitChangedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitChangedSign,
+        rgb: "#ffff00".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitChangedSignBg,
+        rgb: "#000000".hexToRgb.get))
   ]
 
   LightTheme*: ThemeColors = [
@@ -1610,7 +1648,32 @@ const
       foreground: DefaultForegroundColor,
       background: Color(
         index: EditorColorIndex.currentLineBg,
-        rgb: "#d3d3d3".hexToRgb.get))
+        rgb: "#d3d3d3".hexToRgb.get)),
+
+    # Side bar
+    EditorColorPairIndex.sidebarGitAddedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitAddedSign,
+        rgb: "#008000".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitAddedSignBg,
+        rgb: "#000000".hexToRgb.get)),
+
+    EditorColorPairIndex.sidebarGitDeletedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitDeletedSign,
+        rgb: "#ff0000".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitDeletedSign,
+        rgb: "#000000".hexToRgb.get)),
+
+    EditorColorPairIndex.sidebarGitChangedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitChangedSign,
+        rgb: "#ffff00".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitChangedSignBg,
+        rgb: "#000000".hexToRgb.get))
   ]
 
   VividTheme*: ThemeColors = [
@@ -2118,7 +2181,32 @@ const
       foreground: DefaultForegroundColor,
       background: Color(
         index: EditorColorIndex.currentLineBg,
-        rgb: "#444444".hexToRgb.get))
+        rgb: "#444444".hexToRgb.get)),
+
+    # Side bar
+    EditorColorPairIndex.sidebarGitAddedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitAddedSign,
+        rgb: "#008000".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitAddedSignBg,
+        rgb: "#000000".hexToRgb.get)),
+
+    EditorColorPairIndex.sidebarGitDeletedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitDeletedSign,
+        rgb: "#ff0000".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitDeletedSign,
+        rgb: "#000000".hexToRgb.get)),
+
+    EditorColorPairIndex.sidebarGitChangedSign: ColorPair(
+      foreground: Color(
+        index: EditorColorIndex.sidebarGitChangedSign,
+        rgb: "#ffff00".hexToRgb.get),
+      background: Color(
+        index: EditorColorIndex.sidebarGitChangedSignBg,
+        rgb: "#000000".hexToRgb.get))
   ]
 
 var

--- a/src/moepkg/editorview.nim
+++ b/src/moepkg/editorview.nim
@@ -624,7 +624,11 @@ proc updateSidebarBufferForChangedLine*(
           v.firstOriginLine <= d.firstLine or v.firstOriginLine <= d.lastLine
 
     # height * 2 spaces.
-    var newBuffer = view.height.newSeqWith(ru"  ")
+    var
+      buffer = view.height.newSeqWith(ru"  ")
+      highlights = buffer.len.newSeqWith(
+        @[EditorColorPairIndex.default,
+          EditorColorPairIndex.default])
 
     for d in changedLines:
       if view.inRange(d):
@@ -633,19 +637,25 @@ proc updateSidebarBufferForChangedLine*(
             of deleted:
               # Only use the firstLine.
               if lineNum >= d.firstLine and lineNum <= d.firstLine:
-                newBuffer[y] = ru"_ "
+                buffer[y] = ru"_ "
+                highlights[y][0] = EditorColorPairIndex.sideBarGitDeletedSign
             of changedAndDeleted:
               # Only use the firstLine.
               if lineNum >= d.firstLine and lineNum <= d.firstLine:
-                newBuffer[y] = ru"~_"
+                buffer[y] = ru"~_"
+                highlights[y] = EditorColorPairIndex.sideBarGitChangedSign.repeat(
+                  2)
             of changed:
               if lineNum >= d.firstLine and lineNum <= d.lastLine:
-                newBuffer[y] = ru"~ "
+                buffer[y] = ru"~ "
+                highlights[y][0] = EditorColorPairIndex.sideBarGitChangedSign
             of OperationType.added:
               if lineNum >= d.firstLine and lineNum <= d.lastLine:
-                newBuffer[y] = ru"+ "
+                buffer[y] = ru"+ "
+                highlights[y][0] = EditorColorPairIndex.sideBarGitAddedSign
 
-    view.sidebar.get.buffer = newBuffer
+    view.sidebar.get.buffer = buffer
+    view.sidebar.get.highlights = highlights
 
 ## Update a sidebar buffer for syntax checker reuslts.
 ## It's on left side of EditorView.

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -1982,6 +1982,30 @@ proc parseSettingsFile*(settings: TomlValueRef): EditorSettings =
       ColorThemeTable[configTheme][EditorColorPairIndex.currentLineBg].background.rgb =
         toRgb("currentLineBg")
 
+    if settings["Theme"].contains("sidebarGitAddedSign"):
+      ColorThemeTable[configTheme][EditorColorPairIndex.sidebarGitAddedSign].foreground.rgb =
+        toRgb("sidebarGitAddedSign")
+
+    if settings["Theme"].contains("sidebarGitAddedSignBg"):
+      ColorThemeTable[configTheme][EditorColorPairIndex.sidebarGitAddedSign].background.rgb =
+        toRgb("sidebarGitAddedSignBg")
+
+    if settings["Theme"].contains("sidebarGitDeletedSign"):
+      ColorThemeTable[configTheme][EditorColorPairIndex.sidebarGitDeletedSign].foreground.rgb =
+        toRgb("sidebarGitDeletedSign")
+
+    if settings["Theme"].contains("sidebarGitDeletedSignBg"):
+      ColorThemeTable[configTheme][EditorColorPairIndex.sidebarGitDeletedSign].background.rgb =
+        toRgb("sidebarGitDeletedSignBg")
+
+    if settings["Theme"].contains("sidebarGitChangedSign"):
+      ColorThemeTable[configTheme][EditorColorPairIndex.sidebarGitChangedSign].foreground.rgb =
+        toRgb("sidebarGitChangedSign")
+
+    if settings["Theme"].contains("sidebarGitChangedSignBg"):
+      ColorThemeTable[configTheme][EditorColorPairIndex.sidebarGitChangedSign].background.rgb =
+        toRgb("sidebarGitChangedSignBg")
+
   elif result.editorColorTheme == ColorTheme.vscode:
     let vsCodeTheme = loadVSCodeTheme()
     if vsCodeTheme.isOk:
@@ -2788,6 +2812,12 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
   result.addLine fmt "configModeCurrentLine = \"{theme.fgColor(EditorColorPairIndex.configModeCurrentLine)}\""
   result.addLine fmt "configModeCurrentLineBg = \"{theme.bgColor(EditorColorPairIndex.configModeCurrentLine)}\""
   result.addLine fmt "currentLineBg = \"{theme.bgColor(EditorColorPairIndex.currentLineBg)}\""
+  result.addLine fmt "sidebarGitAddedSign = \"{theme.fgColor(EditorColorPairIndex.sidebarGitAddedSign)}\""
+  result.addLine fmt "sidebarGitAddedSignBg = \"{theme.bgColor(EditorColorPairIndex.sidebarGitAddedSign)}\""
+  result.addLine fmt "sidebarGitDeletedSign = \"{theme.fgColor(EditorColorPairIndex.sidebarGitDeletedSign)}\""
+  result.addLine fmt "sidebarGitDeletedSignBg = \"{theme.bgColor(EditorColorPairIndex.sidebarGitDeletedSign)}\""
+  result.addLine fmt "sidebarGitChangedSign = \"{theme.fgColor(EditorColorPairIndex.sidebarGitChangedSign)}\""
+  result.addLine fmt "sidebarGitChangedSignBg = \"{theme.bgColor(EditorColorPairIndex.sidebarGitChangedSign)}\""
 
 # Generate a string of the default TOML configuration.
 proc genDefaultTomlConfigStr*(): string {.inline.} =

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -497,6 +497,18 @@ suite "Config mode: Init buffer":
       ru"  currentLineBg",
       ru"    foreground                   termDefautFg",
       ru"    background                   #444444",
+      ru"",
+      ru"  sidebarGitAddedSign",
+      ru"    foreground                   #008000",
+      ru"    background                   #000000",
+      ru"",
+      ru"  sidebarGitDeletedSign",
+      ru"    foreground                   #ff0000",
+      ru"    background                   #000000",
+      ru"",
+      ru"  sidebarGitChangedSign",
+      ru"    foreground                   #ffff00",
+      ru"    background                   #000000",
       ru""
     ]
 

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -316,6 +316,13 @@ const TomlStr = """
   configModeCurrentLineBg = "#000000"
 
   currentLineBg = "#000000"
+
+  sidebarGitAddedSign = "#000000"
+  sidebarGitAddedSignBg = "#000000"
+  sidebarGitDeletedSign = "#000000"
+  sidebarGitDeletedSignBg = "#000000"
+  sidebarGitChangedSign = "#000000"
+  sidebarGitChangedSignBg = "#000000"
 """
 
 suite "Parse configuration file":


### PR DESCRIPTION
Add settings to `Theme` table
- `sidebarGitAddedSign`
- `sidebarGitAddedSignBg`
- `sidebarGitDeletedSign`
- `sidebarGitDeletedSignBg`
- `sidebarGitChangedSign`
- `sidebarGitChangedSignBg`