### PR TITLE
feat: Add customizable Status line supports

### DIFF
--- a/changelog.d/20230804_205558_GitHub_Actions_customizable-statusline.rst
+++ b/changelog.d/20230804_205558_GitHub_Actions_customizable-statusline.rst
@@ -1,2 +1,6 @@
 .. _#1797:  https://github.com/fox0430/moe/pull/1797
 
+Added
+.....
+
+- `#1797`_ feat: Add customizable Status line supports

--- a/changelog.d/20230804_205558_GitHub_Actions_customizable-statusline.rst
+++ b/changelog.d/20230804_205558_GitHub_Actions_customizable-statusline.rst
@@ -1,0 +1,2 @@
+.. _#1797:  https://github.com/fox0430/moe/pull/1797
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -214,30 +214,6 @@ default is true
 chanedMark
 ```
 
-Show line info (bool)  
-default is true
-```
-line
-```
-
-Show column info (bool)  
-default is ture
-```
-column
-```
-
-Show character encoding (bool)  
-default is true
-```
-encoding
-```
-
-Show language (bool)  
-default is true
-```
-language
-```
-
 Show file location (bool)  
 default is true
 ```
@@ -266,6 +242,17 @@ Show/Hide mode string in status line when window is inactive (bool)
 default is false
 ```
 showModeInactive
+```
+
+Text to customize the items displayed in the status line (string)
+
+Items: `lineNumber`, `totalLines` `columnNumber`, `totalColumns`,  `encoding`, `fileType`, `fileTypeIcon`
+
+You can display information in the status lien by enclosing the above items in parentheses. Example: `{lineNumber}`
+
+defaut is `"{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {fileType}"`
+```
+setupText
 ```
 
 ### BuildOnSave table

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -85,14 +85,6 @@ filename = true
 
 chanedMark = true
 
-line = true
-
-column = true
-
-encoding = true
-
-language = true
-
 directory = true
 
 gitChangedLines = true
@@ -103,6 +95,7 @@ showGitInactive = false
 
 showModeInactive = false
 
+setupText = "{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {fileType}"
 
 [Highlight]
 

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -300,6 +300,7 @@ proc initBufferStatus*(
     result.mode = mode
     result.lastSaveTime = now()
     result.lastGitInfoCheckTime = now()
+    result.fileType = getFileType("")
 
     if mode.isFilerMode:
       result.buffer = initGapBuffer(@[ru ""])

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -50,6 +50,7 @@ type
     isUpdate*: bool
     characterEncoding*: CharacterEncoding
     language*: SourceLanguage
+    fileType*: FileType
     selectedArea*: SelectedArea
     path*: Runes
     openDir*: Runes
@@ -269,6 +270,7 @@ proc initBufferStatus*(
     result.mode = mode
     result.lastSaveTime = now()
     result.lastGitInfoCheckTime = now()
+    result.fileType = getFileType(path)
 
     if isFilerMode(result.mode):
       result.path = absolutePath(path).toRunes

--- a/src/moepkg/configmode.nim
+++ b/src/moepkg/configmode.nim
@@ -79,6 +79,7 @@ type statusLineTableNames {.pure.} = enum
   gitBranchName
   showGitInactive
   showModeInactive
+  setupText
 
 type highlightTableNames {.pure.} = enum
   currentLine
@@ -324,43 +325,38 @@ proc getTabLineTableSettingValues(settings: TabLineSettings,
 proc getStatusLineTableSettingValues(settings: StatusLineSettings,
                                      name: string): seq[Runes] =
 
-  var currentVal: bool
-  case name:
-    of "multipleStatusLine":
-      currentVal = settings.multipleStatusLine
-    of "merge":
-      currentVal = settings.merge
-    of "mode":
-      currentVal = settings.mode
-    of "filename":
-      currentVal = settings.filename
-    of "chanedMark":
-      currentVal = settings.chanedMark
-    of "line":
-      currentVal = settings.line
-    of "column":
-      currentVal = settings.column
-    of "encoding":
-      currentVal = settings.characterEncoding
-    of "language":
-      currentVal = settings.language
-    of "directory":
-      currentVal = settings.directory
-    of "gitChangedLines":
-      currentVal = settings.gitChangedLines
-    of "gitBranchName":
-      currentVal = settings.gitBranchName
-    of "showGitInactive":
-      currentVal = settings.showGitInactive
-    of "showModeInactive":
-      currentVal = settings.showModeInactive
-    else:
-      return
-
-  if currentVal:
-    result = @[ru "true", ru "false"]
+  if name == "setupText":
+    return @[settings.setupText]
   else:
-    result = @[ru "false", ru "true"]
+    var currentVal: bool
+    case name:
+      of "multipleStatusLine":
+        currentVal = settings.multipleStatusLine
+      of "merge":
+        currentVal = settings.merge
+      of "mode":
+        currentVal = settings.mode
+      of "filename":
+        currentVal = settings.filename
+      of "chanedMark":
+        currentVal = settings.chanedMark
+      of "directory":
+        currentVal = settings.directory
+      of "gitChangedLines":
+        currentVal = settings.gitChangedLines
+      of "gitBranchName":
+        currentVal = settings.gitBranchName
+      of "showGitInactive":
+        currentVal = settings.showGitInactive
+      of "showModeInactive":
+        currentVal = settings.showModeInactive
+      else:
+        return
+
+    if currentVal:
+      result = @[ru "true", ru "false"]
+    else:
+      result = @[ru "false", ru "true"]
 
 proc getHighlightTableSettingValues(settings: EditorSettings,
                                     name: string): seq[Runes] =
@@ -781,14 +777,6 @@ proc changeStatusLineTableSetting(settings: var StatusLineSettings,
     settings.filename = parseBool(settingVal)
   of "chanedMark":
     settings.chanedMark = parseBool(settingVal)
-  of "line":
-    settings.line = parseBool(settingVal)
-  of "column":
-    settings.column = parseBool(settingVal)
-  of "encoding":
-    settings.characterEncoding = parseBool(settingVal)
-  of "language":
-    settings.language = parseBool(settingVal)
   of "directory":
     settings.directory = parseBool(settingVal)
   of "gitChangedLines":
@@ -799,6 +787,8 @@ proc changeStatusLineTableSetting(settings: var StatusLineSettings,
     settings.showGitInactive = parseBool(settingVal)
   of "showModeInactive":
     settings.showModeInactive = parseBool(settingVal)
+  of "setupText":
+    settings.setupText = settingVal.toRunes
   else:
     discard
 
@@ -1127,7 +1117,10 @@ proc getSettingType(table, name: string): SettingType =
          "gitChangedLines",
          "gitBranchName",
          "showGitInactive",
-         "showModeInactive": result = SettingType.Bool
+         "showModeInactive":
+           result = SettingType.Bool
+      of "setupText":
+        result = SettingType.String
       else:
         result = SettingType.None
 
@@ -1828,14 +1821,6 @@ proc initStatusLineTableBuffer(settings: StatusLineSettings): seq[Runes] =
         result.add(ru nameStr & space & $settings.filename)
       of "chanedMark":
         result.add(ru nameStr & space & $settings.chanedMark)
-      of "line":
-        result.add(ru nameStr & space & $settings.line)
-      of "column":
-        result.add(ru nameStr & space & $settings.column)
-      of "encoding":
-        result.add(ru nameStr & space & $settings.characterEncoding)
-      of "language":
-        result.add(ru nameStr & space & $settings.language)
       of "directory":
         result.add(ru nameStr & space & $settings.directory)
       of "gitChangedLines":
@@ -1846,6 +1831,8 @@ proc initStatusLineTableBuffer(settings: StatusLineSettings): seq[Runes] =
         result.add(ru nameStr & space & $settings.showGitInactive)
       of "showModeInactive":
         result.add(ru nameStr & space & $settings.showModeInactive)
+      of "setupText":
+        result.add(ru nameStr & space & $settings.setupText)
 
 proc initHighlightTableBuffer(settings: EditorSettings): seq[Runes] =
   result.add(ru"Highlight")

--- a/src/moepkg/filermodeutils.nim
+++ b/src/moepkg/filermodeutils.nim
@@ -291,15 +291,9 @@ proc initFilerHighlight*[T](
         lastColumn: buffer[index].len,
         color: color))
 
-## Return true if Dockerfile or docker compose file.
-proc isDockerFile(filename: string): bool {.inline.} =
- filename == "Dockerfile" or
- filename == "docker-compose.yml" or
- filename == "docker-compose.yaml" or
- filename == "compose.yaml" or
- filename == "compose.yml"
-
 proc pathToIcon(path: string): Runes =
+  # TODO: Use fileutils.getFileType
+
   if dirExists(path):
     return ru"📁 "
 

--- a/src/moepkg/fileutils.nim
+++ b/src/moepkg/fileutils.nim
@@ -169,7 +169,7 @@ proc getFileType*(path: string): FileType =
           return FileType.unknown
     else:
       for ext in FileType:
-        if ext != FileType.unknown and fileSplit.ext == $ext:
+        if ext != FileType.unknown and fileSplit.ext[1 .. ^1] == $ext:
           return ext
       return FileType.unknown
 

--- a/src/moepkg/fileutils.nim
+++ b/src/moepkg/fileutils.nim
@@ -20,6 +20,159 @@
 import std/[os, encodings]
 import gapbuffer, unicodeext
 
+type
+  FileType* = enum
+    dir
+    docker
+    nim
+    nimble
+    rpm
+    deb
+    py
+    ui
+    glade
+    txt
+    md
+    rst
+    cpp
+    cxx
+    hpp
+    c
+    h
+    java
+    php
+    js
+    json
+    rs
+    html
+    xhtml
+    css
+    xml
+    cfg
+    ini
+    sh
+    pdf
+    doc
+    odf
+    ods
+    odt
+    wav
+    mp3
+    ogg
+    zip
+    bz2
+    xz
+    gz
+    tgz
+    zstd
+    exe
+    bin
+    mp4
+    webm
+    avi
+    mpeg
+    patch
+    lock
+    pem
+    crt
+    png
+    jpeg
+    jpg
+    bmp
+    gif
+    unknown
+
+proc fileTypeIcon*(fileType: FileType): Runes =
+  case fileType:
+    of dir:
+      ru"📁"
+    of docker:
+      ru"🐳"
+    of nim:
+      ru"👑"
+    of nimble, rpm, deb:
+      ru"📦"
+    of py:
+      ru"🐍"
+    of ui, glade:
+      ru"🏠"
+    of txt, md, rst:
+      ru"📝"
+    of cpp, cxx, hpp:
+      ru"⧺"
+    of c, h:
+      ru"🅒"
+    of java:
+      ru"🍵"
+    of php:
+      ru"🙈"
+    of js, json:
+      ru"🙉"
+    of rs:
+      ru"🦀"
+    of html, xhtml:
+      ru"🏄"
+    of css:
+      ru"👚"
+    of xml:
+      ru"༕"
+    of cfg, ini:
+      ru"🍳"
+    of sh:
+      ru"🐚"
+    of pdf, doc, odf, ods, odt:
+      ru"🍞"
+    of wav, mp3, ogg:
+      ru"🎼"
+    of zip, bz2, xz, gz, tgz, zstd:
+      ru"🚢"
+    of exe, bin:
+      ru"🏃"
+    of mp4, webm, avi, mpeg:
+      ru"🎞"
+    of patch:
+      ru"💊"
+    of lock:
+      ru"🔒"
+    of pem, crt:
+      ru"🔏"
+    of png, jpeg, jpg, bmp, gif:
+      ru"🎨"
+    else:
+      ru"🍕"
+
+proc isDockerFile*(filename: string): bool {.inline.} =
+  ## Return true if Dockerfile or docker compose file.
+
+  filename == "Dockerfile" or
+  filename == "docker-compose.yml" or
+  filename == "docker-compose.yaml" or
+  filename == "compose.yaml" or
+  filename == "compose.yml"
+
+proc getFileType*(path: string): FileType =
+  if dirExists(path):
+    return FileType.dir
+  else:
+    let fileSplit = splitFile(path)
+    if fileSplit.ext.len == 0:
+      if isDockerFile(fileSplit.name):
+        return FileType.docker
+      else:
+        # Not sure if this is a perfect solution,
+        # it should detect if the current user can execute the file or not:
+        try:
+          let permissions = getFilePermissions(path)
+          if fpUserExec in permissions or fpGroupExec in permissions:
+            return FileType.exe
+        except:
+          return FileType.unknown
+    else:
+      for ext in FileType:
+        if ext != FileType.unknown and fileSplit.ext == $ext:
+          return ext
+      return FileType.unknown
+
 proc normalizedPath*(path: Runes): Runes =
   result = normalizedPath($path).toRunes
   if path.startsWith(ru'~'):

--- a/src/moepkg/statusline.nim
+++ b/src/moepkg/statusline.nim
@@ -111,7 +111,6 @@ proc getFileType(b: BufferStatus): Runes =
       return sourceLanguageToStr[b.language].toRunes
 
 proc getFileTypeIcon(b: BufferStatus): Runes =
-  # TODO: Only languages
   if b.isEditMode:
     return fileTypeIcon(b.fileType)
 

--- a/src/moepkg/unicodeext.nim
+++ b/src/moepkg/unicodeext.nim
@@ -539,3 +539,6 @@ proc stripLineEnd*(runes: Runes): Runes =
   var s = $runes
   s.stripLineEnd
   return s.toRunes
+
+proc replace*(runes1, sub: Runes, by: Runes = ru""): Runes {.inline.} =
+  replace($runes1, $sub, $by).toRunes

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -121,15 +121,13 @@ suite "Config mode: Init buffer":
       "  mode                           true",
       "  filename                       true",
       "  chanedMark                     true",
-      "  line                           true",
-      "  column                         true",
-      "  encoding                       true",
-      "  language                       true",
       "  directory                      true",
       "  gitChangedLines                true",
       "  gitBranchName                  true",
       "  showGitInactive                false",
-      "  showModeInactive               false"].toSeqRunes
+      "  showModeInactive               false",
+      "  setupText                      {lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {fileType}"
+    ].toSeqRunes
 
     for index, line in buffer:
       check Sample[index] == line
@@ -993,50 +991,6 @@ suite "Config mode: Get StatusLine table setting values":
     const Name = "chanedMark"
     let
       default = statusLineSettings.chanedMark
-      values = statusLineSettings.getStatusLineTableSettingValues(Name)
-
-    checkBoolSettingValue(default, values)
-
-  test "Get line values":
-    var status = initEditorStatus()
-    let statusLineSettings = status.settings.statusLine
-
-    const Name = "line"
-    let
-      default = statusLineSettings.line
-      values = statusLineSettings.getStatusLineTableSettingValues(Name)
-
-    checkBoolSettingValue(default, values)
-
-  test "Get column values":
-    var status = initEditorStatus()
-    let statusLineSettings = status.settings.statusLine
-
-    const Name = "column"
-    let
-      default = statusLineSettings.column
-      values = statusLineSettings.getStatusLineTableSettingValues(Name)
-
-    checkBoolSettingValue(default, values)
-
-  test "Get encoding values":
-    var status = initEditorStatus()
-    let statusLineSettings = status.settings.statusLine
-
-    const Name = "encoding"
-    let
-      default = statusLineSettings.characterEncoding
-      values = statusLineSettings.getStatusLineTableSettingValues(Name)
-
-    checkBoolSettingValue(default, values)
-
-  test "Get language values":
-    var status = initEditorStatus()
-    let statusLineSettings = status.settings.statusLine
-
-    const Name = "language"
-    let
-      default = statusLineSettings.language
       values = statusLineSettings.getStatusLineTableSettingValues(Name)
 
     checkBoolSettingValue(default, values)
@@ -2020,46 +1974,6 @@ suite "Config mode: Chaging StatusLine table settings":
     statusLineSettings.changeStatusLineTableSetting("chanedMark", $val)
 
     check val == statusLineSettings.chanedMark
-
-  test "Chaging line":
-    var
-      settings = initEditorSettings()
-      statusLineSettings = settings.statusLine
-
-    let val = not statusLineSettings.line
-    statusLineSettings.changeStatusLineTableSetting("line", $val)
-
-    check val == statusLineSettings.line
-
-  test "Chaging column":
-    var
-      settings = initEditorSettings()
-      statusLineSettings = settings.statusLine
-
-    let val = not statusLineSettings.column
-    statusLineSettings.changeStatusLineTableSetting("column", $val)
-
-    check val == statusLineSettings.column
-
-  test "Chaging encoding":
-    var
-      settings = initEditorSettings()
-      statusLineSettings = settings.statusLine
-
-    let val = not statusLineSettings.characterEncoding
-    statusLineSettings.changeStatusLineTableSetting("encoding", $val)
-
-    check val == statusLineSettings.characterEncoding
-
-  test "Chaging language":
-    var
-      settings = initEditorSettings()
-      statusLineSettings = settings.statusLine
-
-    let val = not statusLineSettings.language
-    statusLineSettings.changeStatusLineTableSetting("language", $val)
-
-    check val == statusLineSettings.language
 
   test "Chaging directory":
     var

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -70,15 +70,12 @@ const TomlStr = """
   mode = false
   filename = false
   chanedMark = false
-  line = false
-  column = false
-  encoding = false
-  language = false
   directory = false
   gitChangedLines = false
   gitBranchName = false
   showGitInactive = true
   showModeInactive = true
+  setupText = "{lineNumber}/{totalLines}"
 
   [Highlight]
   currentLine = true
@@ -393,15 +390,12 @@ suite "Parse configuration file":
     check not settings.statusLine.mode
     check not settings.statusLine.filename
     check not settings.statusLine.chanedMark
-    check not settings.statusLine.line
-    check not settings.statusLine.column
-    check not settings.statusLine.characterEncoding
-    check not settings.statusLine.language
     check not settings.statusLine.directory
     check not settings.statusLine.gitChangedLines
     check not settings.statusLine.gitBranchName
     check settings.statusLine.showGitInactive
     check settings.statusLine.showModeInactive
+    check settings.statusLine.setupText == ru"{lineNumber}/{totalLines}"
 
     check settings.view.highlightCurrentLine
     check not settings.highlight.replaceText

--- a/tests/tstatusline.nim
+++ b/tests/tstatusline.nim
@@ -1,0 +1,263 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, os, strutils, strformat, sugar, importutils]
+import moepkg/[bufferstatus, unicodeext, editorstatus, ui, gapbuffer, git, color]
+
+import moepkg/statusline {.all.}
+
+proc resize(status: var EditorStatus, h, w: int) =
+  updateTerminalSize(h, w)
+  status.resize
+
+suite "statusline: displayPath":
+  test "Empty":
+    const Path = ""
+    let bufStatus = initBufferStatus(Path)
+
+    check ru"No name" == displayPath(bufStatus)
+
+  test "Absolute path":
+    const Path = "/path/to/file"
+    let bufStatus = initBufferStatus(Path)
+
+    check Path.toRunes == displayPath(bufStatus)
+
+  test "Relative path":
+    const Path = "./file"
+    let bufStatus = initBufferStatus(Path)
+
+    check Path.toRunes == displayPath(bufStatus)
+
+  test "In the home dir":
+    let path = getHomeDir() / "file"
+    let bufStatus = initBufferStatus(path)
+
+    check ru"~/file" == displayPath(bufStatus)
+
+suite "statusline: getFileType":
+  test "Nim and Normal mode":
+    const Path = "test.nim"
+    let bufStatus = initBufferStatus(Path)
+
+    check ru"Nim" == bufStatus.getFileType
+
+  test "Plain and Normal mode":
+    const Path = "test.txt"
+    let bufStatus = initBufferStatus(Path)
+
+    check ru"Plain" == bufStatus.getFileType
+
+suite "statusline: statusLineInfoBuffer":
+  test "Default setting with Nim":
+    var status = initEditorStatus()
+
+    const Path = "test.nim"
+    status.addNewBufferInCurrentWin(Path)
+
+    status.resize(100, 100)
+    status.update
+
+    const SetupText =
+      ru"{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {fileType}"
+
+    check ru"1/1 1/0 UTF-8 Nim " ==
+      currentBufStatus.statusLineInfoBuffer(currentMainWindowNode, SetupText)
+
+  test "Nim 2":
+    var status = initEditorStatus()
+
+    const Path = "test.nim"
+    status.addNewBufferInCurrentWin(Path)
+
+    for i in 0 ..< 9:
+      currentBufStatus.buffer.add ' '.repeat(10).toRunes
+
+    currentMainWindowNode.currentLine = 9
+    currentMainWindowNode.currentColumn = 9
+
+    status.resize(100, 100)
+    status.update
+
+    const SetupText =
+      ru"{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {fileType} {fileTypeIcon}"
+
+    check ru"10/10 10/10 UTF-8 Nim 👑 " ==
+      currentBufStatus.statusLineInfoBuffer(currentMainWindowNode, SetupText)
+
+  test "Plain":
+    var status = initEditorStatus()
+
+    const Path = "test.txt"
+    status.addNewBufferInCurrentWin(Path)
+
+    status.resize(100, 100)
+    status.update
+
+    const SetupText =
+      ru"{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {fileType} {fileTypeIcon}"
+
+    check ru"1/1 1/0 UTF-8 Plain 📝 " ==
+      currentBufStatus.statusLineInfoBuffer(currentMainWindowNode, SetupText)
+
+  test "Empty":
+    var status = initEditorStatus()
+
+    const Path = "test.txt"
+    status.addNewBufferInCurrentWin(Path)
+
+    status.resize(100, 100)
+    status.update
+
+    const SetupText = ru""
+
+    check ru"" == currentBufStatus.statusLineInfoBuffer(
+      currentMainWindowNode,
+      SetupText)
+
+  test "Wihtout items":
+    var status = initEditorStatus()
+
+    const Path = "test.txt"
+    status.addNewBufferInCurrentWin(Path)
+
+    status.resize(100, 100)
+    status.update
+
+    # This is the invalid item.
+    const SetupText = ru"lineNumber"
+
+    check ru"lineNumber " ==
+      currentBufStatus.statusLineInfoBuffer(currentMainWindowNode, SetupText)
+
+suite "statusline: addFilerModeInfo":
+  test "Active window":
+    var status = initEditorStatus()
+
+    const Path = getHomeDir()
+    status.addNewBufferInCurrentWin(Path, Mode.filer)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+    status.statusLine[0].addFilerModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    # 1 is "../"
+    let numOfFiles = collect(for k in walkDir(Path): k).len + 1
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      fmt" {getHomeDir()}                                                                                    1/{numOfFiles} ".toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineFilerMode)
+    ]
+
+  test "Inactive window":
+    var status = initEditorStatus()
+
+    const Path = getHomeDir()
+    status.addNewBufferInCurrentWin(Path, Mode.filer)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = false
+    status.statusLine[0].addFilerModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    # 1 is "../"
+    let numOfFiles = collect(for k in walkDir(Path): k).len + 1
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      fmt" {getHomeDir()}                                                                                    1/{numOfFiles} ".toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineFilerModeInactive)
+    ]
+
+suite "statusline: gitBranchNameBuffer":
+  test "With changedLines":
+    const
+      BranchName = ru"branch-name"
+      WithGitChangedLine = true
+    check ru" branch-name " == gitBranchNameBuffer(
+      BranchName,
+      WithGitChangedLine)
+
+  test "Without changedLines":
+    const
+      BranchName = ru"branch-name"
+      WithGitChangedLine = false
+    check ru"  branch-name " == gitBranchNameBuffer(
+      BranchName,
+      WithGitChangedLine)
+
+suite "statusline: changedLinesBuffer":
+  test "Added line":
+    check ru" +1 ~0 -0" ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.added, firstLine: 0, lastLine: 0)])
+
+  test "Changed line":
+    check ru" +0 ~1 -0" ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0)])
+
+  test "Deleted line":
+    check ru" +0 ~0 -1" ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0)])
+
+  test "Changed and deleted line":
+    check ru" +0 ~1 -1" ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)])
+
+  test "Mixed":
+    check ru" +1 ~2 -2" ==
+      changedLinesBuffer(@[
+        Diff(operation: OperationType.added, firstLine: 0, lastLine: 0),
+        Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0),
+        Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0),
+        Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)
+      ])

--- a/tests/tstatusline.nim
+++ b/tests/tstatusline.nim
@@ -815,7 +815,7 @@ suite "statusline: addGitInfo":
     check status.statusLine[0].highlight.segments == @[
       StatusLineColorSegment(
         first: 0,
-        last: 31,
+        last: status.statusLine[0].buffer.high,
         color: EditorColorPairIndex.statusLineGitBranch)
     ]
 
@@ -857,7 +857,7 @@ suite "statusline: addGitInfo":
         color: EditorColorPairIndex.statusLineGitChangedLines),
       StatusLineColorSegment(
         first: 9,
-        last: 40,
+        last: status.statusLine[0].buffer.high,
         color: EditorColorPairIndex.statusLineGitBranch)
     ]
 
@@ -1026,9 +1026,9 @@ suite "statusline: updateStatusLineBuffer":
     let branchName = getCurrentGitBranchName().get
 
     privateAccess(status.statusLine[0].type)
-    check status.statusLine[0].buffer ==
-      fmt" NORMAL   {branchName}  No name                                1/1 1/0 UTF-8 Plain "
-      .toRunes
+    check status.statusLine[0].buffer.startsWith(
+      fmt" NORMAL   {branchName}  No name".toRunes)
+    check status.statusLine[0].buffer.endsWith(ru"1/1 1/0 UTF-8 Plain ")
 
     privateAccess(status.statusLine[0].highlight.type)
     privateAccess(StatusLineColorSegment.type)
@@ -1039,10 +1039,10 @@ suite "statusline: updateStatusLineBuffer":
         color: EditorColorPairIndex.statusLineModeNormalMode),
       StatusLineColorSegment(
         first: 8,
-        last: 39,
+        last: 8 + 4 + branchName.high,
         color: EditorColorPairIndex.statusLineGitBranch),
       StatusLineColorSegment(
-        first: 40,
+        first: 8 + 4 + branchName.high + 1,
         last: 99,
         color: EditorColorPairIndex.statusLineNormalMode)
     ]

--- a/tests/tstatusline.nim
+++ b/tests/tstatusline.nim
@@ -18,6 +18,7 @@
 #[############################################################################]#
 
 import std/[unittest, os, strutils, strformat, importutils]
+import pkg/results
 import moepkg/[bufferstatus, unicodeext, editorstatus, ui, gapbuffer, git, color]
 
 import moepkg/statusline {.all.}
@@ -146,6 +147,77 @@ suite "statusline: statusLineInfoBuffer":
     check ru"lineNumber " ==
       currentBufStatus.statusLineInfoBuffer(currentMainWindowNode, SetupText)
 
+suite "statusline: statusLineFilerInfoBuffer":
+  let path = getCurrentDir() / "statusline_test_dir"
+
+  setup:
+    createDir(path)
+
+  teardown:
+    removeDir(path)
+
+  test "1 digit":
+    # Create a file for the test.
+    writeFile(path / "dummy", "")
+
+    var status = initEditorStatus()
+
+    status.addNewBufferInCurrentWin(path, Mode.filer)
+
+    status.resize(100, 100)
+    status.update
+
+    check statusLineFilerInfoBuffer(currentBufStatus, currentMainWindowNode) ==
+      fmt"1/2 ".toRunes
+
+  test "1 digit 2":
+    # Create a file for the test.
+    writeFile(path / "dummy", "")
+
+    var status = initEditorStatus()
+
+    status.addNewBufferInCurrentWin(path, Mode.filer)
+
+    currentMainWindowNode.currentLine = 1
+
+    status.resize(100, 100)
+    status.update
+
+    check statusLineFilerInfoBuffer(currentBufStatus, currentMainWindowNode) ==
+      fmt"2/2 ".toRunes
+
+  test "2 digit":
+    # Create files for the test.
+    for i in 0 ..< 9:
+      writeFile(path / "dummy" & $i, "")
+
+    var status = initEditorStatus()
+
+    status.addNewBufferInCurrentWin(path, Mode.filer)
+
+    status.resize(100, 100)
+    status.update
+
+    check statusLineFilerInfoBuffer(currentBufStatus, currentMainWindowNode) ==
+      fmt"1/10 ".toRunes
+
+  test "2 digit 2":
+    # Create files for the test.
+    for i in 0 ..< 9:
+      writeFile(path / "dummy" & $i, "")
+
+    var status = initEditorStatus()
+
+    status.addNewBufferInCurrentWin(path, Mode.filer)
+
+    currentMainWindowNode.currentLine = 9
+
+    status.resize(100, 100)
+    status.update
+
+    check statusLineFilerInfoBuffer(currentBufStatus, currentMainWindowNode) ==
+      fmt"10/10 ".toRunes
+
 suite "statusline: addFilerModeInfo":
   # "../", dummy1 and dummy2
   const NumOfFiles = 3
@@ -193,8 +265,14 @@ suite "statusline: addFilerModeInfo":
     privateAccess(status.statusLine[0].highlight.type)
     privateAccess(StatusLineColorSegment.type)
     check status.statusLine[0].highlight.segments == @[
-      StatusLineColorSegment(first: 0, last: 6, color: EditorColorPairIndex.statusLineModeFilerMode),
-      StatusLineColorSegment(first: 7, last: 99, color: EditorColorPairIndex.statusLineFilerMode)
+      StatusLineColorSegment(
+        first: 0,
+        last: 6,
+        color: EditorColorPairIndex.statusLineModeFilerMode),
+      StatusLineColorSegment(
+        first: 7,
+        last: 99,
+        color: EditorColorPairIndex.statusLineFilerMode)
     ]
 
   test "Inactive window":
@@ -222,7 +300,7 @@ suite "statusline: addFilerModeInfo":
       status.settings)
 
     privateAccess(status.statusLine[0].type)
-    check startsWith($status.statusLine[0].buffer, fmt"   {path}")
+    check startsWith($status.statusLine[0].buffer, fmt" {path}")
     check endsWith($status.statusLine[0].buffer, fmt"1/{NumOfFiles} ")
     for i in fmt"   {path}".len .. fmt"1/{NumOfFiles} ".len:
       check " " == $status.statusLine[0].buffer[i]
@@ -230,8 +308,342 @@ suite "statusline: addFilerModeInfo":
     privateAccess(status.statusLine[0].highlight.type)
     privateAccess(StatusLineColorSegment.type)
     check status.statusLine[0].highlight.segments == @[
-      StatusLineColorSegment(first: 0, last: 1, color: EditorColorPairIndex.statusLineModeFilerMode),
-      StatusLineColorSegment(first: 2, last: 99, color: EditorColorPairIndex.statusLineFilerModeInactive)
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineFilerModeInactive)
+    ]
+
+suite "statusline: addBufManagerModeInfo":
+  test "Active window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.bufManager)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addBufManagerModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      " BUFFER                                                                                         1/1 "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 7,
+        color: EditorColorPairIndex.statusLineModeNormalMode),
+      StatusLineColorSegment(
+        first: 8,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalMode)
+    ]
+
+  test "Inactive window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.bufManager)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = false
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addBufManagerModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      "                                                                                                1/1 "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalModeInactive)
+    ]
+
+suite "statusline: addLogViewerModeInfo":
+  test "Active window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.logViewer)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addLogViewerModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      " LOG                                                                                            1/1 "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 4,
+        color: EditorColorPairIndex.statusLineModeNormalMode),
+      StatusLineColorSegment(
+        first: 5,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalMode)
+    ]
+
+  test "Inactive window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.logViewer)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = false
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addLogViewerModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      "                                                                                                1/1 "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalModeInactive)
+    ]
+
+suite "statusline: addQuickRunModeInfo":
+  test "Active window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.quickRun)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addQuickRunModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      " QUICKRUN                                                                                       1/1 "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 9,
+        color: EditorColorPairIndex.statusLineModeNormalMode),
+      StatusLineColorSegment(
+        first: 10,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalMode)
+    ]
+
+  test "Inactive window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.quickRun)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = false
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addQuickRunModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      "                                                                                                1/1 "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalModeInactive)
+    ]
+
+suite "statusline: addNormalModeInfo":
+  test "Active window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addNormalModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      " NORMAL  No name                                                                1/1 1/0 UTF-8 Plain "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 7,
+        color: EditorColorPairIndex.statusLineModeNormalMode),
+      StatusLineColorSegment(
+        first: 8,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalMode)
+    ]
+
+  test "Active window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = false
+
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    status.statusLine[0].addNormalModeInfo(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      " No name                                                                        1/1 1/0 UTF-8 Plain "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalModeInactive)
     ]
 
 suite "statusline: gitBranchNameBuffer":
@@ -252,31 +664,417 @@ suite "statusline: gitBranchNameBuffer":
       WithGitChangedLine)
 
 suite "statusline: changedLinesBuffer":
-  test "Added line":
+  test "Added line With Git branch":
+    const WithGitBranch = true
     check ru" +1 ~0 -0" ==
       changedLinesBuffer(
-        @[Diff(operation: OperationType.added, firstLine: 0, lastLine: 0)])
+        @[Diff(operation: OperationType.added, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
 
-  test "Changed line":
+  test "Changed line With Git branch":
+    const WithGitBranch = true
     check ru" +0 ~1 -0" ==
       changedLinesBuffer(
-        @[Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0)])
+        @[Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
 
-  test "Deleted line":
+  test "Deleted line With Git branch":
+    const WithGitBranch = true
     check ru" +0 ~0 -1" ==
       changedLinesBuffer(
-        @[Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0)])
+        @[Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
 
-  test "Changed and deleted line":
+  test "Changed and deleted line With Git branch":
+    const WithGitBranch = true
     check ru" +0 ~1 -1" ==
       changedLinesBuffer(
-        @[Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)])
+        @[Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
 
-  test "Mixed":
+  test "Mixed With Git branch":
+    const WithGitBranch = true
     check ru" +1 ~2 -2" ==
-      changedLinesBuffer(@[
-        Diff(operation: OperationType.added, firstLine: 0, lastLine: 0),
-        Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0),
-        Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0),
-        Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)
-      ])
+      changedLinesBuffer(
+        @[
+          Diff(operation: OperationType.added, firstLine: 0, lastLine: 0),
+          Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0),
+          Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0),
+          Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)
+        ],
+        WithGitBranch)
+
+  test "Only Added line":
+    const WithGitBranch = false
+    check ru" +1 ~0 -0 " ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.added, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
+
+  test "Only Changed line":
+    const WithGitBranch = false
+    check ru" +0 ~1 -0 " ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
+
+  test "Only Deleted line":
+    const WithGitBranch = false
+    check ru" +0 ~0 -1 " ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
+
+  test "Only Changed and deleted line":
+    const WithGitBranch = false
+    check ru" +0 ~1 -1 " ==
+      changedLinesBuffer(
+        @[Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)],
+        WithGitBranch)
+
+  test "Only Mixed":
+    const WithGitBranch = false
+    check ru" +1 ~2 -2 " ==
+      changedLinesBuffer(
+        @[
+          Diff(operation: OperationType.added, firstLine: 0, lastLine: 0),
+          Diff(operation: OperationType.deleted, firstLine: 0, lastLine: 0),
+          Diff(operation: OperationType.changed, firstLine: 0, lastLine: 0),
+          Diff(operation: OperationType.changedAndDeleted, firstLine: 0, lastLine: 0)
+        ],
+        WithGitBranch)
+
+suite "statusline: addGitInfo":
+  test "Only Changed lines":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.settings.statusLine.gitChangedLines = true
+    status.settings.statusLine.gitBranchName = false
+
+    currentBufStatus.changedLines = @[
+      Diff(operation: OperationType.added, firstLine: 0, lastLine: 0)
+    ]
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+    status.statusLine[0].addGitInfo(
+      currentBufStatus,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer == ru" +1 ~0 -0 "
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 9,
+        color: EditorColorPairIndex.statusLineGitChangedLines)
+    ]
+
+  test "Only Git branch":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.settings.statusLine.gitBranchName = true
+    status.settings.statusLine.gitChangedLines = false
+
+    currentBufStatus.changedLines = @[
+      Diff(operation: OperationType.added, firstLine: 0, lastLine: 0)
+    ]
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+    status.statusLine[0].addGitInfo(
+      currentBufStatus,
+      IsActiveWindow,
+      status.settings)
+
+    let branchName = getCurrentGitBranchName().get
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer == fmt"  {branchName} ".toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 31,
+        color: EditorColorPairIndex.statusLineGitBranch)
+    ]
+
+  test "Git branch and Changed lines":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.settings.statusLine.gitBranchName = true
+    status.settings.statusLine.gitChangedLines = true
+
+    currentBufStatus.changedLines = @[
+      Diff(operation: OperationType.added, firstLine: 0, lastLine: 0)
+    ]
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+    status.statusLine[0].addGitInfo(
+      currentBufStatus,
+      IsActiveWindow,
+      status.settings)
+
+    let branchName = getCurrentGitBranchName().get
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer == fmt" +1 ~0 -0  {branchName} ".toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 8,
+        color: EditorColorPairIndex.statusLineGitChangedLines),
+      StatusLineColorSegment(
+        first: 9,
+        last: 40,
+        color: EditorColorPairIndex.statusLineGitBranch)
+    ]
+
+suite "statusline: modeLabel":
+  test "Insert mode":
+    check modeLablel(Mode.insert) == "INSERT"
+
+  test "Visual mode":
+    check modeLablel(Mode.visual) == "VISUAL"
+
+  test "Visual block mode":
+    check modeLablel(Mode.visualBlock) == "VISUAL BLOCK"
+
+  test "Visual line mode":
+    check modeLablel(Mode.visualLine) == "VISUAL LINE"
+
+  test "Replace mode":
+    check modeLablel(Mode.replace) == "REPLACE"
+
+  test "Filer mode":
+    check modeLablel(Mode.filer) == "FILER"
+
+  test "Buffer Manager mode":
+    check modeLablel(Mode.bufManager) == "BUFFER"
+
+  test "Ex mode":
+    check modeLablel(Mode.ex) == "EX"
+
+  test "Log viewer mode":
+    check modeLablel(Mode.logViewer) == "LOG"
+
+  test "Recent file mode":
+    check modeLablel(Mode.recentFile) == "RECENT"
+
+  test "QuickRun mode":
+    check modeLablel(Mode.quickRun) == "QUICKRUN"
+
+  test "Backup mode":
+    check modeLablel(Mode.backup) == "BACKUP"
+
+  test "Diff mode":
+    check modeLablel(Mode.diff) == "DIFF"
+
+  test "Config mode":
+    check modeLablel(Mode.config) == "CONFIG"
+
+  test "Debug mode":
+    check modeLablel(Mode.debug) == "DEBUG"
+
+suite "statusline: modeLablelColor":
+  test "Insert mode":
+    check modeLablelColor(Mode.insert) ==
+      EditorColorPairIndex.statusLineModeInsertMode
+
+  test "Viausl mode":
+    check modeLablelColor(Mode.visual) ==
+      EditorColorPairIndex.statusLineModeVisualMode
+
+  test "Viausl block mode":
+    check modeLablelColor(Mode.visualBlock) ==
+      EditorColorPairIndex.statusLineModeVisualMode
+
+  test "Viausl line mode":
+    check modeLablelColor(Mode.visualLine) ==
+      EditorColorPairIndex.statusLineModeVisualMode
+
+  test "Replace mode":
+    check modeLablelColor(Mode.replace) ==
+      EditorColorPairIndex.statusLineModeReplaceMode
+
+  test "Filer mode":
+    check modeLablelColor(Mode.filer) ==
+      EditorColorPairIndex.statusLineModeFilerMode
+
+  test "Ex mode":
+    check modeLablelColor(Mode.ex) ==
+      EditorColorPairIndex.statusLineModeExMode
+
+  test "Normal mode":
+    check modeLablelColor(Mode.normal) ==
+      EditorColorPairIndex.statusLineModeNormalMode
+
+suite "statusline: addModeLabel":
+  test "Normal mode in active window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer == ru" NORMAL "
+
+  test "Normal mode in inactive window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = false
+    status.statusLine[0].addModeLabel(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings.statusLine)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer == ru""
+
+suite "statusline: clear":
+  test "Clear":
+    var s = initStatusLine()
+
+    privateAccess(s.type)
+    s.buffer = ru"test"
+
+    privateAccess(s.highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    s.highlight.segments = @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 4,
+        color: EditorColorPairIndex.statusLineModeNormalMode)
+    ]
+
+    s.clear
+
+    check s.buffer.len == 0
+    check s.highlight.segments.len == 0
+
+suite "statusline: updateStatusLineBuffer":
+  test "Normal mode in active window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = true
+    status.statusLine[0].updateStatusLineBuffer(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    let branchName = getCurrentGitBranchName().get
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      fmt" NORMAL   {branchName}  No name                                1/1 1/0 UTF-8 Plain "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 7,
+        color: EditorColorPairIndex.statusLineModeNormalMode),
+      StatusLineColorSegment(
+        first: 8,
+        last: 39,
+        color: EditorColorPairIndex.statusLineGitBranch),
+      StatusLineColorSegment(
+        first: 40,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalMode)
+    ]
+
+  test "Normal mode in inactive window":
+    var status = initEditorStatus()
+
+    const Path = ""
+    status.addNewBufferInCurrentWin(Path, Mode.normal)
+
+    status.resize(100, 100)
+    status.update
+
+    status.statusLine[0].clear
+
+    const IsActiveWindow = false
+    status.statusLine[0].updateStatusLineBuffer(
+      currentBufStatus,
+      currentMainWindowNode,
+      IsActiveWindow,
+      status.settings)
+
+    privateAccess(status.statusLine[0].type)
+    check status.statusLine[0].buffer ==
+      " No name                                                                        1/1 1/0 UTF-8 Plain "
+      .toRunes
+
+    privateAccess(status.statusLine[0].highlight.type)
+    privateAccess(StatusLineColorSegment.type)
+    check status.statusLine[0].highlight.segments == @[
+      StatusLineColorSegment(
+        first: 0,
+        last: 99,
+        color: EditorColorPairIndex.statusLineNormalModeInactive)
+    ]


### PR DESCRIPTION
The information displayed to the right of the status line is fully customizable.

- Add `StatusLine.setupText` setting. the default setting is `"{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {fileType}"`
- Remove settings: `StatusLine.line`, `StatusLine. column`, `StatusLine.encoding`, `StatusLine.language`.
- Cleanup `statusline.nim`

## TODO
- [x] Add tests
- [x] Update docs

Close #892 