### PR TITLE
Change behaviors of moving to blank line

### DIFF
--- a/changelog.d/20230925_220054_GitHub_Actions_fix-move-behavior.rst
+++ b/changelog.d/20230925_220054_GitHub_Actions_fix-move-behavior.rst
@@ -3,5 +3,5 @@
 Changed
 .......
 
-- `#1861`_ Change behaviors of moving to a blank line
+- `#1862`_ Change behaviors of moving to a blank line
 

--- a/changelog.d/20230925_220054_GitHub_Actions_fix-move-behavior.rst
+++ b/changelog.d/20230925_220054_GitHub_Actions_fix-move-behavior.rst
@@ -1,0 +1,7 @@
+.. _#1862:  https://github.com/fox0430/moe/pull/1862
+
+Changed
+.......
+
+- `#1861`_ Change behaviors of moving to a blank line
+

--- a/src/moepkg/movement.nim
+++ b/src/moepkg/movement.nim
@@ -67,17 +67,23 @@ proc keyDown*(bufStatus: var BufferStatus, windowNode: var WindowNode) =
 proc getFirstNonBlankOfLine*(
   bufStatus: BufferStatus,
   windowNode: WindowNode): int =
+    ## Return a position of a first non blank column in the currentLine line.
+    ## Return 0 if it empty line.
+    ## Return -1 if it all spaces.
 
     if currentLineLen == 0: return 0
 
     let lineLen = currentLineLen
     while bufStatus.buffer[windowNode.currentLine][result] == ru' ':
-      inc(result)
+      result.inc
       if result == lineLen: return -1
 
 proc getFirstNonBlankOfLineOrLastColumn*(
   bufStatus: BufferStatus,
   windowNode: WindowNode): int =
+    ## Return a position of a first non blank column in the currentLine line.
+    ## Return 0 if it empty line.
+    ## Return the last index of the line if it all spaces.
 
     result = bufStatus.getFirstNonBlankOfLine(windowNode)
     if result == -1:
@@ -86,18 +92,26 @@ proc getFirstNonBlankOfLineOrLastColumn*(
 proc getFirstNonBlankOfLineOrFirstColumn*(
   bufStatus  : BufferStatus,
   windowNode : WindowNode): int =
+    ## Return a position of a first non blank column in the currentLine line.
+    ## Return 0 if it empty line.
+    ## Return the first index of the line if it all spaces.
 
     result = bufStatus.getFirstNonBlankOfLine(windowNode)
     if result == -1: return 0
 
 proc getLastNonBlankOfLine*(
   bufStatus: BufferStatus,
-  windowNode: WindowNode): Natural =
+  windowNode: WindowNode): int =
+    ## Return a position of a last non blank column in the currentLine line.
+    ## Return 0 if it empty line.
+    ## Return -1 if there are no spaces in the line.
 
     if currentLineLen == 0: return 0
 
     result = currentLineLen - 1
-    while bufStatus.buffer[windowNode.currentLine][result] == ru' ': dec(result)
+    while bufStatus.buffer[windowNode.currentLine][result] == ru' ':
+      result.dec
+      if result == -1: return -1
 
 proc moveToFirstNonBlankOfLine*(
   bufStatus: var BufferStatus,
@@ -174,6 +188,9 @@ proc jumpLine*(
       windowNode.view.reload(bufStatus.buffer, startOfPrintedLines)
 
 proc findNextBlankLine*(bufStatus: BufferStatus, currentLine: int): int =
+  ## Return a next blank line number.
+  ## Return the last line number if there are no blank lines.
+
   result = -1
 
   if currentLine < bufStatus.buffer.len - 1:
@@ -185,9 +202,12 @@ proc findNextBlankLine*(bufStatus: BufferStatus, currentLine: int): int =
       elif currentLineStartedBlank:
         currentLineStartedBlank = false
 
-  return -1
+    return bufStatus.buffer.high
 
 proc findPreviousBlankLine*(bufStatus: BufferStatus, currentLine: int): int =
+  ## Return a previous blank line number.
+  ## Return the first line number if there are no blank lines.
+
   result = -1
 
   if currentLine > 0:
@@ -199,20 +219,29 @@ proc findPreviousBlankLine*(bufStatus: BufferStatus, currentLine: int): int =
       elif currentLineStartedBlank:
         currentLineStartedBlank = false
 
-  return -1
+    return 0
 
 proc moveToNextBlankLine*(bufStatus: BufferStatus, windowNode: var WindowNode) =
+  ## Move to the last column in the next blank line.
+  ## If there is no blank line, move to the last line.
+
   let nextBlankLine = bufStatus.findNextBlankLine(windowNode.currentLine)
-  if nextBlankLine >= 0: bufStatus.jumpLine(windowNode, nextBlankLine)
+  if nextBlankLine >= 0:
+    bufStatus.jumpLine(windowNode, nextBlankLine)
+    windowNode.currentColumn = max(
+      bufStatus.buffer[windowNode.currentLine].high,
+      0)
 
 proc moveToPreviousBlankLine*(
   bufStatus: BufferStatus,
   windowNode: var WindowNode) =
+    ## Move to the first column in the prev blank line.
+    ## If there is no blank line, move to the first line.
 
-    let
-      currentLine = windowNode.currentLine
-      previousBlankLine = bufStatus.findPreviousBlankLine(currentLine)
-    if previousBlankLine >= 0: bufStatus.jumpLine(windowNode, previousBlankLine)
+    let previousBlankLine = bufStatus.findPreviousBlankLine(windowNode.currentLine)
+    if previousBlankLine >= 0:
+      bufStatus.jumpLine(windowNode, previousBlankLine)
+      windowNode.currentColumn = 0
 
 proc moveToFirstLine*(
   bufStatus: BufferStatus,

--- a/src/moepkg/movement.nim
+++ b/src/moepkg/movement.nim
@@ -226,11 +226,11 @@ proc moveToNextBlankLine*(bufStatus: BufferStatus, windowNode: var WindowNode) =
   ## If there is no blank line, move to the last line.
 
   let nextBlankLine = bufStatus.findNextBlankLine(windowNode.currentLine)
-  if nextBlankLine >= 0:
-    bufStatus.jumpLine(windowNode, nextBlankLine)
-    windowNode.currentColumn = max(
-      bufStatus.buffer[windowNode.currentLine].high,
-      0)
+  if nextBlankLine >= 0: bufStatus.jumpLine(windowNode, nextBlankLine)
+
+  windowNode.currentColumn = max(
+    bufStatus.buffer[windowNode.currentLine].high,
+    0)
 
 proc moveToPreviousBlankLine*(
   bufStatus: BufferStatus,
@@ -239,9 +239,9 @@ proc moveToPreviousBlankLine*(
     ## If there is no blank line, move to the first line.
 
     let previousBlankLine = bufStatus.findPreviousBlankLine(windowNode.currentLine)
-    if previousBlankLine >= 0:
-      bufStatus.jumpLine(windowNode, previousBlankLine)
-      windowNode.currentColumn = 0
+    if previousBlankLine >= 0: bufStatus.jumpLine(windowNode, previousBlankLine)
+
+    windowNode.currentColumn = 0
 
 proc moveToFirstLine*(
   bufStatus: BufferStatus,

--- a/tests/tmovement.nim
+++ b/tests/tmovement.nim
@@ -215,6 +215,17 @@ test "Move to previous blank line":
   check currentMainWindowNode.currentLine == 1
   check currentMainWindowNode.currentColumn == 0
 
+test "Move to previous blank line 2":
+  var status = initEditorStatus()
+  status.addNewBufferInCurrentWin
+  currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"def", ru"", ru"ghi"])
+  currentMainWindowNode.currentLine = 2
+
+  currentBufStatus.moveToPreviousBlankLine(currentMainWindowNode)
+
+  check currentMainWindowNode.currentLine == 0
+  check currentMainWindowNode.currentColumn == 0
+
 test "Move to next blank line":
   var status = initEditorStatus()
   status.addNewBufferInCurrentWin
@@ -224,6 +235,17 @@ test "Move to next blank line":
 
   check currentMainWindowNode.currentLine == 2
   check currentMainWindowNode.currentColumn == 0
+
+test "Move to next blank line 2":
+  var status = initEditorStatus()
+  status.addNewBufferInCurrentWin
+  currentBufStatus.buffer = initGapBuffer(@[ru"abc", ru"", ru"def", ru"ghi"])
+  currentMainWindowNode.currentLine = 1
+
+  currentBufStatus.moveToNextBlankLine(currentMainWindowNode)
+
+  check currentMainWindowNode.currentLine == 3
+  check currentMainWindowNode.currentColumn == 2
 
 test "Move to the top line of the screen":
   var status = initEditorStatus()

--- a/tests/tmovement.nim
+++ b/tests/tmovement.nim
@@ -226,6 +226,17 @@ test "Move to previous blank line 2":
   check currentMainWindowNode.currentLine == 0
   check currentMainWindowNode.currentColumn == 0
 
+test "Move to previous blank line 3":
+  var status = initEditorStatus()
+  status.addNewBufferInCurrentWin
+  currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
+  currentMainWindowNode.currentColumn = 2
+
+  currentBufStatus.moveToPreviousBlankLine(currentMainWindowNode)
+
+  check currentMainWindowNode.currentLine == 0
+  check currentMainWindowNode.currentColumn == 0
+
 test "Move to next blank line":
   var status = initEditorStatus()
   status.addNewBufferInCurrentWin
@@ -245,6 +256,16 @@ test "Move to next blank line 2":
   currentBufStatus.moveToNextBlankLine(currentMainWindowNode)
 
   check currentMainWindowNode.currentLine == 3
+  check currentMainWindowNode.currentColumn == 2
+
+test "Move to next blank line 3":
+  var status = initEditorStatus()
+  status.addNewBufferInCurrentWin
+  currentBufStatus.buffer = initGapBuffer(@[ru"abc"])
+
+  currentBufStatus.moveToNextBlankLine(currentMainWindowNode)
+
+  check currentMainWindowNode.currentLine == 0
   check currentMainWindowNode.currentColumn == 2
 
 test "Move to the top line of the screen":


### PR DESCRIPTION
- Fix `{` and `}` command behaviors in normal mode
- Changed to move to the first or last line if there is no blank line