### PR TITLE
ci: Disable the Choosenim cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -72,18 +72,6 @@ jobs:
     - run: |
         sudo apt-get update -yqq
         sudo apt-get install -y gcc libncursesw5-dev build-essential xvfb x11-xserver-utils xsel xclip
-    - name: Cache choosenim
-      id: cache-choosenim
-      uses: actions/cache@v3.3.1
-      with:
-        path: ~/.choosenim
-        key: ${{ runner.os }}-choosenim-${{ env.NIM_VERSION }}
-    - name: Cache nimble
-      id: cache-nimble
-      uses: actions/cache@v3.3.1
-      with:
-        path: ~/.nimble
-        key: ${{ runner.os }}-nimble-${{ env.NIM_VERSION }}
     - uses: jiro4989/setup-nim-action@v1.4.8
       with:
         nim-version: ${{ env.NIM_VERSION }}

--- a/changelog.d/20230811_162701_GitHub_Actions_disable-choosenim-cache.rst
+++ b/changelog.d/20230811_162701_GitHub_Actions_disable-choosenim-cache.rst
@@ -1,0 +1,2 @@
+.. _#1802:  https://github.com/fox0430/moe/pull/1802
+

--- a/changelog.d/20230811_162701_GitHub_Actions_disable-choosenim-cache.rst
+++ b/changelog.d/20230811_162701_GitHub_Actions_disable-choosenim-cache.rst
@@ -1,2 +1,6 @@
 .. _#1802:  https://github.com/fox0430/moe/pull/1802
 
+Changed
+.....
+
+- `#1802`: ci: Disable the Choosenim cache


### PR DESCRIPTION
Disable the cache for the Choosenim in CI because the latest stable version may not be used.