### PR TITLE
feat: Auto split view when starting

### DIFF
--- a/changelog.d/20230928_200227_GitHub_Actions_auto-split-open.rst
+++ b/changelog.d/20230928_200227_GitHub_Actions_auto-split-open.rst
@@ -3,5 +3,5 @@
 Added
 .....
 
-- `#1867`_ feat: Auto split view when starting
+- `#1868`_ feat: Auto split view when starting
 

--- a/changelog.d/20230928_200227_GitHub_Actions_auto-split-open.rst
+++ b/changelog.d/20230928_200227_GitHub_Actions_auto-split-open.rst
@@ -1,0 +1,7 @@
+.. _#1868:  https://github.com/fox0430/moe/pull/1868
+
+Added
+.....
+
+- `#1867`_ feat: Auto split view when starting
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -789,6 +789,22 @@ Enable/Disable syntax checker (bool)
 enable
 ```
 
+### StartUp.FileOpen table
+
+Display all buffers in multiple views if multiple paths are received when starting the editor (bool)  
+The default is `true`
+```
+autoSplit
+```
+
+Setting the split type for `StartUp.FileOpen.autoSplit`. (string)  
+`vertical` or `horizontal`  
+The default is `vertical`
+
+```
+splitType 
+```
+
 ### Color and theme
 moe supports 24 bit color and set in hexadecimal (#000000 ~ #ffffff).
 And, `termDefaultBg` and `termDefaultFg`.

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -224,6 +224,10 @@ minDelay = 5
 
 maxDelay = 20
 
+[StartUp.FileOpen]
+autoSplit = true
+splitType = "vertical"
+
 [Debug.WindowNode]
 enable = true
 currentWindow = true

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -371,6 +371,8 @@ proc addNewBufferInCurrentWin*(
     ## Add a new buffer and change the current buffer to it and init an editor
     ## view.
 
+    # TODO: Return an Error.
+
     let index = status.addNewBuffer(path, mode)
     if index.isErr: return
 

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -488,14 +488,11 @@ proc colorFromNode(node: JsonNode): Rgb =
   else:
     return TerminalDefaultRgb
 
-proc parseWindowSplitType(s: string): Result[WindowSplitType, string] =
-  case s:
-    of "vertical":
-      return Result[WindowSplitType, string].ok WindowSplitType.vertical
-    of "horizontal":
-      return Result[WindowSplitType, string].ok WindowSplitType.horizontal
-    else:
-      return Result[WindowSplitType, string].err "Invalid value"
+proc parseWindowSplitType*(s: string): Result[WindowSplitType, string] =
+  try:
+    return Result[WindowSplitType, string].ok parseEnum[WindowSplitType](s)
+  except ValueError:
+    return Result[WindowSplitType, string].err "Invalid value"
 
 proc makeColorThemeFromVSCodeThemeFile(jsonNode: JsonNode): ThemeColors =
   # Load the theme file of VSCode and adapt it as the theme of moe.
@@ -2443,9 +2440,9 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
   result.addLine fmt "minDelay = {$settings.smoothScroll.minDelay}"
   result.addLine fmt "maxDelay = {$settings.smoothScroll.maxDelay}"
 
-  result.addLine fmt "[StartUp.OpenFile]"
+  result.addLine fmt "[StartUp.FileOpen]"
   result.addLine fmt "autoSplit = {$settings.startUp.fileOpen.autoSplit}"
-  result.addLine fmt "splitType = {$settings.startUp.fileOpen.splitType}"
+  result.addLine fmt "splitType = \"{$settings.startUp.fileOpen.splitType}\""
 
   result.addLine fmt "[Debug.WindowNode]"
   result.addLine fmt "enable = {$settings.debugMode.windowNode.enable}"

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -38,6 +38,10 @@ type
     xclip
     wlClipboard
 
+  WindowSplitType* {.pure.} = enum
+    vertical
+    horizontal
+
   DebugWindowNodeSettings* = object
     enable*: bool
     currentWindow*: bool
@@ -205,6 +209,13 @@ type
     minDelay*: int
     maxDelay*: int
 
+  StartUpFileOpenSettings* = object
+    autoSplit*: bool
+    splitType*: WindowSplitType
+
+  StartUpSettings* = object
+    fileOpen*: StartUpFileOpenSettings
+
   EditorSettings* = object
     editorColorTheme*: ColorTheme
     statusLine*: StatusLineSettings
@@ -241,6 +252,7 @@ type
     persist*: PersistSettings
     git*: GitSettings
     syntaxChecker*: SyntaxCheckerSettings
+    startUp*: StartUpSettings
 
   InvalidItem = object
     name: string
@@ -416,6 +428,13 @@ proc initSmoothScrollSettings(): SmoothScrollSettings =
   result.minDelay = 5
   result.maxDelay = 20
 
+proc initStartUpFileOpenSettings(): StartUpFileOpenSettings =
+  result.autoSplit = true
+  result.splitType = WindowSplitType.vertical
+
+proc initStartUpSettings(): StartUpSettings =
+  result.fileOpen = initStartUpFileOpenSettings()
+
 proc initEditorSettings*(): EditorSettings =
   result.editorColorTheme = ColorTheme.dark
   result.statusLine = initStatusLineSettings()
@@ -447,6 +466,7 @@ proc initEditorSettings*(): EditorSettings =
   result.persist = initPersistSettings()
   result.git = initGitSettings()
   result.syntaxChecker = initSyntaxCheckerSettings()
+  result.startUp = initStartUpSettings()
 
 proc parseColorTheme(theme: string): Result[ColorTheme, string] =
   case theme:
@@ -467,6 +487,15 @@ proc colorFromNode(node: JsonNode): Rgb =
     return asString[1 .. 6].hexToRgb.get
   else:
     return TerminalDefaultRgb
+
+proc parseWindowSplitType(s: string): Result[WindowSplitType, string] =
+  case s:
+    of "vertical":
+      return Result[WindowSplitType, string].ok WindowSplitType.vertical
+    of "horizontal":
+      return Result[WindowSplitType, string].ok WindowSplitType.horizontal
+    else:
+      return Result[WindowSplitType, string].err "Invalid value"
 
 proc makeColorThemeFromVSCodeThemeFile(jsonNode: JsonNode): ThemeColors =
   # Load the theme file of VSCode and adapt it as the theme of moe.
@@ -944,8 +973,8 @@ proc vsCodeDefaultExtensionsDir(flavor: VsCodeFlavor): string =
       return vsCodeDefaultExtensionsDir()
 
 proc detectVsCodeFlavor(): Option[VsCodeFlavor] =
-  # Check settings dirs in the following order.
-  # vscodium -> code-oss -> vscode
+  ## Check settings dirs in the following order.
+  ## vscodium -> code-oss -> vscode
 
   if fileExists(vsCodiumUserSettingsFilePath()):
     return some(VsCodeFlavor.VSCodium)
@@ -955,7 +984,7 @@ proc detectVsCodeFlavor(): Option[VsCodeFlavor] =
     return some(VsCodeFlavor.VSCode)
 
 proc isCurrentVsCodeThemePackage(json: JsonNode, themeName: string): bool =
-  # Return true if `json` is the current VSCode theme.
+  ## Return true if `json` is the current VSCode theme.
 
   if json{"contributes", "themes"} != nil:
     let themes = json{"contributes", "themes"}
@@ -983,9 +1012,9 @@ proc parseVsCodeThemeJson(
                 except CatchableError: none(JsonNode)
 
 proc loadVSCodeTheme*(): Result[ColorTheme, string] =
-  # If no vscode theme can be found, this defaults to the dark theme.
-  # Hopefully other contributors will come and add support for Windows,
-  # and other systems.
+  ## If no vscode theme can be found, this defaults to the dark theme.
+  ## Hopefully other contributors will come and add support for Windows,
+  ## and other systems.
 
   let vsCodeFlavor = detectVsCodeFlavor()
   if vsCodeFlavor.isNone:
@@ -1570,6 +1599,21 @@ proc parseSmoothScrollTable(
     if smoothScrollConfigs.contains("maxDelay"):
       s.smoothScroll.maxDelay = smoothScrollConfigs["maxDelay"].getInt
 
+proc parseStartUpSettingsTable(
+  s: var EditorSettings,
+  startUpConfigs: TomlValueRef) =
+
+    if startUpConfigs.contains("FileOpen"):
+      if startUpConfigs["FileOpen"].contains("autoSplit"):
+        s.startUp.fileOpen.autoSplit =
+          startUpConfigs["FileOpen"]["autoSplit"].getBool
+
+      if startUpConfigs["FileOpen"].contains("splitType"):
+        s.startUp.fileOpen.splitType = startUpConfigs["FileOpen"]["splitType"]
+          .getStr
+          .parseWindowSplitType
+          .get
+
 proc parseThemeTable(
   s: var EditorSettings,
   themeConfigs: Option[TomlValueRef]) =
@@ -1704,6 +1748,9 @@ proc parseTomlConfigs*(tomlConfigs: TomlValueRef): EditorSettings =
 
   if tomlConfigs.contains("SmoothScroll"):
     result.parseSmoothScrollTable(tomlConfigs["SmoothScroll"])
+
+  if tomlConfigs.contains("StartUp"):
+    result.parseStartUpSettingsTable(tomlConfigs["StartUp"])
 
   if result.editorColorTheme == ColorTheme.config or
      result.editorColorTheme == ColorTheme.vscode:
@@ -2100,6 +2147,25 @@ proc validateSmoothScrollTable(table: TomlValueRef): Option[InvalidItem] =
       else:
         return some(InvalidItem(name: $key, val: $val))
 
+proc validateStartUpTable(table: TomlValueRef): Option[InvalidItem] =
+  for key, val in table.getTable:
+    case key:
+      of "FileOpen":
+        # Check [StartUp.FileOpen]
+        for key,val in table["FileOpen"].getTable:
+          case key:
+            of "autoSplit":
+              if val.kind != TomlValueKind.Bool:
+                return some(InvalidItem(name: $key, val: $val))
+            of "splitType":
+              if val.kind != TomlValueKind.String or
+                 parseWindowSplitType(val.getStr).isErr:
+                   return some(InvalidItem(name: $key, val: $val))
+            else:
+              return some(InvalidItem(name: $key, val: $val))
+      else:
+        return some(InvalidItem(name: $key, val: $val))
+
 proc validateTomlConfig(toml: TomlValueRef): Option[InvalidItem] =
   for key, val in toml.getTable:
     case key:
@@ -2156,6 +2222,9 @@ proc validateTomlConfig(toml: TomlValueRef): Option[InvalidItem] =
         if r.isSome: return r
       of "SmoothScroll":
         let r = validateSmoothScrollTable(val)
+        if r.isSome: return r
+      of "StartUp":
+        let r = validateStartUpTable(val)
         if r.isSome: return r
       else:
         return some(InvalidItem(name: $key, val: $val))
@@ -2373,6 +2442,10 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
   result.addLine fmt "enable = {$settings.smoothScroll.enable}"
   result.addLine fmt "minDelay = {$settings.smoothScroll.minDelay}"
   result.addLine fmt "maxDelay = {$settings.smoothScroll.maxDelay}"
+
+  result.addLine fmt "[StartUp.OpenFile]"
+  result.addLine fmt "autoSplit = {$settings.startUp.fileOpen.autoSplit}"
+  result.addLine fmt "splitType = {$settings.startUp.fileOpen.splitType}"
 
   result.addLine fmt "[Debug.WindowNode]"
   result.addLine fmt "enable = {$settings.debugMode.windowNode.enable}"

--- a/tests/tmoe.nim
+++ b/tests/tmoe.nim
@@ -1,0 +1,125 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, os]
+import moepkg/[editorstatus, cmdlineoption, bufferstatus, unicodeext, gapbuffer,
+               windownode, settings]
+
+import moe {.all.}
+
+suite "moe: addBufferStatus":
+  test "No args":
+    var status = initEditorStatus()
+    const ParsedList = CmdParsedList()
+
+    status.addBufferStatus(ParsedList)
+
+    check status.bufStatus.len == 1
+    check currentBufStatus.buffer.toSeqRunes == @[ru""]
+    check currentBufStatus.path == ru""
+    check currentBufStatus.mode == Mode.normal
+
+    check mainWindowNode.getAllWindowNode.len == 1
+
+  test "1 file":
+    var status = initEditorStatus()
+    const ParsedList = CmdParsedList(path: @["test.nim"])
+
+    status.addBufferStatus(ParsedList)
+
+    check status.bufStatus.len == 1
+    check currentBufStatus.buffer.toSeqRunes == @[ru""]
+    check currentBufStatus.path == ru"test.nim"
+    check currentBufStatus.mode == Mode.normal
+
+    check mainWindowNode.getAllWindowNode.len == 1
+
+  test "1 dir":
+    var status = initEditorStatus()
+    const ParsedList = CmdParsedList(path: @["./"])
+
+    status.addBufferStatus(ParsedList)
+
+    check status.bufStatus.len == 1
+    check currentBufStatus.buffer.toSeqRunes.len > 0
+    check currentBufStatus.path == getCurrentDir().toRunes & ru"/"
+    check currentBufStatus.mode == Mode.filer
+
+    check mainWindowNode.getAllWindowNode.len == 1
+
+  test "2 files and auto vertical split":
+    var status = initEditorStatus()
+    const ParsedList = CmdParsedList(path: @["test1.nim", "test2.nim"])
+
+    status.addBufferStatus(ParsedList)
+
+    check status.bufStatus.len == 2
+
+    check status.bufStatus[0].buffer.toSeqRunes == @[ru""]
+    check status.bufStatus[0].path == ru"test1.nim"
+    check status.bufStatus[0].mode == Mode.normal
+
+    check status.bufStatus[1].buffer.toSeqRunes == @[ru""]
+    check status.bufStatus[1].path == ru"test2.nim"
+    check status.bufStatus[1].mode == Mode.normal
+
+    check mainWindowNode.getAllWindowNode.len == 2
+    check currentMainWindowNode.bufferIndex == 1
+    check currentMainWindowNode.parent.splitType == SplitType.vertical
+
+  test "2 files and auto horizontal split":
+    var status = initEditorStatus()
+    status.settings.startUp.fileOpen.splitType = WindowSplitType.horizontal
+    const ParsedList = CmdParsedList(path: @["test1.nim", "test2.nim"])
+
+    status.addBufferStatus(ParsedList)
+
+    check status.bufStatus.len == 2
+
+    check status.bufStatus[0].buffer.toSeqRunes == @[ru""]
+    check status.bufStatus[0].path == ru"test1.nim"
+    check status.bufStatus[0].mode == Mode.normal
+
+    check status.bufStatus[1].buffer.toSeqRunes == @[ru""]
+    check status.bufStatus[1].path == ru"test2.nim"
+    check status.bufStatus[1].mode == Mode.normal
+
+    check mainWindowNode.getAllWindowNode.len == 2
+    check currentMainWindowNode.bufferIndex == 1
+    check currentMainWindowNode.parent.splitType == SplitType.horaizontal
+
+  test "2 files and startUp.fileOpen.autoSplit = false":
+    var status = initEditorStatus()
+    status.settings.startUp.fileOpen.autoSplit = false
+    const ParsedList = CmdParsedList(path: @["test1.nim", "test2.nim"])
+
+    status.addBufferStatus(ParsedList)
+
+    check status.bufStatus.len == 2
+
+    check status.bufStatus[0].buffer.toSeqRunes == @[ru""]
+    check status.bufStatus[0].path == ru"test1.nim"
+    check status.bufStatus[0].mode == Mode.normal
+
+    check status.bufStatus[1].buffer.toSeqRunes == @[ru""]
+    check status.bufStatus[1].path == ru"test2.nim"
+    check status.bufStatus[1].mode == Mode.normal
+
+    check mainWindowNode.getAllWindowNode.len == 1
+    check currentMainWindowNode.bufferIndex == 1

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -149,6 +149,10 @@ const TomlStr = """
   minDelay = 1
   maxDelay = 1
 
+  [StartUp.FileOpen]
+  autoSplit = false
+  splitType = "horizontal"
+
   [Debug.WindowNode]
   enable = false
   currentWindow = false
@@ -465,6 +469,9 @@ suite "Parse configuration file":
     check not settings.smoothScroll.enable
     check settings.smoothScroll.minDelay == 1
     check settings.smoothScroll.maxDelay == 1
+
+    check not settings.startUp.fileOpen.autoSplit
+    check settings.startUp.fileOpen.splitType == WindowSplitType.horizontal
 
     check not settings.debugMode.windowNode.enable
     check not settings.debugMode.windowNode.currentWindow


### PR DESCRIPTION
Add settings to display all buffers in multiple views if multiple paths are received when starting the editor.

- Add `StartUp.FileOpen.autoSplit` setting
- Add `StartUp.FileOpen.splitType` setting

### TODO
- [x] Config mode
- [x] Tests
- [x] Docs

Close #1867 

