### PR TITLE
[Enhancement] Add Linter for GHA Workflows

### DIFF
--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -1,0 +1,46 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+name: actionlint
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/*.yaml
+  push:
+    paths:
+      - .github/workflows/*.yaml
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: validate
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3.5.3
+        with:
+          persist-credentials: false
+
+      - name: actionlint
+        uses: docker://rhysd/actionlint:latest
+        with:
+          args: -color

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -91,7 +91,7 @@ jobs:
     - name: Install integration tools
       run: |
         # shpec
-        sudo sh -c "`curl -L https://raw.githubusercontent.com/rylnd/shpec/master/install.sh`"
+        sudo sh -c "$(curl -L https://raw.githubusercontent.com/rylnd/shpec/master/install.sh)"
         # abduco
         wget http://mirrors.kernel.org/ubuntu/pool/universe/a/abduco/abduco_0.1-2_amd64.deb
         sudo dpkg -i abduco_0.1-2_amd64.deb

--- a/changelog.d/20230721_133910_Kevin_Matthes_actionlint.rst
+++ b/changelog.d/20230721_133910_Kevin_Matthes_actionlint.rst
@@ -1,0 +1,7 @@
+.. _#1776:  https://github.com/fox0430/moe/pull/1776
+
+Added
+.....
+
+- `#1776`_ CI:  linter for GHA workflows
+


### PR DESCRIPTION
This PR adds a linter for GitHub Action workflows which is called whenever workflow files were edited.  This shall ensure the correctness of the workflows and prevent difficult bug tracing.

If changes to the workflows should be necessary as the linter could complain about certain style issues, I will take care about those.