### PR TITLE
Enhance performance for plain text syntax highlighting

### DIFF
--- a/changelog.d/20230910_163316_GitHub_Actions_plain-highlighting-performance.rst
+++ b/changelog.d/20230910_163316_GitHub_Actions_plain-highlighting-performance.rst
@@ -1,0 +1,7 @@
+.. _#1843:  https://github.com/fox0430/moe/pull/1843
+
+Changed
+.......
+
+- `1843`_ Enhanced performance for plain text syntax highlighting
+

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -306,7 +306,7 @@ proc syntaxSettingCommand(status: var EditorStatus, command: Runes) =
                    else: SourceLanguage.langNone
 
   currentMainWindowNode.highlight = initHighlight(
-    $currentBufStatus.buffer,
+    currentBufStatus.buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     sourceLang)
 

--- a/tests/teditorstatus.nim
+++ b/tests/teditorstatus.nim
@@ -113,7 +113,7 @@ test "resize 1":
   currentBufStatus.buffer = initGapBuffer(@[ru"a"])
 
   currentMainWindowNode.highlight =
-    initHighlight($currentBufStatus.buffer,
+    initHighlight(currentBufStatus.buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     currentBufStatus.language)
 
@@ -129,7 +129,7 @@ test "resize 2":
   currentBufStatus.buffer = initGapBuffer(@[ru"a"])
 
   currentMainWindowNode.highlight =
-    initHighlight($currentBufStatus.buffer,
+    initHighlight(currentBufStatus.buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     currentBufStatus.language)
 

--- a/tests/thighlight.nim
+++ b/tests/thighlight.nim
@@ -17,8 +17,8 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[unittest, strutils, sequtils]
-import moepkg/color
+import std/[unittest, sequtils]
+import moepkg/[color, unicodeext]
 import moepkg/syntax/highlite
 
 import moepkg/highlight {.all.}
@@ -28,33 +28,35 @@ suite "highlight: initHighlight":
     ReservedWord(word: "WIP", color: EditorColorPairIndex.reservedWord)
   ]
 
-  test "Start with newline":
-    let
-      code = "\x0Aproc test =\x0A  echo \"Hello, world!\""
-      buffer = split(code, '\n')
-      highlight = initHighlight(
-        code,
-        ReservedWords,
-        SourceLanguage.langNim)
-
-    # unite segments
-    var unitedStr: string
-    for i in 0 ..< highlight.len:
-      let segment = highlight[i]
-      if i > 0 and segment.firstRow != highlight[i-1].lastRow: unitedStr &= "\n"
-      let
-        firstRow = segment.firstRow
-        firstColumn = segment.firstColumn
-        lastColumn = segment.lastColumn
-      unitedStr &= buffer[firstRow][firstColumn .. lastColumn]
-
-    check(unitedStr == code)
+  test "langNone":
+    const Buffer = @["", "1", "123"].toSeqRunes
+    let h = initHighlight(Buffer, ReservedWords, SourceLanguage.langNone)
+    check h.colorSegments == @[
+      ColorSegment(
+        firstRow: 0,
+        firstColumn: 0,
+        lastRow: 0,
+        lastColumn: -1,
+        color: EditorColorPairIndex.default),
+      ColorSegment(
+        firstRow: 0,
+        firstColumn: 0,
+        lastRow: 0,
+        lastColumn: 0,
+        color: EditorColorPairIndex.default),
+      ColorSegment(
+        firstRow: 0,
+        firstColumn: 0,
+        lastRow: 0,
+        lastColumn: 2,
+        color: EditorColorPairIndex.default)]
 
   test """Highlight "echo \"""":
     # Fix #733
     const Code = """echo "\""""
+    let buffer = @[Code].toSeqRunes
     discard initHighlight(
-      Code,
+      buffer,
       ReservedWords,
       SourceLanguage.langNim)
 
@@ -64,10 +66,12 @@ suite "highlight: initHighlight":
     const
       Code = "/"
       EmptyReservedWords = @[]
-    let highlight = initHighlight(
-      Code,
-      EmptyReservedWords,
-      SourceLanguage.langC)
+    let
+      buffer = @[Code].toSeqRunes
+      highlight = initHighlight(
+        buffer,
+        EmptyReservedWords,
+        SourceLanguage.langC)
 
     check highlight[] == Highlight(
       colorSegments: @[
@@ -80,19 +84,23 @@ suite "highlight: initHighlight":
 
   test "initHighlight shell script (Fix #1166)":
     const Code = "echo hello"
-    let r = initHighlight(
-      Code,
-      ReservedWords,
-      SourceLanguage.langShell)
+    let
+      buffer = @[Code].toSeqRunes
+      highlight = initHighlight(
+        buffer,
+        ReservedWords,
+        SourceLanguage.langShell)
 
-    check r.len > 0
+    check highlight.len > 0
 
   test "Nim pragma":
     const Code = """{.pragma.}""""
-    let highlight = initHighlight(
-      Code,
-      ReservedWords,
-      SourceLanguage.langNim)
+    let
+      buffer = @[Code].toSeqRunes
+      highlight = initHighlight(
+        buffer,
+        ReservedWords,
+        SourceLanguage.langNim)
 
     check highlight[2] == ColorSegment(
       firstRow: 0,
@@ -105,10 +113,12 @@ suite "highlight: initHighlight":
     # https://github.com/fox0430/moe/issues/1524
 
     const Code = "test: '0'"
-    let highlight = initHighlight(
-      Code,
-      ReservedWords,
-      SourceLanguage.langYaml)
+    let
+      buffer = @[Code].toSeqRunes
+      highlight = initHighlight(
+        buffer,
+        ReservedWords,
+        SourceLanguage.langYaml)
 
     check highlight[] == Highlight(
       colorSegments: @[
@@ -143,20 +153,22 @@ suite "highlight: indexOf":
   ]
 
   test "Basic":
+    const Code = "proc test =\x0A  echo \"Hello, world!\""
     let
-      code = "proc test =\x0A  echo \"Hello, world!\""
+      buffer = @[Code].toSeqRunes
       highlight = initHighlight(
-        code,
+       buffer,
        ReservedWords,
        SourceLanguage.langNim)
 
     check(highlight.indexOf(0, 0) == 0)
 
   test "Start with newline":
+    const Code = "\x0Aproc test =\x0A  echo \"Hello, world!\""
     let
-      code = "\x0Aproc test =\x0A  echo \"Hello, world!\""
+      buffer = @[Code].toSeqRunes
       highlight = initHighlight(
-        code,
+       buffer,
        ReservedWords,
        SourceLanguage.langNim)
 
@@ -168,11 +180,14 @@ suite "highlight: overwrite":
   ]
 
   test "Basic":
-    let code = "　"
-    var highlight = initHighlight(
-      code,
-     ReservedWords,
-     SourceLanguage.langNone)
+    # Full width space
+    const Code = "　"
+    let buffer = @[Code].toSeqRunes
+    var
+      highlight = initHighlight(
+        buffer,
+        ReservedWords,
+        SourceLanguage.langNone)
 
     let colorSegment = ColorSegment(
       firstRow: 0,

--- a/tests/thighlight.nim
+++ b/tests/thighlight.nim
@@ -31,6 +31,7 @@ suite "highlight: initHighlight":
   test "langNone":
     const Buffer = @["", "1", "123"].toSeqRunes
     let h = initHighlight(Buffer, ReservedWords, SourceLanguage.langNone)
+    echo h.colorSegments
     check h.colorSegments == @[
       ColorSegment(
         firstRow: 0,
@@ -39,15 +40,15 @@ suite "highlight: initHighlight":
         lastColumn: -1,
         color: EditorColorPairIndex.default),
       ColorSegment(
-        firstRow: 0,
+        firstRow: 1,
         firstColumn: 0,
-        lastRow: 0,
+        lastRow: 1,
         lastColumn: 0,
         color: EditorColorPairIndex.default),
       ColorSegment(
-        firstRow: 0,
+        firstRow: 2,
         firstColumn: 0,
-        lastRow: 0,
+        lastRow: 2,
         lastColumn: 2,
         color: EditorColorPairIndex.default)]
 

--- a/tests/tinsertmode.nim
+++ b/tests/tinsertmode.nim
@@ -34,7 +34,7 @@ suite "Insert mode":
     status.bufStatus[0].buffer = initGapBuffer(@[ru""])
 
     currentMainWindowNode.highlight = initHighlight(
-      $status.bufStatus[0].buffer,
+      status.bufStatus[0].buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       status.bufStatus[0].language)
 

--- a/tests/tmovement.nim
+++ b/tests/tmovement.nim
@@ -31,7 +31,7 @@ test "Move right":
   status.bufStatus[0].buffer = initGapBuffer(@[ru"abc"])
 
   currentMainWindowNode.highlight = initHighlight(
-    $status.bufStatus[0].buffer,
+    status.bufStatus[0].buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     status.bufStatus[0].language)
 
@@ -46,7 +46,7 @@ test "Move left":
   status.bufStatus[0].buffer = initGapBuffer(@[ru"abc"])
 
   currentMainWindowNode.highlight = initHighlight(
-    $status.bufStatus[0].buffer,
+    status.bufStatus[0].buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     status.bufStatus[0].language)
 
@@ -62,7 +62,7 @@ test "Move down":
   status.bufStatus[0].buffer = initGapBuffer(@[ru"abc", ru"efg", ru"hij"])
 
   currentMainWindowNode.highlight = initHighlight(
-    $status.bufStatus[0].buffer,
+    status.bufStatus[0].buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     status.bufStatus[0].language)
 
@@ -77,7 +77,7 @@ test "Move up":
   status.bufStatus[0].buffer = initGapBuffer(@[ru"abc", ru"efg", ru"hij"])
 
   currentMainWindowNode.highlight = initHighlight(
-    $status.bufStatus[0].buffer,
+    status.bufStatus[0].buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     status.bufStatus[0].language)
 

--- a/tests/tviewhighlight.nim
+++ b/tests/tviewhighlight.nim
@@ -28,7 +28,7 @@ import moepkg/viewhighlight {.all.}
 
 proc initHighlight(status: EditorStatus) {.inline.} =
   currentMainWindowNode.highlight = initHighlight(
-    $currentBufStatus.buffer,
+    currentBufStatus.buffer.toSeqRunes,
     status.settings.highlight.reservedWords,
     currentBufStatus.language)
 
@@ -212,7 +212,7 @@ suite "Highlight trailing spaces":
     status.settings.highlight.currentWord = false
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -820,7 +820,7 @@ echo "test"
 
     var bufStatus = initBufferStatus("").get
     bufStatus.buffer = Buffer.toGapBuffer
-    var h = initHighlight($bufStatus.buffer, @[], SourceLanguage.langNim)
+    var h = initHighlight(bufStatus.buffer.toSeqRunes, @[], SourceLanguage.langNim)
 
     h.highlightGitConflicts(bufStatus, Range)
 
@@ -954,7 +954,7 @@ echo "test"
     for line in Code:
       bufStatus.buffer.add line.toRunes
 
-    var h = initHighlight($bufStatus.buffer, @[], SourceLanguage.langNim)
+    var h = initHighlight(bufStatus.buffer.toSeqRunes, @[], SourceLanguage.langNim)
 
     h.highlightGitConflicts(bufStatus, Range)
 

--- a/tests/tvisualmode.nim
+++ b/tests/tvisualmode.nim
@@ -40,7 +40,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"abcd"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -63,7 +63,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"a", ru"b", ru"c"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -87,7 +87,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"ab", ru"cdef"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -113,7 +113,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"defg"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -148,7 +148,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -180,7 +180,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -206,7 +206,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"a", ru"", ru"a"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -235,7 +235,7 @@ suite "Visual mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"a b c"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -264,7 +264,7 @@ suite "Visual mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -299,7 +299,7 @@ suite "Visual mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -333,7 +333,7 @@ suite "Visual mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -361,7 +361,7 @@ suite "Visual mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru""])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -389,7 +389,7 @@ suite "Visual mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"", ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -416,7 +416,7 @@ suite "Visual block mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -448,7 +448,7 @@ suite "Visual block mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"d"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -484,7 +484,7 @@ suite "Visual block mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"d"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -512,7 +512,7 @@ suite "Visual block mode: Delete buffer (Disable clipboard)":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -547,7 +547,7 @@ if isXselAvailable():
       currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -591,7 +591,7 @@ if isXselAvailable():
       currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -643,7 +643,7 @@ if isXselAvailable():
       currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -678,7 +678,7 @@ if isXselAvailable():
       currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"d"])
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -718,7 +718,7 @@ if isXselAvailable():
       currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -752,7 +752,7 @@ if isXselAvailable():
       currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"", ru"edf"])
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -783,7 +783,7 @@ if isXselAvailable():
       currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"de", ru"fgh"])
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -820,7 +820,7 @@ suite "Visual mode: Join lines":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -851,7 +851,7 @@ suite "Visual block mode: Join lines":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -882,7 +882,7 @@ test "Visual mode: Add indent":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -912,7 +912,7 @@ suite "Visual block mode: Add indent":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -942,7 +942,7 @@ suite "Visual mode: Delete indent":
     currentBufStatus.buffer = initGapBuffer(@[ru"  abc", ru"  def", ru"  ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -972,7 +972,7 @@ suite "Visual block mode: Delete indent":
     currentBufStatus.buffer = initGapBuffer(@[ru"  abc", ru"  def", ru"  ghi"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1002,7 +1002,7 @@ suite "Visual mode: Converts string into lower-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"ABC"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1028,7 +1028,7 @@ suite "Visual mode: Converts string into lower-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"AあbC"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1054,7 +1054,7 @@ suite "Visual mode: Converts string into lower-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"ABC", ru"DEF"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1078,7 +1078,8 @@ suite "Visual mode: Converts string into lower-case string":
     var status = initEditorStatus()
     status.addNewBufferInCurrentWin
     currentBufStatus.buffer = initGapBuffer(@[ru"ABC", ru"", ru"DEF", ru""])
-    currentMainWindowNode.highlight = initHighlight($currentBufStatus.buffer,
+    currentMainWindowNode.highlight = initHighlight(
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1106,7 +1107,7 @@ test "Visual block mode: Converts string into lower-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"ABC"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1131,7 +1132,7 @@ test "Visual block mode: Converts string into lower-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"ABC", ru"DEF"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1161,7 +1162,7 @@ suite "Visual mode: Converts string into upper-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1187,7 +1188,7 @@ suite "Visual mode: Converts string into upper-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"aあBc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1213,7 +1214,7 @@ suite "Visual mode: Converts string into upper-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1237,7 +1238,7 @@ suite "Visual mode: Converts string into upper-case string":
     status.addNewBufferInCurrentWin
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"", ru"def", ru""])
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1264,7 +1265,7 @@ suite "Visual mode: Movement":
     status.addNewBufferInCurrentWin
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1287,7 +1288,7 @@ suite "Visual block mode: Converts string into upper-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1313,7 +1314,7 @@ suite "Visual block mode: Converts string into upper-case string":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1342,7 +1343,7 @@ suite "Visual block mode: Insert buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1433,7 +1434,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1459,7 +1460,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1485,7 +1486,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1511,7 +1512,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru "def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1542,7 +1543,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1568,7 +1569,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1594,7 +1595,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1623,7 +1624,7 @@ suite "Visual mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1689,7 +1690,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1715,7 +1716,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1740,7 +1741,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1766,7 +1767,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1792,7 +1793,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru "def"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1823,7 +1824,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1849,7 +1850,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1875,7 +1876,7 @@ suite "Visual block mode: Run command when Readonly mode":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1903,7 +1904,7 @@ suite "Visual block mode: Movement":
     status.addNewBufferInCurrentWin
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1928,7 +1929,7 @@ suite "Visual line mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"a", ru"b", ru"c", ru"d"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1951,7 +1952,7 @@ suite "Visual line mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"a", ru"b", ru"c", ru"d"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1976,7 +1977,7 @@ suite "Visual line mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"a", ru"b", ru"c", ru"d"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -1999,7 +2000,7 @@ suite "Visual line mode: Delete buffer":
     currentBufStatus.buffer = initGapBuffer(@[ru"a", ru"b", ru"c", ru"d"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -2024,7 +2025,7 @@ suite "Visual line mode: Yank buffer (Disable clipboard)":
     currentBufStatus.buffer = buffer.toGapBuffer
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -2057,7 +2058,7 @@ if isXselAvailable():
       currentBufStatus.buffer = buffer.toGapBuffer
 
       currentMainWindowNode.highlight = initHighlight(
-        $currentBufStatus.buffer,
+        currentBufStatus.buffer.toSeqRunes,
         status.settings.highlight.reservedWords,
         currentBufStatus.language)
 
@@ -2093,7 +2094,7 @@ suite "Visual line mode: idenet":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 
@@ -2119,7 +2120,7 @@ suite "Visual line mode: idenet":
     currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
 
     currentMainWindowNode.highlight = initHighlight(
-      $currentBufStatus.buffer,
+      currentBufStatus.buffer.toSeqRunes,
       status.settings.highlight.reservedWords,
       currentBufStatus.language)
 


### PR DESCRIPTION
 Enhance performance for plain text syntax highlighting parsing speed when opening a 1GB and 13944700 lines plain file has become about 10x faster.

```
base64 /dev/urandom | head -c 1073741824  > file.txt
moe file.txt
```

| Before | After |
| --- | --- |
| 10 seconds, 879 milliseconds | 1 second, 672 milliseconds |