### PR TITLE
[Enhancement] Switch to Maintenance-free cffconvert Docker Image

### DIFF
--- a/.github/workflows/cff.yaml
+++ b/.github/workflows/cff.yaml
@@ -41,6 +41,6 @@ jobs:
           persist-credentials: false
 
       - name: cffconvert
-        uses: citation-file-format/cffconvert-github-action@2.0.0
+        uses: docker://citationcff/cffconvert:latest
         with:
           args: --validate

--- a/changelog.d/20230721_132941_Kevin_Matthes_cffconvert-docker-image.rst
+++ b/changelog.d/20230721_132941_Kevin_Matthes_cffconvert-docker-image.rst
@@ -1,0 +1,7 @@
+.. _#1775:  https://github.com/fox0430/moe/pull/1775
+
+Changed
+.......
+
+- `#1775`_ CI:  switch to maintenance-free cffconvert Docker image
+


### PR DESCRIPTION
The CFF validation Action is built upon a Docker image which is a wrapper around the Python 3 CLI.  We can reduce the maintenance effort of the CFF validation workflow by calling that Docker image directly with `latest` as requested version to always have access to the latest version of the validator.