### PR TITLE
Remove "Q" command for QuickRun in Ex mode

### DIFF
--- a/changelog.d/20230821_190830_GitHub_Actions_fix-quickrun-command.rst
+++ b/changelog.d/20230821_190830_GitHub_Actions_fix-quickrun-command.rst
@@ -1,0 +1,7 @@
+.. _#1811:  https://github.com/fox0430/moe/pull/1811
+
+Fixed
+.....
+
+- `#1811`_ Remove "Q" command for QuickRun in Ex mode
+

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -231,7 +231,7 @@
 
 ```putConfigFile``` - Put a sample configuration file in ~/.config/moe
 
-```run``` or ```Q``` - Quick run
+```run``` - Quick run
 
 ```recent``` - Open recent file selection mode (Only supported on Linux)  
 

--- a/src/moepkg/exmodeutils.nim
+++ b/src/moepkg/exmodeutils.nim
@@ -697,8 +697,7 @@ proc isNewEmptyBufferInSplitWindowVerticallyCommand*(
     command.len == 1 and cmpIgnoreCase($command[0], "vnew") == 0
 
 proc isQuickRunCommand*(command: seq[Runes]): bool {.inline.} =
-  command.len == 1 and
-  (cmpIgnoreCase($command[0], "run") == 0 or command[0] == ru"Q")
+  command.len == 1 and cmpIgnoreCase($command[0], "run") == 0
 
 proc isRecentFileModeCommand*(command: seq[Runes]): bool {.inline.} =
   command.len == 1 and cmpIgnoreCase($command[0], "recent") == 0

--- a/src/moepkg/helputils.nim
+++ b/src/moepkg/helputils.nim
@@ -266,7 +266,7 @@ help - Open this help
 
 putConfigFile - Put a sample configuration file in ~/.config/moe
 
-run or Q - Quick run
+run - Quick run
 
 recent - Open recent file selection mode (Only supported on Linux)
 


### PR DESCRIPTION
Remove `Q` command for QuickRun because conflicts with the editor exit command.
