### PR TITLE
ci: Fix abduco installation

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -82,8 +82,8 @@ jobs:
         sudo sh -c "$(curl -L https://raw.githubusercontent.com/rylnd/shpec/master/install.sh)"
         # abduco
         wget https://github.com/martanne/abduco/releases/download/v0.6/abduco-0.6.tar.gz
-        tar -zcvf abduco-0.6.tar.gz.tar.gz abduco
-        cd abduco
+        tar -zxvf abduco-0.6.tar.gz
+        cd abduco-0.6
         make && sudo make install
 
     - name: Run unit test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -81,8 +81,10 @@ jobs:
         # shpec
         sudo sh -c "$(curl -L https://raw.githubusercontent.com/rylnd/shpec/master/install.sh)"
         # abduco
-        wget http://mirrors.kernel.org/ubuntu/pool/universe/a/abduco/abduco_0.1-2_amd64.deb
-        sudo dpkg -i abduco_0.1-2_amd64.deb
+        wget https://github.com/martanne/abduco/releases/download/v0.6/abduco-0.6.tar.gz
+        tar -zcvf abduco-0.6.tar.gz.tar.gz abduco
+        cd abduco
+        make && sudo make install
 
     - name: Run unit test
       run: |

--- a/changelog.d/20230822_160616_GitHub_Actions_fix-abduco-installation.rst
+++ b/changelog.d/20230822_160616_GitHub_Actions_fix-abduco-installation.rst
@@ -1,0 +1,7 @@
+.. _#1814:  https://github.com/fox0430/moe/pull/1814
+
+Fixed
+.....
+
+- `#1814`_ ci: Fix abduco installation
+


### PR DESCRIPTION
Fix the abduco installation in CI because the Ubuntu package was removed.