### PR TITLE
[Bugfix] Prevent comment-changes Workflow from Failing

### DIFF
--- a/.github/workflows/comment-changes.yaml
+++ b/.github/workflows/comment-changes.yaml
@@ -24,7 +24,6 @@ on:
     types:
       - opened
       - reopened
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -34,8 +33,10 @@ jobs:
     name: run
     runs-on: ubuntu-latest
 
-    # Ignore Dependabot PRs.
-    if: ${{ github.actor != 'dependabot[bot]' }}
+    # Ignore Dependabot PRs and do not attempt to push to other repositories.
+    if: |
+      github.actor != 'dependabot[bot]' &&
+      github.event.pull_request.head.repo.full_name == 'fox0430/moe'
     steps:
       - name: Checkout source
         uses: actions/checkout@v3.5.3

--- a/changelog.d/20230718_091043_Kevin_Matthes_comment-changes-fail.rst
+++ b/changelog.d/20230718_091043_Kevin_Matthes_comment-changes-fail.rst
@@ -1,0 +1,7 @@
+.. _#1771:  https://github.com/fox0430/moe/pull/1771
+
+Fixed
+.....
+
+- `#1771`_ prevent comment-changes workflow from failing
+


### PR DESCRIPTION
This PR shall prevent the `comment-changes` workflow from failing by running it only if the repository the PR originates from is *this* repository.  Furthermore, I removed the manual trigger as the PR number is always required but a manual dispatch does not necessarily ensure that information.