### PR TITLE
feat: Show syntax checker messages on the command line

### DIFF
--- a/changelog.d/20230721_202249_GitHub_Actions_show-synax-checker-messages.rst
+++ b/changelog.d/20230721_202249_GitHub_Actions_show-synax-checker-messages.rst
@@ -1,0 +1,7 @@
+.. _#1777:  https://github.com/fox0430/moe/pull/1777
+
+Added
+.....
+
+- `#1777`_ feat: Show syntax checker messages on the command line
+

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -121,6 +121,8 @@ proc isSearchMode*(mode: Mode): bool {.inline.} =
 proc isSearchMode*(b: BufferStatus): bool {.inline.} =
   b.isSearchForwardMode or b.isSearchBackwardMode
 
+proc isNormalMode*(mode: Mode): bool {.inline.} = mode == Mode.normal
+
 proc isNormalMode*(mode, prevMode: Mode): bool {.inline.} =
   (mode == Mode.normal) or
   (mode.isExMode and prevMode == Mode.normal) or
@@ -200,14 +202,20 @@ proc isRecentFileMode*(mode, prevMode: Mode): bool {.inline.} =
 proc isRecentFileMode*(b: BufferStatus): bool {.inline.} =
   isRecentFileMode(b.mode, b.prevMode)
 
-# Modes for editing text
 proc isEditMode*(mode, prevMode: Mode): bool {.inline.} =
+  ## Modes for editing text
+
   isNormalMode(mode, prevMode) or
   isInsertMode(mode) or
   isVisualMode(mode) or
   isReplaceMode(mode)
 
-# Modes for editing text
+proc isEditMode*(mode: Mode): bool {.inline.} =
+  isNormalMode(mode) or
+  isInsertMode(mode) or
+  isVisualMode(mode) or
+  isReplaceMode(mode)
+
 proc isEditMode*(b: BufferStatus): bool {.inline.} =
   b.isNormalMode or
   b.isInsertMode or

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -661,6 +661,22 @@ proc updateSuggestWindow(status: var EditorStatus) =
     mainWindowY,
     status.settings.statusLine.enable)
 
+proc updateCommandLine(status: var EditorStatus) =
+  ## Update the command line.
+
+  if currentBufStatus.mode.isEditMode and
+     currentBufStatus.syntaxCheckResults.len > 0:
+       let message = currentBufStatus.syntaxCheckResults.formatedMessage(
+         currentMainWindowNode.currentLine)
+       if message.isSome:
+          # Write messages for syntax checker reuslts.
+         status.commandLine.write message.get
+       elif status.commandLine.buffer.isSyntaxCheckFormatedMessage:
+         # Clear if messages for other lines are still displayed.
+         status.commandLine.clear
+
+  status.commandLine.update
+
 ## Update all views, highlighting, cursor, etc.
 proc update*(status: var EditorStatus) =
   # Disable the cursor while updating.
@@ -832,7 +848,7 @@ proc update*(status: var EditorStatus) =
 
   if status.sidebar.isSome: status.sidebar.get.update
 
-  status.commandLine.update
+  status.updateCommandLine
 
   if currentBufStatus.isCursor:
     setCursor(true)

--- a/src/moepkg/syntaxcheck.nim
+++ b/src/moepkg/syntaxcheck.nim
@@ -17,7 +17,7 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[os, strformat, strutils]
+import std/[os, strformat, strutils, options]
 import pkg/[regex, results]
 import syntax/highlite
 import independentutils, unicodeext, backgroundprocess
@@ -42,6 +42,22 @@ type
     command*: BackgroundProcessCommand
     filePath*: Runes
     process*: BackgroundProcess
+
+proc isSyntaxCheckFormatedMessage*(m: string | Runes): bool {.inline.} =
+  startsWith($m, "SyntaxError: ")
+
+proc formatedMessage*(
+  syntaxErrors: seq[SyntaxError],
+  line: int): Option[Runes] =
+    ## Return a formated syntax error message with the position for
+    ## the specified line, if it exists.
+    ## Message exmaple: "SyntaxError: (1, 2) Syntax error!"
+
+    for se in syntaxErrors:
+      if line == se.position.line:
+        return fmt"SyntaxError: ({$se.position.line}, {$se.position.column}) {$se.message}"
+          .toRunes
+          .some
 
 proc syntaxCheckCommand(
   path: string,


### PR DESCRIPTION
Show messages from the syntax checker on the command line.


![moe_syntaxcheck](https://github.com/fox0430/moe/assets/15966436/73826004-396e-4a74-b4d4-da6af537744a)
