### PR TITLE
feat: Add Language Server Protocol support

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -84,7 +84,11 @@ jobs:
         cd abduco-0.6
         make && sudo make install
 
-    - name: Run unit test
+    - name: Install nimlsp
       run: |
         nimble refresh
+        nimble install nimlsp
+
+    - name: Run unit test
+      run: |
         xvfb-run nimble test --verbose -y

--- a/README.md
+++ b/README.md
@@ -136,9 +136,6 @@ We recommend Linux environments.
 ```sh
 # Latest developmental state inside Github repository
 nimble install moe@#head
-
-# Latest released version
-nimble install moe
 ```
 
 Check [detail](https://github.com/fox0430/moe/blob/develop/documents/overview.md)

--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@ This project's goals are easily customizable, high productivity, user friendly, 
 
 - Tab line
 
-- Simple file manager
-
 - Indentation lines
 
 - Auto close/delete paren
@@ -93,6 +91,8 @@ This project's goals are easily customizable, high productivity, user friendly, 
 
 - Macros
 
+- Language Server Protocol (WIP)
+
 ## Planned features
 
 - Supports regular expression and PEG
@@ -111,8 +111,6 @@ This project's goals are easily customizable, high productivity, user friendly, 
 
 - Edit files over ssh
 
-- Language Server Protocol
-
 - Fuzzy search
 
 - Plugins
@@ -127,28 +125,29 @@ We recommend Linux environments.
 
 ### Requires
 
-- Nim 1.6.2 or higher
+- [Nim](https://nim-lang.org) 1.6.2 or higher
 
-- ncurses
+- [Ncurses](https://invisible-island.net/ncurses) 6.1 or higher
 
-- xclip v0.13 or higher (Option on GNU/Linux)
+- [xclip](https://github.com/astrand/xclip) v0.13 or higher (Option on GNU/Linux)
 
-- xsel (Option on GNU/Linux)
+- [xsel](http://www.kfish.org/software/xsel/) (Option on GNU/Linux)
 
 ```sh
-# Latest released version
-nimble install moe
 # Latest developmental state inside Github repository
 nimble install moe@#head
+
+# Latest released version
+nimble install moe
 ```
 
 Check [detail](https://github.com/fox0430/moe/blob/develop/documents/overview.md)
 
 ## Usage
 
-[Documents (Release)](https://github.com/fox0430/moe/blob/master/documents/index.md)
-
 [Documents (Latest)](https://github.com/fox0430/moe/blob/develop/documents/index.md)
+
+[Documents (Release)](https://github.com/fox0430/moe/blob/master/documents/index.md)
 
 ## The origin of the name
 moe is a recursive acronym for "moe is an optimal editor".    

--- a/changelog.d/20231007_074514_shuu.n_init_lsp_support.rst
+++ b/changelog.d/20231007_074514_shuu.n_init_lsp_support.rst
@@ -1,0 +1,7 @@
+.. _#1877:  https://github.com/fox0430/moe/pull/1877
+
+Added
+.....
+
+- `#1877`_ feat: Add Language Server Protocol support
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -815,7 +815,7 @@ extensions
 
 A LSP server command (string)  
 ```
-serverCommand
+command
 ```
 
 Please check more [details](https://github.com/fox0430/moe/blob/develop/documents/lsp.md)

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -797,6 +797,29 @@ default is 20
 maxDelay
 ```
 
+### Lsp table
+
+Enable/Disable LSP (bool)  
+defaut is `false`
+```
+enable
+```
+
+### Lsp.{languageId} table
+
+File extensions (Array[string])
+```
+extensions
+
+```
+
+A LSP server command (string)  
+```
+serverCommand
+```
+
+Please check more [details](https://github.com/fox0430/moe/blob/develop/documents/lsp.md)
+
 ### StartUp.FileOpen table
 
 Display all buffers in multiple views if multiple paths are received when starting the editor (bool)  

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -63,7 +63,7 @@
 | <kbd>**y**</kbd><kbd>**}**</kbd><br> Yank to the next blank line | <kbd>**y**</kbd><kbd>**l**</kbd><br> Yank a character| <kbd>**X**</kbd> OR <kbd>**d**</kbd><kbd>**h**</kbd><br> Cut a character before cursor | <kbd>**g**</kbd><kbd>**a**</kbd><br> Show current character info |
 | <kbd>**t**</kbd><kbd>**x**</kbd><br> Move to the left of the next ```x``` (any character) on the current line | <kbd>**T**</kbd><kbd>**x**</kbd><br> Move to the right of the back ```x ``` (any character) on the current line | <kbd>**y**</kbd><kbd>**t**</kbd><br><kbd>**Any key**</kbd><br> Yank characters to an any character | <kbd>**c**</kbd><kbd>**f**</kbd><br><kbd>**Any key**</kbd><br> Delete characters to an any character and enter insert mode |
 | <kbd>**H**</kbd></br> Move to the top line of the screen | <kbd>**M**</kbd></br> Move to the center line of the screen | <kbd>**L**</kbd></br> Move to the bottom line of the screen | <kbd>**%**</kbd></br> Move to matching pair of paren |
-| <kbd>**q**</kbd> <kbd>**Any key**</kbd></br> Start recording operations for Macros | <kbd>**q**</kbd></br> Stop recording operations | <kbd>**@**</kbd> <kbd>**Any key**</kbd></br> Exce a macro |
+| <kbd>**q**</kbd> <kbd>**Any key**</kbd></br> Start recording operations for Macros | <kbd>**q**</kbd></br> Stop recording operations | <kbd>**@**</kbd> <kbd>**Any key**</kbd></br> Exce a macro |<kbd>**K**</kbd></br> Hover (Need LSP) |
 
 </details>
 

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -64,8 +64,7 @@
 | <kbd>**t**</kbd><kbd>**x**</kbd><br> Move to the left of the next ```x``` (any character) on the current line | <kbd>**T**</kbd><kbd>**x**</kbd><br> Move to the right of the back ```x ``` (any character) on the current line | <kbd>**y**</kbd><kbd>**t**</kbd><br><kbd>**Any key**</kbd><br> Yank characters to an any character | <kbd>**c**</kbd><kbd>**f**</kbd><br><kbd>**Any key**</kbd><br> Delete characters to an any character and enter insert mode |
 | <kbd>**H**</kbd></br> Move to the top line of the screen | <kbd>**M**</kbd></br> Move to the center line of the screen | <kbd>**L**</kbd></br> Move to the bottom line of the screen | <kbd>**%**</kbd></br> Move to matching pair of paren |
 | <kbd>**q**</kbd> <kbd>**Any key**</kbd></br> Start recording operations for Macros | <kbd>**q**</kbd></br> Stop recording operations | <kbd>**@**</kbd> <kbd>**Any key**</kbd></br> Exce a macro | <kbd>**c**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key and enter Insert mode |
-| <kbd>**d**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key |
-| <kbd>**K**</kbd></br> Hover (Need LSP) |
+| <kbd>**d**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key |<kbd>**K**</kbd></br> Hover (Need LSP) |
 
 </details>
 

--- a/documents/index.md
+++ b/documents/index.md
@@ -8,6 +8,8 @@
 
 [Configuration file](https://github.com/fox0430/moe/blob/develop/documents/configfile.md)
 
+[Language Server Protocol](https://github.com/fox0430/moe/blob/develop/documents/lsp.md)
+
 [Platform / Terminal](https://github.com/fox0430/moe/blob/develop/documents/platform_terminal.md)
 
 [Developer](https://github.com/fox0430/moe/blob/develop/documents/developer.md)

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -1,0 +1,54 @@
+# Language Server Protocol
+
+Moe supports [LSP](https://microsoft.github.io/language-server-protocol/) but work in progress and not recommended for use yet.
+Please feedback, bug reports and PRs.
+
+## Supported LSP commands
+
+- `Initialize`
+- `shutdown`
+- `workspace/didChangeConfiguration`
+- `textDocument/didOpen`
+- `textDocument/didChange`
+- `textDocument/didClose`
+- `textDocument/hover`
+
+## Configuration
+
+Please edit you configuration file.
+
+Example
+```toml
+[Lsp]
+enable = true
+
+[Lsp.nim]
+# File extensions
+extensions = ["nim"]
+
+# The LSP server command
+serverCommand = "nimlsp"
+```
+
+Configure each language by adding table `[Lsp.{languageId}]`.
+If you want to add rust-analyzer,
+```toml
+[Lsp]
+enable = true
+
+[Lsp.nim]
+extensions = ["nim"]
+serverCommand = "nimlsp"
+
+[Lsp.rust]
+extensions = ["rs"]
+serverCommand = "rust-analyzer"
+```
+
+## Uses
+
+### Hover
+
+Press `K` on the word in Normal mode.
+
+![hover](https://github.com/fox0430/moe/assets/15966436/9e1f78d7-c52d-4bf7-bb51-7d86659ffeb5)

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -1,6 +1,7 @@
 # Language Server Protocol
 
 Moe supports [LSP](https://microsoft.github.io/language-server-protocol/) but work in progress and not recommended for use yet.
+
 Please feedback, bug reports and PRs.
 
 ## Supported LSP commands

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -2,6 +2,8 @@
 
 Moe supports [LSP](https://microsoft.github.io/language-server-protocol/) but work in progress and not recommended for use yet.
 
+Currently, I only tested by [nimlsp](https://github.com/PMunch/nimlsp).
+
 Please feedback, bug reports and PRs.
 
 ## Supported LSP commands

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -28,7 +28,7 @@ enable = true
 extensions = ["nim"]
 
 # The LSP server command
-serverCommand = "nimlsp"
+command = "nimlsp"
 ```
 
 Configure each language by adding table `[Lsp.{languageId}]`.
@@ -39,11 +39,11 @@ enable = true
 
 [Lsp.nim]
 extensions = ["nim"]
-serverCommand = "nimlsp"
+command = "nimlsp"
 
 [Lsp.rust]
 extensions = ["rs"]
-serverCommand = "rust-analyzer"
+command = "rust-analyzer"
 ```
 
 ## Uses

--- a/documents/overview.md
+++ b/documents/overview.md
@@ -7,8 +7,8 @@ Currently you can use normal mode, visual mode, replace mode, insert mode, ex mo
 # Install and compile
 
 ## Requires
-- Nim 1.6.2 or higher
-- ncurses
+- [Nim](https://nim-lang.org) 1.6.2 or higher
+- [Ncurses](https://invisible-island.net/ncurses) 6.1 or higher
 
 ### Install
 
@@ -55,6 +55,11 @@ $ nimble release
 # Test
 
 ## Unit test
+
+### Requires
+
+- [nimlsp](https://github.com/PMunch/nimlsp)
+
 ```
 nimble test
 ```

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -224,6 +224,16 @@ minDelay = 5
 
 maxDelay = 20
 
+[Lsp]
+
+enable = false
+
+[Lsp.nim]
+
+extensions = ["nim"]
+
+serverCommand = ["nimlsp"]
+
 [Debug.WindowNode]
 enable = true
 currentWindow = true

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -236,7 +236,7 @@ enable = false
 
 extensions = ["nim"]
 
-serverCommand = "nimlsp"
+command = "nimlsp"
 
 [Debug.WindowNode]
 enable = true

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -236,7 +236,7 @@ enable = false
 
 extensions = ["nim"]
 
-serverCommand = ["nimlsp"]
+serverCommand = "nimlsp"
 
 [Debug.WindowNode]
 enable = true

--- a/moe.nimble
+++ b/moe.nimble
@@ -15,7 +15,6 @@ requires "unicodedb >= 0.12.0"
 requires "parsetoml >= 0.7.1"
 requires "regex >= 0.22.0"
 requires "results >= 0.4.0"
-requires "asynctools >= 0.1.1"
 
 task release, "Build for release":
   exec "nimble build -d:release"

--- a/moe.nimble
+++ b/moe.nimble
@@ -15,6 +15,7 @@ requires "unicodedb >= 0.12.0"
 requires "parsetoml >= 0.7.1"
 requires "regex >= 0.22.0"
 requires "results >= 0.4.0"
+requires "asynctools >= 0.1.1"
 
 task release, "Build for release":
   exec "nimble build -d:release"

--- a/src/moe.nim
+++ b/src/moe.nim
@@ -20,7 +20,7 @@
 import std/[os, times]
 import pkg/results
 import moepkg/[ui, bufferstatus, editorstatus, cmdlineoption, mainloop, git,
-               editorview, theme, registers, settings, messages]
+               editorview, theme, registers, settings, messages, logger]
 
 proc loadPersistData(status: var EditorStatus) =
   ## Load persisted data (Ex command history, search history and cursor
@@ -106,6 +106,10 @@ proc initEditor(): EditorStatus =
   result = initEditorStatus()
   result.loadConfigurationFile
   result.timeConfFileLastReloaded = now()
+
+  if result.settings.lsp.enable:
+    # Force enable logger if enabled LSP.
+    initLogger()
 
   block initColors:
     # TODO: Show error messages when failing to the load VSCode theme.

--- a/src/moepkg/appinfo.nim
+++ b/src/moepkg/appinfo.nim
@@ -1,0 +1,76 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[strformat, strutils, os, pegs]
+import pkg/results
+
+type
+  VersionInfo* = object
+    major*, minor*, patch*: int
+
+proc toSemVerString*(v: VersionInfo): string {.inline.} =
+  fmt"{v.major}.{v.minor}.{v.patch}"
+
+proc parseVersionInfo*(s: string): Result[VersionInfo, string] =
+  let strSplit = s.split('.')
+  try:
+    return Result[VersionInfo, string].ok VersionInfo(
+      major: strSplit[0].parseInt,
+      minor: strSplit[1].parseInt,
+      patch: strSplit[2].parseInt)
+  except:
+    return Result[VersionInfo, string].err fmt"Invalid value: {getCurrentExceptionMsg()}"
+
+proc staticReadVersionFromNimble: string {.compileTime.} =
+  ## Get the moe version from moe.nimble.
+
+  let
+    peg = """@ "version" \s* "=" \s* \" {[0-9.]+} \" @ $""".peg
+
+    nimblePath = currentSourcePath.parentDir() / "../../moe.nimble"
+    nimbleSpec = staticRead(nimblePath)
+
+  var captures: seq[string] = @[""]
+  assert nimbleSpec.match(peg, captures)
+  assert captures.len == 1
+  return captures[0]
+
+proc moeVersion*(): VersionInfo {.compileTime.} =
+  staticReadVersionFromNimble().parseVersionInfo.get
+
+proc moeSemVersionStr*(): string {.compileTime.} =
+  moeVersion().toSemVerString
+
+proc staticGetGitHash: string {.compileTime.} =
+  ## Get the current git hash.
+
+  const CmdResult = gorgeEx("git rev-parse HEAD")
+  if CmdResult.exitCode == 0 and CmdResult.output.len == 40:
+    return CmdResult.output
+  else:
+    return ""
+
+proc gitHash*(): string {.compileTime.} =
+  staticGetGitHash()
+
+proc buildType*: string {.compileTime.} =
+  ## Return the build type. "Release" or "Debug".
+
+  if defined(release): return "Release"
+  else: return "Debug"

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -50,6 +50,7 @@ type
     isUpdate*: bool
     characterEncoding*: CharacterEncoding
     language*: SourceLanguage
+    languageId*: string
     fileType*: FileType
     selectedArea*: SelectedArea
     path*: Runes

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -52,6 +52,7 @@ type
     language*: SourceLanguage
     languageId*: string
     fileType*: FileType
+    extension*: Runes
     selectedArea*: SelectedArea
     path*: Runes
     openDir*: Runes
@@ -280,8 +281,7 @@ proc initBufferStatus*(
       prevMode: mode,
       mode: mode,
       lastSaveTime: now(),
-      lastGitInfoCheckTime: now(),
-      fileType: getFileType(path))
+      lastGitInfoCheckTime: now())
 
     if isFilerMode(mode):
       if isAccessibleDir(path):
@@ -292,6 +292,9 @@ proc initBufferStatus*(
         return Result[BufferStatus, string].err "Can not open dir"
     else:
       b.path = path.toRunes
+
+      b.fileType = getFileType(path)
+      b.extension = getFileExtension(b.path)
 
       if not fileExists($b.path):
         b.buffer = newFile()

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -56,7 +56,8 @@ type
     path*: Runes
     openDir*: Runes
     positionRecord*: Table[int, tuple[line, column, expandedColumn: int]]
-    countChange*: int
+    countChange*: int # Counting temporary changes
+    version*: Natural # Counting total changes
     cmdLoop*: int
     mode* : Mode
     prevMode* : Mode

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -50,7 +50,6 @@ type
     isUpdate*: bool
     characterEncoding*: CharacterEncoding
     language*: SourceLanguage
-    languageId*: string
     fileType*: FileType
     extension*: Runes
     selectedArea*: SelectedArea

--- a/src/moepkg/configmode.nim
+++ b/src/moepkg/configmode.nim
@@ -21,7 +21,7 @@ import std/[times, strutils, options, strformat, sequtils]
 import pkg/results
 import gapbuffer, ui, editorstatus, unicodeext, windownode, movement, settings,
        bufferstatus, color, highlight, editor, commandline, popupwindow, rgb,
-       theme
+       theme, independentutils
 
 type
   StandardTableNames {.pure.} = enum
@@ -1678,14 +1678,14 @@ proc editEnumAndBoolSettings(
       x = absoluteX + positionOfSetVal() + NumOfIndent - Margin
 
     var
-      popupWindow = initWindow(h, w, y, x, EditorColorPairIndex.popupWindow.int16)
+      popupWindow = initPopupWindow(Position(y: y, x: x), Size(h: h, w: w))
       suggestIndex = 0
 
     while settingValues.len > 1:
-      popupWindow.writePopUpWindow(
-        h, w, y, x,
-        some(suggestIndex),
-        settingValues)
+      popupWindow.currentLine = some(suggestIndex)
+      popupWindow.buffer = settingValues
+
+      popupWindow.update
 
       let key = currentMainWindowNode.getKey
 

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -303,10 +303,10 @@ proc initLsp(
     if not status.lspClients.contains(langId):
       # Init a LSP client and start a LSP server.
       var c = initLspClient(
-        $status.settings.lsp.languages[langId].serverCommand)
+        $status.settings.lsp.languages[langId].command)
       if c.isErr:
         status.commandLine.writeLspInitializeError(
-          status.settings.lsp.languages[langId].serverCommand,
+          status.settings.lsp.languages[langId].command,
           c.error)
         return Result[(), string].err c.error
 
@@ -343,7 +343,7 @@ proc initLsp(
         $status.bufStatus[^1].buffer)
       if err.isErr:
         status.commandLine.writeLspInitializeError(
-          status.settings.lsp.languages[langId].serverCommand,
+          status.settings.lsp.languages[langId].command,
           err.error)
 
     return Result[(), string].ok ()
@@ -427,10 +427,10 @@ proc addNewBuffer*(
               langId)
             if err.isOk:
               status.commandLine.writeLspInitialized(
-                status.settings.lsp.languages[langId].serverCommand)
+                status.settings.lsp.languages[langId].command)
             else:
               status.commandLine.writeLspInitializeError(
-                status.settings.lsp.languages[langId].serverCommand,
+                status.settings.lsp.languages[langId].command,
                 err.error)
 
     return Result[int, string].ok status.bufStatus.high

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -351,15 +351,17 @@ proc addNewBuffer*(
           addMessageLog errMessage
           return Result[int, string].err errMessage
 
-        if status.bufStatus[^1].path.contains(ru"."):
-          let firstPosition = status.bufStatus[^1].path.rfind(ru".")
-          if firstPosition < status.bufStatus[^1].path.high:
-            # Set BufferStatus.languageId.
-            let
-              extension = path[firstPosition + 1 .. path.high]
-              langId = status.settings.lsp.languageIdFromLspLanguageSettings(
-                extension.toRunes)
-            status.bufStatus[^1].languageId = langId.get
+        if status.bufStatus[^1].isNormalMode and
+           status.bufStatus[^1].path.contains(ru"."):
+             let firstPosition = status.bufStatus[^1].path.rfind(ru".")
+             if firstPosition < status.bufStatus[^1].path.high:
+               # Set BufferStatus.languageId.
+               let
+                 extension = path[firstPosition + 1 .. path.high]
+                 langId = status.settings.lsp.languageIdFromLspLanguageSettings(
+                   extension.toRunes)
+               if langId.isSome:
+                 status.bufStatus[^1].languageId = langId.get
 
         if status.settings.git.showChangedLine and
            status.bufStatus[^1].isTrackingByGit:

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -313,7 +313,9 @@ proc initLsp(status: var EditorStatus, bufferIndex: int): Result[(), string] =
     # Initialize request
     let err = status.lspClients[langId].initialize(
       status.bufStatus.high,
-      initInitializeParams($status.bufStatus[bufferIndex].openDir))
+      initInitializeParams(
+        $status.bufStatus[bufferIndex].openDir,
+        status.settings.lsp.languages[langId].trace))
     if err.isErr:
       return Result[(), string].err err.error
 

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -671,7 +671,8 @@ proc checkBufferStatusUpdate(status: EditorStatus) =
       buf.version.inc
 
       if status.lspClients.contains($buf.extension) and
-         status.lspClients[$buf.extension].isInitialized:
+         status.lspClients[$buf.extension].isInitialized and
+         buf.version > 1:
            # Send a textDocument/didChange notification to the LSP server.
            discard status.lspClients[$buf.extension].textDocumentDidChange(
              buf.version,

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -419,7 +419,10 @@ proc addNewBuffer*(
                status.commandLine.writeGitInfoUpdateError(gitDiffProcess.error)
 
         if status.settings.lsp.enable:
-          if status.bufStatus[^1].extension.len > 0 and
+          let langId = $status.bufStatus[^1].extension
+
+          if langId.len > 0 and
+             status.settings.lsp.languages.contains(langId) and
              not status.lspClients.contains($status.bufStatus[^1].extension):
                # Init LSP client and server.
                let langId = $status.bufStatus[^1].extension

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -418,20 +418,21 @@ proc addNewBuffer*(
                status.commandLine.writeGitInfoUpdateError(gitDiffProcess.error)
 
         if status.settings.lsp.enable:
-          if not status.lspClients.contains($status.bufStatus[^1].extension):
-            # Init LSP client and server.
-            let langId = $status.bufStatus[^1].extension
+          if status.bufStatus[^1].extension.len > 0 and
+             not status.lspClients.contains($status.bufStatus[^1].extension):
+               # Init LSP client and server.
+               let langId = $status.bufStatus[^1].extension
 
-            let err = status.initLsp(
-              $status.bufStatus[^1].openDir,
-              langId)
-            if err.isOk:
-              status.commandLine.writeLspInitialized(
-                status.settings.lsp.languages[langId].command)
-            else:
-              status.commandLine.writeLspInitializeError(
-                status.settings.lsp.languages[langId].command,
-                err.error)
+               let err = status.initLsp(
+                 $status.bufStatus[^1].openDir,
+                 langId)
+               if err.isOk:
+                 status.commandLine.writeLspInitialized(
+                   status.settings.lsp.languages[langId].command)
+               else:
+                 status.commandLine.writeLspInitializeError(
+                   status.settings.lsp.languages[langId].command,
+                   err.error)
 
     return Result[int, string].ok status.bufStatus.high
 

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -402,18 +402,6 @@ proc addNewBuffer*(
           addMessageLog errMessage
           return Result[int, string].err errMessage
 
-        if status.bufStatus[^1].isNormalMode and
-           status.bufStatus[^1].path.contains(ru"."):
-             let firstPosition = status.bufStatus[^1].path.rfind(ru".")
-             if firstPosition < status.bufStatus[^1].path.high:
-               # Set BufferStatus.languageId.
-               let
-                 extension = path[firstPosition + 1 .. path.high]
-                 langId = status.settings.lsp.languageIdFromLspLanguageSettings(
-                   extension.toRunes)
-               if langId.isSome:
-                 status.bufStatus[^1].languageId = langId.get
-
         if status.settings.git.showChangedLine and
            status.bufStatus[^1].isTrackingByGit:
              let gitDiffProcess = startBackgroundGitDiff(
@@ -424,6 +412,13 @@ proc addNewBuffer*(
                status.backgroundTasks.gitDiff.add gitDiffProcess.get
              else:
                status.commandLine.writeGitInfoUpdateError(gitDiffProcess.error)
+
+        if status.bufStatus[^1].extension.len > 0:
+          # Set languageId for LSP.
+          let langId = status.settings.lsp.languageIdFromLspLanguageSettings(
+            status.bufStatus[^1].extension)
+          if langId.isSome:
+            status.bufStatus[^1].languageId = langId.get
 
         if status.settings.lsp.enable and
            status.bufStatus[^1].languageId.len > 0 and

--- a/src/moepkg/fileutils.nim
+++ b/src/moepkg/fileutils.nim
@@ -182,6 +182,15 @@ proc getFileType*(path: string): FileType =
           return ext
       return FileType.unknown
 
+proc getFileExtension*(path: Runes): Runes =
+  ## Return a file extension from path.
+  ## Return empty string if dosen't exist.
+
+  if not dirExists($path) and path.contains(ru'.'):
+    let position = path.rfind(ru'.')
+    if position < path.high:
+      return path[position + 1 .. ^1]
+
 proc normalizedPath*(path: Runes): Runes =
   result = normalizedPath($path).toRunes
   if path.startsWith(ru'~'):

--- a/src/moepkg/helputils.nim
+++ b/src/moepkg/helputils.nim
@@ -124,6 +124,7 @@ ga         - Show current character info
 q any      - Start recording operations for Macros
 q          - Stop recoding operations
 @ any      - Exec a macro
+K          - Hover (Need LSP)
 
 # Register
 

--- a/src/moepkg/independentutils.nim
+++ b/src/moepkg/independentutils.nim
@@ -24,15 +24,21 @@ type
     y*: int
     x*: int
 
+  WindowPosition* = Position
+
   Size* = object
     h*: int
     w*: int
+
+  WindowSize* = Size
 
   Rect* = object
     x*: int
     y*: int
     h*: int
     w*: int
+
+  WindowRect* = Rect
 
   Range* = object
     first*: int

--- a/src/moepkg/independentutils.nim
+++ b/src/moepkg/independentutils.nim
@@ -89,6 +89,6 @@ proc isEmpty*[T](s: seq[T]): bool {.inline.} = s.len == 0
 
 proc isEmpty*(s: string): bool {.inline.} = s.len == 0
 
-proc dec*(n: var Natural): Natural {.inline.} = n -= 1
+proc dec*(n: var Natural) {.inline.} = n -= 1
 
-proc inc*(n: var Natural): Natural {.inline.} = n += 1
+proc inc*(n: var Natural) {.inline.} = n += 1

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -1,0 +1,315 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+# NOTE: Language Server Protocol Specification - 3.17
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+
+import std/[strformat, strutils, json, options, os, osproc]
+import pkg/results
+import ../[appinfo, independentutils, unicodeext]
+import protocol/types
+import jsonrpc
+
+type
+  LspPosition* = types.Position
+
+  HoverContent* = object
+    title*: Runes
+    description*: seq[Runes]
+
+  LspError* = object
+    code*: int
+      # Error code.
+    message*: string
+      # Error message.
+    data*: string
+      # Error data.
+
+  LspClient* = ref object
+    serverProcess: Process
+      # LSP server process.
+    serverStreams: Streams
+      # Streams for the LSP server process.
+    isInitialized*: bool
+      # Set true if initialized LSP client/server.
+
+type
+  R = Result
+
+  LspErrorParseResult* = R[LspError, string]
+  LspInitializeResult* = R[InitializeResult, string]
+  LspInitializedResult* = R[(), string]
+  LspShutdownResult* = R[(), string]
+  LspDidOpenTextDocumentResult* = R[(), string]
+  LspDidChangeTextDocumentResult* = R[(), string]
+  LspDidCloseTextDocumentResult* = R[(), string]
+  LspHoverResult* = R[Hover, string]
+
+proc toLspPosition*(p: BufferPosition): LspPosition {.inline.} =
+  LspPosition(line: p.line, character: p.column)
+
+proc pathToUri(path: string): string =
+  # This is a modified copy of encodeUrl in the uri module. This doesn't encode
+  # the / character, meaning a full file path can be passed in without breaking
+  # it.
+
+  # Assume 12% non-alnum-chars
+  result = "file://" & newStringOfCap(path.len + path.len shr 2)
+
+  for c in path:
+    case c
+      # https://tools.ietf.org/html/rfc3986#section-2.3
+      of 'a'..'z', 'A'..'Z', '0'..'9', '-', '.', '_', '~', '/':
+        result.add c
+      of '\\':
+        result.add '%'
+        result.add toHex(ord(c), 2)
+      else:
+        result.add '%'
+        result.add toHex(ord(c), 2)
+
+proc serverProcessId*(c: LspClient): int {.inline.} =
+  ## Return a process id of the LSP server process.
+
+  c.serverProcess.processID
+
+proc send(
+  c: LspClient,
+  id: int,
+  methodName: string,
+  params: JsonNode): JsonRpcResponseResult =
+    ## Send a request to the LSP server and return a response.
+
+    return c.serverStreams.sendRequest(id, methodName, params)
+
+proc notify(
+  c: LspClient,
+  methodName: string,
+  params: JsonNode) {.inline.} =
+    ## Send a notification to the LSP server.
+
+    c.serverStreams.sendNotify(methodName, params)
+
+proc isLspError(res: JsonNode): bool {.inline.} = res.contains("error")
+
+proc parseLspError*(res: JsonNode): LspErrorParseResult =
+  try:
+    return LspErrorParseResult.ok res["error"].to(LspError)
+  except:
+    return LspErrorParseResult.err fmt"Invalid error: {$res}"
+
+proc initLspClient*(serverCommand: string): LspClient =
+  ## Start a LSP server process and init streams.
+
+  const
+    WorkingDir = ""
+    Env = nil
+  let
+    commandSplit = serverCommand.split(' ')
+    args =
+      if commandSplit.len > 1: commandSplit[1 .. ^1]
+      else: @[]
+    opts: set[ProcessOption] = {poStdErrToStdOut, poUsePath}
+
+  result = LspClient(
+    serverProcess: startProcess(commandSplit[0], WorkingDir, args, Env, opts))
+  result.serverStreams = Streams(
+    input: result.serverProcess.inputStream,
+    output: result.serverProcess.outputStream)
+
+proc initInitializeParams*(workspaceRoot: string): InitializeParams =
+  let
+    path =
+      if workspaceRoot.len == 0: none(string)
+      else: some(workspaceRoot)
+    uri =
+      if workspaceRoot.len == 0: none(string)
+      else: some(workspaceRoot.pathToUri)
+
+  # TODO: WIP. Need to set more correct parameters.
+  InitializeParams(
+    processId: some(%getCurrentProcessId()),
+    rootPath: path,
+    rootUri: uri,
+    clientInfo: some(ClientInfo(
+      name: "moe",
+      version: some(moeSemVersionStr()))),
+    capabilities: ClientCapabilities())
+
+proc initialize*(
+  c: LspClient,
+  id: int,
+  initParams: InitializeParams): LspInitializeResult =
+    ## Send a initialize request to the server.
+    ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
+
+    let params = %* initParams
+
+    let r = c.send(id, "initialize", params)
+    if r.isErr:
+      return LspInitializeResult.err fmt"lsp: Initialize request failed: {r.error}"
+
+    if r.get.isLspError:
+      return LspInitializeResult.err fmt"lsp: Initialize request failed: {$r.error}"
+
+    try:
+      return LspInitializeResult.ok r.get["result"].to(InitializeResult)
+    except CatchableError as e:
+      let msg = fmt"json to InitializeResult failed {e.msg}"
+      return LspInitializeResult.err fmt"lsp: Initialize request failed: {msg}"
+
+proc initialized*(c: LspClient): LspInitializedResult =
+  ## Send a initialized notification to the server.
+  ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized
+
+  let params = %* {}
+  c.notify("initialized", params)
+
+  c.isInitialized = true
+
+  return LspInitializedResult.ok ()
+
+proc shutdown*(c: LspClient, id: int): LspShutdownResult =
+  ## Send a shutdown request to the server.
+  ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown
+
+  let r = c.send(id, "shutdown", %*{})
+  if r.isErr:
+    return LspShutdownResult.err "lsp: Shutdown request failed: {r.error}"
+
+  if r.get.isLspError:
+    return LspShutdownResult.err fmt"lsp: Shutdown request failed: {$r.error}"
+
+  if r.get["result"].kind == JNull: return LspShutdownResult.ok ()
+  else: return LspShutdownResult.err fmt"lsp: Shutdown request failed: {r.get}"
+
+proc initTextDocumentDidOpenParams(
+  version: int,
+  uri, languageId, text: string): DidOpenTextDocumentParams {.inline.} =
+
+    DidOpenTextDocumentParams(
+      textDocument: TextDocumentItem(
+        uri: uri,
+        languageId: languageId,
+        version: version,
+        text: text))
+
+proc textDocumentDidOpen*(
+  c: LspClient,
+  version: int,
+  path, languageId, text: string): LspDidOpenTextDocumentResult =
+    ## Send a textDocument/didOpen notification to the server.
+    ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen
+
+    let params = %* initTextDocumentDidOpenParams(
+      version,
+      path.pathToUri,
+      languageId,
+      text)
+    c.notify("textDocument/didOpen", params)
+
+    return LspDidOpenTextDocumentResult.ok ()
+
+proc initTextDocumentDidChangeParams(
+  version: int,
+  text: string): DidChangeTextDocumentParams {.inline.} =
+
+    DidChangeTextDocumentParams(
+      textDocument: VersionedTextDocumentIdentifier(version: some(%version)),
+      contentChanges: @[TextDocumentContentChangeEvent(text: text)])
+
+proc textDocumentDidChange*(
+  c: LspClient,
+  version: int,
+  text: string): LspDidChangeTextDocumentResult =
+    ## Send a textDocument/didChange notification to the server.
+    ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange
+
+    let params = %* initTextDocumentDidChangeParams(version, text)
+    c.notify("textDocument/didChange", params)
+
+    return LspDidChangeTextDocumentResult.ok ()
+
+proc initTextDocumentDidClose(
+  path: string): DidCloseTextDocumentParams {.inline.} =
+
+    DidCloseTextDocumentParams(
+      textDocument: TextDocumentIdentifier(uri: path.pathToUri))
+
+proc textDocumentDidClose*(
+  c: LspClient,
+  text: string): LspDidCloseTextDocumentResult =
+    ## Send a textDocument/didClose notification to the server.
+    ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didClose
+
+    let params = %* initTextDocumentDidClose(text)
+    c.notify("textDocument/didClose", params)
+
+    return LspDidChangeTextDocumentResult.ok ()
+
+proc initHoverParams(
+  path: string,
+  position: LspPosition): HoverParams {.inline.} =
+
+    HoverParams(
+      textDocument: TextDocumentIdentifier(uri: path.pathToUri),
+      position: position)
+
+proc toHoverContent*(hover: Hover): HoverContent =
+  let contents = %*hover.contents
+  if contents.len == 1:
+    if contents[0].contains("value"):
+      result.description = contents[0]["value"].getStr.splitLines.toSeqRunes
+  else:
+    if contents[0].contains("value"):
+      result.title = contents[0]["value"].getStr.toRunes
+
+    for i in 1 ..< contents.len:
+      if contents[i].contains("value"):
+        result.description.add contents[i]["value"].getStr.splitLines.toSeqRunes
+        if i < contents.len - 1: result.description.add ru""
+
+proc toRunes*(hoverContent: HoverContent): seq[Runes] =
+  if hoverContent.title.len > 0:
+    result.add @[hoverContent.title, ru""]
+
+  for line in hoverContent.description:
+    result.add line
+
+proc textDocumentHover*(
+  c: LspClient,
+  id: int,
+  path: string,
+  position: BufferPosition): LspHoverResult =
+    ## Send a textDocument/hover request to the server.
+    ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_hover
+
+    let params = %* initHoverParams(path, position.toLspPosition)
+    let r = c.send(id, "textDocument/hover", params)
+    if r.isErr:
+      return LspHoverResult.err fmt"lsp: textDocument/hover request failed: {r.error}"
+
+    if r.get.isLspError:
+      return LspHoverResult.err fmt"lsp: textDocument/hover request failed: {$r.error}"
+
+    try:
+      return LspHoverResult.ok r.get["result"].to(Hover)
+    except CatchableError as e:
+      let msg = fmt"json to Hover failed {e.msg}"
+      return LspHoverResult.err fmt"lsp: textDocument/hover request failed: {msg}"

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -22,7 +22,11 @@
 
 import std/[strformat, strutils, json, options, os, osproc]
 import pkg/results
-import ../[appinfo, independentutils, unicodeext]
+
+import ../appinfo
+import ../independentutils
+import ../unicodeext
+
 import protocol/types
 import jsonrpc
 

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -20,7 +20,7 @@
 # NOTE: Language Server Protocol Specification - 3.17
 # https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
 
-import std/[strformat, strutils, json, options, os, osproc]
+import std/[strformat, strutils, json, options, os]
 import pkg/results
 import pkg/asynctools/asyncproc
 

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -204,7 +204,7 @@ proc initialize*(
     ## Send a initialize request to the server and check server capabilities.
     ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialize
 
-    if c.serverProcess == nil:
+    if not c.serverProcess.running:
       return LspInitializeResult.err fmt"lsp: server crashed"
 
     let params = %* initParams
@@ -231,7 +231,7 @@ proc initialized*(c: LspClient): LspInitializedResult =
   ## Send a initialized notification to the server.
   ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initialized
 
-  if c.serverProcess == nil:
+  if not c.serverProcess.running:
     return LspInitializeResult.err fmt"lsp: server crashed"
 
   let params = %* {}
@@ -248,7 +248,7 @@ proc shutdown*(c: LspClient, id: int): LspShutdownResult =
   ## Send a shutdown request to the server.
   ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#shutdown
 
-  if c.serverProcess == nil:
+  if not c.serverProcess.running:
     return LspShutdownResult.err fmt"lsp: server crashed"
 
   let r = c.send(id, "shutdown", %*{})
@@ -266,7 +266,7 @@ proc workspaceDidChangeConfiguration*(
     ## Send a workspace/didChangeConfiguration notification to the server.
     ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspace_didChangeConfiguration
 
-    if c.serverProcess == nil:
+    if not c.serverProcess.running:
       return LspWorkspaceDidChangeConfigurationResult.err fmt"lsp: server crashed"
 
     let params = %* DidChangeConfigurationParams()
@@ -295,7 +295,7 @@ proc textDocumentDidOpen*(
     ## Send a textDocument/didOpen notification to the server.
     ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen
 
-    if c.serverProcess == nil:
+    if not c.serverProcess.running:
       return LspDidOpenTextDocumentResult.err fmt"lsp: server crashed"
 
     let params = %* initTextDocumentDidOpenParams(
@@ -327,7 +327,7 @@ proc textDocumentDidChange*(
     ## Send a textDocument/didChange notification to the server.
     ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didChange
 
-    if c.serverProcess == nil:
+    if not c.serverProcess.running:
       return LspDidChangeTextDocumentResult.err fmt"lsp: server crashed"
 
     let params = %* initTextDocumentDidChangeParams(version, path, text)
@@ -350,7 +350,7 @@ proc textDocumentDidClose*(
     ## Send a textDocument/didClose notification to the server.
     ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didClose
 
-    if c.serverProcess == nil:
+    if not c.serverProcess.running:
       return LspDidCloseTextDocumentResult.err fmt"lsp: server crashed"
 
     let params = %* initTextDocumentDidClose(text)
@@ -380,7 +380,7 @@ proc textDocumentHover*(
     if not c.capabilities.hover:
       return LspHoverResult.err fmt"lsp: textDocument/hover unavailable"
 
-    if c.serverProcess == nil:
+    if not c.serverProcess.running:
       return LspHoverResult.err fmt"lsp: server crashed"
 
     let params = %* initHoverParams(path, position.toLspPosition)

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -278,19 +278,17 @@ proc workspaceDidChangeConfiguration*(
     return LspWorkspaceDidChangeConfigurationResult.ok ()
 
 proc initTextDocumentDidOpenParams(
-  version: int,
   uri, languageId, text: string): DidOpenTextDocumentParams {.inline.} =
 
     DidOpenTextDocumentParams(
       textDocument: TextDocumentItem(
         uri: uri,
         languageId: languageId,
-        version: version,
+        version: 1,
         text: text))
 
 proc textDocumentDidOpen*(
   c: LspClient,
-  version: int,
   path, languageId, text: string): LspDidOpenTextDocumentResult =
     ## Send a textDocument/didOpen notification to the server.
     ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_didOpen
@@ -299,7 +297,6 @@ proc textDocumentDidOpen*(
       return LspDidOpenTextDocumentResult.err fmt"lsp: server crashed"
 
     let params = %* initTextDocumentDidOpenParams(
-      version,
       path.pathToUri,
       languageId,
       text)

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -123,14 +123,14 @@ proc parseLspError*(res: JsonNode): LspErrorParseResult =
   except:
     return LspErrorParseResult.err fmt"Invalid error: {$res}"
 
-proc initLspClient*(serverCommand: string): initLspClientResult =
+proc initLspClient*(command: string): initLspClientResult =
   ## Start a LSP server process and init streams.
 
   const
     WorkingDir = ""
     Env = nil
   let
-    commandSplit = serverCommand.split(' ')
+    commandSplit = command.split(' ')
     args =
       if commandSplit.len > 1: commandSplit[1 .. ^1]
       else: @[]

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -105,7 +105,7 @@ proc send(
   params: JsonNode): Future[JsonRpcResponseResult] {.async.} =
     ## Send a request to the LSP server and return a response.
 
-    await c.serverPipes.sendRequest(id, methodName, params)
+    return await c.serverPipes.sendRequest(id, methodName, params)
 
 proc notify(
   c: LspClient,
@@ -113,7 +113,7 @@ proc notify(
   params: JsonNode): Future[Result[(), string]] {.async.}  =
     ## Send a notification to the LSP server.
 
-    await c.serverPipes.input.sendNotify(methodName, params)
+    return await c.serverPipes.input.sendNotify(methodName, params)
 
 proc isLspError(res: JsonNode): bool {.inline.} = res.contains("error")
 

--- a/src/moepkg/lsp/jsonrpc.nim
+++ b/src/moepkg/lsp/jsonrpc.nim
@@ -62,13 +62,13 @@ proc readLine(s: Stream, timeout: int): Result[string, string] =
     d = initDuration(milliseconds = timeout)
     n = now()
   while now() - n < d:
-    sleep 100
-
     try:
       if not s.atEnd():
         return Result[string, string].ok s.readLine
     except CatchableError as e:
       return Result[string, string].err e.msg
+
+    sleep 100
 
   return Result[string, string].err "timeout"
 

--- a/src/moepkg/lsp/jsonrpc.nim
+++ b/src/moepkg/lsp/jsonrpc.nim
@@ -1,0 +1,169 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[streams, strformat, strutils, json, parseutils, options, logging,
+            times, os]
+import pkg/results
+import ../messagelog
+
+type
+  ReadFrameResult = Result[string, string]
+  JsonRpcResponseResult* = Result[JsonNode, string]
+
+  Streams* = object
+    input*, output*: Stream
+
+proc skipWhitespace(x: string, pos: int): int =
+  result = pos
+  while result < x.len and x[result] in Whitespace:
+    inc result
+
+proc isInvalidContentType(s: string, valueStart: int): bool {.inline.} =
+  s.find("utf-8", valueStart) == -1 and s.find("utf8", valueStart) == -1
+
+proc isValidJsonRpc(json: JsonNode): bool {.inline.} =
+  json.contains("jsonrpc")
+
+proc readLine(s: Stream, timeout: int): Result[string, string] =
+  ## readLine with timeout.
+
+  let
+    d = initDuration(milliseconds = timeout)
+    n = now()
+  while now() - n < d:
+    sleep 100
+    if not s.atEnd():
+      return Result[string, string].ok s.readLine
+
+  return Result[string, string].err "timeout"
+
+proc readFrame(s: Stream): ReadFrameResult =
+  ## Read text from the stream and return json node.
+
+  var contentLen = -1
+  var headerStarted = false
+
+  while true:
+    const Timeout = 1000
+    var ln = s.readLine(Timeout)
+    if ln.isErr:
+      debug "readLine Error!: " & ln.error
+      return ReadFrameResult.err ln.error
+
+    if ln.get.len != 0:
+      debug fmt"lsp: server res: {ln.get}"
+      addMessageLog fmt"lsp: server res: {ln.get}"
+
+      let sep = ln.get.find(':')
+      if sep == -1:
+        # Skip line if not json.
+        continue
+
+      headerStarted = true
+
+      let valueStart = ln.get.skipWhitespace(sep + 1)
+
+      case ln.get[0 ..< sep]
+        of "Content-Type":
+          if isInvalidContentType(ln.get, valueStart):
+            return ReadFrameResult.err "Only utf-8 is supported"
+        of "Content-Length":
+          if parseInt(ln.get, contentLen, valueStart) == 0:
+            return ReadFrameResult.err fmt"Invalid Content-Length: {ln.get.substr(valueStart)}"
+        else:
+          # Unrecognized headers are ignored
+          discard
+    elif not headerStarted:
+      continue
+    else:
+      if contentLen != -1:
+        return ReadFrameResult.ok s.readStr(contentLen)
+      else:
+        return ReadFrameResult.err "Missing Content-Length header"
+
+proc read*(s: Stream): JsonRpcResponseResult =
+  ## Return a json-rpc response from the stream.
+
+  let r = s.readFrame
+  if r.isErr:
+    return JsonRpcResponseResult.err r.error
+
+  var res: JsonNode
+  try:
+    res = r.get.parseJson
+  except CatchableError as e:
+    return JsonRpcResponseResult.err e.msg
+
+  if res.isValidJsonRpc:
+    return JsonRpcResponseResult.ok res
+  else:
+    return JsonRpcResponseResult.err fmt"Invalid jsonrpc: {$res}"
+
+proc send(s: Stream, frame: string) =
+  ## Write json-rpc message to the stream.
+
+  let req = "Content-Length: " & $frame.len & "\r\n\r\n" & frame
+
+  debug fmt"lsp: client req: {req}"
+  addMessageLog fmt"lsp: client req: {req}"
+
+  s.write req
+  s.flush
+
+proc newReqest(id: int, methodName: string, params: JsonNode): string =
+  result = newStringOfCap(1024)
+  let req = %* {
+    "jsonrpc": "2.0",
+    "id": id,
+    "method": methodName,
+    "params": params
+  }
+  result.toUgly(req)
+
+proc sendRequest*(
+  s: Streams,
+  id: int,
+  methodName: string,
+  params: JsonNode): JsonRpcResponseResult =
+    ## Send a request and return a response.
+
+    let req = newReqest(id, methodName, params)
+    s.input.send(req)
+
+    let res = s.output.read
+    if res.isOk:
+      return JsonRpcResponseResult.ok res.get
+    else:
+      return JsonRpcResponseResult.err res.error
+
+proc newNotify(methodName: string, params: JsonNode): string =
+  result = newStringOfCap(1024)
+  let req = %* {
+    "jsonrpc": "2.0",
+    "method": methodName,
+    "params": params
+  }
+  result.toUgly(req)
+
+proc sendNotify*(s: Streams, methodName: string, params: JsonNode) =
+  ## Send a notification.
+  ## No response to the notification. Also, no `id` is required in the request.
+
+  let notify = newNotify(methodName, params)
+  s.input.send(notify)

--- a/src/moepkg/lsp/jsonrpc.nim
+++ b/src/moepkg/lsp/jsonrpc.nim
@@ -147,7 +147,7 @@ proc read*(output: AsyncPipe): JsonRpcResponseResult =
     return JsonRpcResponseResult.err fmt"Invalid jsonrpc: {$res}"
 
 proc write(input: AsyncPipe, buffer: string) {.async.} =
-  discard await input.write(cast[pointer](addr buffer[0]), buffer.len)
+  discard await input.write(cast[pointer](buffer[0].unsafeAddr), buffer.len)
 
 proc send(
   input: AsyncPipe,

--- a/src/moepkg/lsp/protocol/enums.nim
+++ b/src/moepkg/lsp/protocol/enums.nim
@@ -1,0 +1,188 @@
+## Copyright (c) 2023 The core Nim team
+## https://github.com/nim-lang/langserver
+
+# NOTE: Language Server Protocol Specification - 3.17
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+
+type
+  ErrorCode* = enum
+    RequestCancelled = -32800 # All the other error codes are from JSON-RPC
+    ParseError = -32700,
+    InternalError = -32603,
+    InvalidParams = -32602,
+    MethodNotFound = -32601,
+    InvalidRequest = -32600,
+    ServerErrorStart = -32099,
+    ServerNotInitialized = -32002,
+    ServerErrorEnd = -32000,
+
+# Anything below here comes from the LSP specification
+type
+  LanguageId* {.pure.} = enum
+    abap = "abap "
+    bat = "bat"
+    bibtex = "bibtex"
+    clojure = "clojure "
+    coffeescript = "coffeescript"
+    c = "c"
+    cpp = "cpp"
+    csharp = "csharp"
+    css = "css"
+    diff = "diff"
+    dart = "dart"
+    dockerfile = "dockerfile"
+    elixir = "elixir"
+    erlang = "erlang"
+    fsharp = "fsharp"
+    gitCommit = "git-commit"
+    gitRebase = "git-rebase"
+    go = "go"
+    groovry = "groovry"
+    handlebars = "handlebars"
+    haskell = "haskell"
+    html = "html"
+    ini = "ini"
+    java = "java"
+    javascript = "javascript"
+    json = "json"
+    latex = "latex"
+    less = "less"
+    lua = "lua"
+    makefile = "makefile"
+    nim = "nim"
+    objectiveC = "objective-c"
+    objectiveCpp = "objective-cpp"
+    perl = "perl"
+    perl6 = "perl6"
+    php= "php"
+    powershell = "powershell"
+    pug = "jade"
+    python = "python"
+    r = "r"
+    razor = "razor"
+    ruby = "ruby"
+    rust = "rust"
+    scss = "scss"
+    scala = "scala"
+    shaderLab = "shaderlab"
+    bash = "shellscript"
+    sql = "sql"
+    swift = "swift"
+    typeScript = "typescript"
+    typeScriptReact = "typescriptreact"
+    tex = "tex"
+    visualBasic = "vb"
+    xml = "xml"
+    xsl = "xsl"
+    yaml = "yaml"
+
+  DiagnosticSeverity* {.pure.} = enum
+    Error = 1,
+    Warning = 2,
+    Information = 3,
+    Hint = 4
+
+  SymbolKind* {.pure.} = enum
+    File = 1,
+    Module = 2,
+    Namespace = 3,
+    Package = 4,
+    Class = 5,
+    Method = 6,
+    Property = 7,
+    Field = 8,
+    Constructor = 9,
+    Enum = 10,
+    Interface = 11,
+    Function = 12,
+    Variable = 13,
+    Constant = 14,
+    String = 15,
+    Number = 16,
+    Boolean = 17,
+    Array = 18,
+    Object = 19,
+    Key = 20,
+    Null = 21,
+    EnumMember = 22,
+    Struct = 23,
+    Event = 24,
+    Operator = 25,
+    TypeParameter = 26
+
+  CompletionItemKind* {.pure.} = enum
+    Text = 1,
+    Method = 2,
+    Function = 3,
+    Constructor = 4,
+    Field = 5,
+    Variable = 6,
+    Class = 7,
+    Interface = 8,
+    Module = 9,
+    Property = 10,
+    Unit = 11,
+    Value = 12,
+    Enum = 13,
+    Keyword = 14,
+    Snippet = 15,
+    Color = 16,
+    File = 17,
+    Reference = 18,
+    Folder = 19,
+    EnumMember = 20,
+    Constant = 21,
+    Struct = 22,
+    Event = 23,
+    Operator = 24,
+    TypeParameter = 25
+
+  TextDocumentSyncKind* {.pure.} = enum
+    None = 0,
+    Full = 1,
+    Incremental = 2
+
+  MessageType* {.pure.} = enum
+    Error = 1,
+    Warning = 2,
+    Info = 3,
+    Log = 4
+
+  FileChangeType* {.pure.} = enum
+    Created = 1,
+    Changed = 2,
+    Deleted = 3
+
+  WatchKind* {.pure.} = enum
+    Create = 1,
+    Change = 2,
+    Delete = 4
+
+  TextDocumentSaveReason* {.pure.} = enum
+    Manual = 1,
+    AfterDelay = 2,
+    FocusOut = 3
+
+  CompletionTriggerKind* {.pure.} = enum
+    Invoked = 1,
+    TriggerCharacter = 2,
+    TriggerForIncompleteCompletions = 3
+
+  InsertTextFormat* {.pure.} = enum
+    PlainText = 1,
+    Snippet = 2
+
+  DocumentHighlightKind* {.pure.} = enum
+    Text = 1,
+    Read = 2,
+    Write = 3
+
+  SignatureHelpTriggerKind* {.pure.} = enum
+    Invoked = 1,
+    TriggerCharacter = 2,
+    ContentChange = 3
+
+  TraceValue* {.pure.} = enum
+    off
+    messages
+    verbose

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -95,7 +95,7 @@ type
   InitializeParams* = ref object of RootObj
     processId*: OptionalNode # int or float
     clientInfo*: Option[ClientInfo]
-    locale: Option[string]
+    locale*: Option[string]
     rootPath*: Option[string]
     rootUri*: Option[string]
     initializationOptions*: OptionalNode

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -437,9 +437,11 @@ type
     contentChanges*: seq[TextDocumentContentChangeEvent]
 
   TextDocumentContentChangeEvent* = ref object of RootObj
-    range*: Option[Range]
-    rangeLength*: Option[int]
     text*: string
+    #range*: Option[Range]
+    #rangeLength*: Option[int]
+      # If `range` and `rangeLength` exist, nimlsp considers it to be an
+      # invalid notification.
 
   TextDocumentChangeRegistrationOptions* = ref object of TextDocumentRegistrationOptions
     syncKind*: int

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -1,0 +1,639 @@
+## Copyright (c) 2023 The core Nim team
+## https://github.com/nim-lang/langserver
+
+# NOTE: Language Server Protocol Specification - 3.17
+# https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/
+
+import std/[json, options]
+import enums
+
+type
+  OptionalSeq*[T] = Option[seq[T]]
+  OptionalNode = Option[JsonNode]
+
+  CancelParams* = ref object of RootObj
+    id*: OptionalNode
+
+  Position* = ref object of RootObj
+    line*: int
+    character*: int
+
+  Range* = ref object of RootObj
+    start*: Position
+    `end`*: Position
+
+  Location* = ref object of RootObj
+    uri*: string
+    `range`*: Range
+
+  Diagnostic* = ref object of RootObj
+    `range`*: Range
+    severity*: Option[int]
+    code*: OptionalNode # int or string
+    source*: Option[string]
+    message*: string
+    relatedInformation*: OptionalSeq[DiagnosticRelatedInformation]
+
+  DiagnosticRelatedInformation* = ref object of RootObj
+    location*: Location
+    message*: string
+
+  Command* = ref object of RootObj
+    title*: string
+    command*: string
+    arguments*: OptionalNode
+
+  CodeAction* = ref object of RootObj
+    command*: Command
+    title*: string
+    kind*: string
+
+  TextEdit* = ref object of RootObj
+    `range`*: Range
+    newText*: string
+
+  TextDocumentEdit* = ref object of RootObj
+    textDocument*: VersionedTextDocumentIdentifier
+    edits*: OptionalSeq[TextEdit]
+
+  WorkspaceEdit* = ref object of RootObj
+    changes*: OptionalNode
+    documentChanges*: OptionalSeq[TextDocumentEdit]
+
+  TextDocumentIdentifier* = ref object of RootObj
+    uri*: string
+
+  TextDocumentItem* = ref object of RootObj
+    uri*: string
+    languageId*: string
+    version*: int
+    text*: string
+
+  VersionedTextDocumentIdentifier* = ref object of TextDocumentIdentifier
+    version*: OptionalNode # int or float
+
+  TextDocumentPositionParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    position*: Position
+
+  ExpandTextDocumentPositionParams* = ref object of TextDocumentPositionParams
+    level*: Option[int]
+
+  DocumentFilter* = ref object of RootObj
+    language*: Option[string]
+    scheme*: Option[string]
+    pattern*: Option[string]
+
+  MarkupContent* = ref object of RootObj
+    kind*: string
+    value*: string
+
+  ClientInfo* = ref object of RootObj
+    name*: string
+    version*: Option[string]
+
+  InitializeParams* = ref object of RootObj
+    processId*: OptionalNode # int or float
+    clientInfo*: Option[ClientInfo]
+    locale: Option[string]
+    rootPath*: Option[string]
+    rootUri*: Option[string]
+    initializationOptions*: OptionalNode
+    capabilities*: ClientCapabilities
+    trace*: Option[string]
+    workspaceFolders*: OptionalSeq[WorkspaceFolder]
+
+  WorkDoneProgressBegin* = ref object of RootObj
+    kind*: string
+    title*: string
+    cancellable*: Option[bool]
+    message*: Option[string]
+    percentage*: Option[int]
+
+  WorkDoneProgressReport* = ref object of RootObj
+    kind*: string
+    cancellable*: Option[bool]
+    message*: Option[string]
+    percentage*: Option[int]
+
+  WorkDoneProgressEnd* = ref object of RootObj
+    kind*: string
+    message*: Option[string]
+
+  ProgressParams* = ref object of RootObj
+    token*: string # can be also int but the server will send strings
+    value*: OptionalNode
+
+  ConfigurationItem* = ref object of RootObj
+    scopeUri*: Option[string]
+    section*: Option[string]
+
+  ConfigurationParams* = ref object of RootObj
+    items*: seq[ConfigurationItem]
+
+  WorkspaceEditCapability* = ref object of RootObj
+    documentChanges*: Option[bool]
+
+  DidChangeConfigurationCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  DidChangeWatchedFilesCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  SymbolKindCapability* = ref object of RootObj
+    valueSet*: OptionalSeq[int]
+
+  SymbolCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+    symbolKind*: Option[SymbolKindCapability]
+
+  ExecuteCommandCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  WorkspaceClientCapabilities* = ref object of RootObj
+    applyEdit*: Option[bool]
+    workspaceEdit*: Option[WorkspaceEditCapability]
+    didChangeConfiguration*: Option[DidChangeConfigurationCapability]
+    didChangeWatchedFiles*: Option[DidChangeWatchedFilesCapability]
+    symbol*: Option[SymbolCapability]
+    executeCommand*: Option[ExecuteCommandCapability]
+    workspaceFolders*: Option[bool]
+    configuration*: Option[bool]
+
+  SynchronizationCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+    willSave*: Option[bool]
+    willSaveWaitUntil*: Option[bool]
+    didSave*: Option[bool]
+
+  CompletionItemCapability* = ref object of RootObj
+    snippetSupport*: Option[bool]
+    commitCharactersSupport*: Option[bool]
+    documentFormat*: OptionalSeq[string]
+    deprecatedSupport*: Option[bool]
+
+  CompletionItemKindCapability* = ref object of RootObj
+    valueSet*: OptionalSeq[int]
+
+  CompletionCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+    completionItem*: Option[CompletionItemCapability]
+    completionItemKind*: Option[CompletionItemKindCapability]
+    contextSupport*: Option[bool]
+
+  HoverCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+    contentFormat*: OptionalSeq[string]
+
+  SignatureInformationCapability* = ref object of RootObj
+    documentationFormat*: OptionalSeq[string]
+
+  SignatureHelpCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+    signatureInformation*: Option[SignatureInformationCapability]
+
+  ReferencesCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  DocumentHighlightCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  DocumentSymbolCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+    symbolKind*: Option[SymbolKindCapability]
+
+  FormattingCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  RangeFormattingCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  OnTypeFormattingCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  DefinitionCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  TypeDefinitionCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  ImplementationCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  CodeActionCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  CodeLensCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  DocumentLinkCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  ColorProviderCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  RenameCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+    prepareSupport*: Option[bool]
+
+  PublishDiagnosticsCapability* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
+  TextDocumentClientCapabilities* = ref object of RootObj
+    synchronization*: Option[SynchronizationCapability]
+    completion*: Option[CompletionCapability]
+    hover*: Option[HoverCapability]
+    signatureHelp*: Option[SignatureHelpCapability]
+    references*: Option[ReferencesCapability]
+    documentHighlight*: Option[DocumentHighlightCapability]
+    documentSymbol*: Option[DocumentSymbolCapability]
+    formatting*: Option[FormattingCapability]
+    rangeFormatting*: Option[RangeFormattingCapability]
+    onTypeFormatting*: Option[OnTypeFormattingCapability]
+    definition*: Option[DefinitionCapability]
+    typeDefinition*: Option[TypeDefinitionCapability]
+    implementation*: Option[ImplementationCapability]
+    codeAction*: Option[CodeActionCapability]
+    codeLens*: Option[CodeLensCapability]
+    documentLink*: Option[DocumentLinkCapability]
+    colorProvider*: Option[ColorProviderCapability]
+    rename*: Option[RenameCapability]
+    publishDiagnostics*: Option[PublishDiagnosticsCapability]
+
+  WindowCapabilities* = ref object of RootObj
+    workDoneProgress*: Option[bool]
+
+  ClientCapabilities* = ref object of RootObj
+    workspace*: Option[WorkspaceClientCapabilities]
+    textDocument*: Option[TextDocumentClientCapabilities]
+    window*: Option[WindowCapabilities]
+    # experimental*: OptionalNode
+
+  WorkspaceFolder* = ref object of RootObj
+    uri*: string
+    name*: string
+
+  InitializeResult* = ref object of RootObj
+    capabilities*: ServerCapabilities
+
+  InitializeError* = ref object of RootObj
+    retry*: bool
+
+  CompletionOptions* = ref object of RootObj
+    resolveProvider*: Option[bool]
+    triggerCharacters*: OptionalSeq[string]
+
+  SignatureHelpOptions* = ref object of RootObj
+    triggerCharacters*: OptionalSeq[string]
+
+  CodeLensOptions* = ref object of RootObj
+    resolveProvider*: Option[bool]
+
+  DocumentOnTypeFormattingOptions* = ref object of RootObj
+    firstTriggerCharacter*: string
+    moreTriggerCharacter*: OptionalSeq[string]
+
+  DocumentLinkOptions* = ref object of RootObj
+    resolveProvider*: Option[bool]
+
+  ExecuteCommandOptions* = ref object of RootObj
+   commands*: OptionalSeq[string]
+
+  SaveOptions* = ref object of RootObj
+    includeText*: Option[bool]
+
+  ColorProviderOptions* = ref object of RootObj
+
+  TextDocumentSyncOptions* = ref object of RootObj
+    openClose*: Option[bool]
+    change*: Option[TextDocumentSyncKind]
+
+  StaticRegistrationOptions* = ref object of RootObj
+    id*: Option[string]
+
+  WorkspaceFolderCapability* = ref object of RootObj
+    supported*: Option[bool]
+    changeNotifications*: Option[OptionalNode] # string or bool
+
+  WorkspaceCapability* = ref object of RootObj
+    workspaceFolders*: Option[WorkspaceFolderCapability]
+
+  TextDocumentRegistrationOptions* = ref object of RootObj
+    documentSelector*: OptionalSeq[DocumentFilter]
+
+  TextDocumentAndStaticRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    id*: Option[string]
+
+  RenameOptions* = object
+    # We support rename, but need to change json
+    # depending on if the client supports prepare or not
+    supportsPrepare*: bool
+
+  ServerCapabilities* = ref object of RootObj
+    textDocumentSync*: OptionalNode # TextDocumentSyncOptions or int
+    hoverProvider*: Option[bool]
+    completionProvider*: CompletionOptions
+    signatureHelpProvider*: SignatureHelpOptions
+    definitionProvider*: Option[bool]
+    declarationProvider*: Option[bool]
+    typeDefinitionProvider*: Option[bool]
+    implementationProvider*: OptionalNode # bool or TextDocumentAndStaticRegistrationOptions
+    referencesProvider*: Option[bool]
+    documentHighlightProvider*: Option[bool]
+    documentSymbolProvider*: Option[bool]
+    workspaceSymbolProvider*: Option[bool]
+    codeActionProvider*: Option[bool]
+    codeLensProvider*: Option[CodeLensOptions]
+    documentFormattingProvider*: Option[bool]
+    documentRangeFormattingProvider*: Option[bool]
+    documentOnTypeFormattingProvider*: Option[DocumentOnTypeFormattingOptions]
+    renameProvider*: JsonNode # bool or RenameOptions
+    documentLinkProvider*: Option[DocumentLinkOptions]
+    colorProvider*: Option[OptionalNode] # bool or ColorProviderOptions or TextDocumentAndStaticRegistrationOptions
+    executeCommandProvider*: Option[ExecuteCommandOptions]
+    workspace*: Option[WorkspaceCapability]
+    experimental*: Option[OptionalNode]
+
+  InitializedParams* = ref object of RootObj
+    DUMMY*: Option[nil]
+
+  ShowMessageParams* = ref object of RootObj
+    `type`*: int
+    message*: string
+
+  MessageActionItem* = ref object of RootObj
+    title*: string
+
+  ShowMessageRequestParams* = ref object of RootObj
+    `type`*: int
+    message*: string
+    actions*: OptionalSeq[MessageActionItem]
+
+  LogMessageParams* = ref object of RootObj
+    `type`*: int
+    message*: string
+
+  Registration* = ref object of RootObj
+    id*: string
+    `method`*: string
+    registrationOptions*: OptionalNode
+
+  RegistrationParams* = ref object of RootObj
+    registrations*: OptionalSeq[Registration]
+
+  Unregistration* = ref object of RootObj
+    id*: string
+    `method`*: string
+
+  UnregistrationParams* = ref object of RootObj
+    unregistrations*: OptionalSeq[Unregistration]
+
+  WorkspaceFoldersChangeEvent* = ref object of RootObj
+    added*: OptionalSeq[WorkspaceFolder]
+    removed*: OptionalSeq[WorkspaceFolder]
+
+  DidChangeWorkspaceFoldersParams* = ref object of RootObj
+    event*: WorkspaceFoldersChangeEvent
+
+  DidChangeConfigurationParams* = ref object of RootObj
+    settings*: OptionalNode
+
+  FileEvent* = ref object of RootObj
+    uri*: string
+    `type`*: int
+
+  DidChangeWatchedFilesParams* = ref object of RootObj
+    changes*: OptionalSeq[FileEvent]
+
+  DidChangeWatchedFilesRegistrationOptions* = ref object of RootObj
+    watchers*: OptionalSeq[FileSystemWatcher]
+
+  FileSystemWatcher* = ref object of RootObj
+    globPattern*: string
+    kind*: Option[int]
+
+  WorkspaceSymbolParams* = ref object of RootObj
+    query*: string
+
+  ExecuteCommandParams* = ref object of RootObj
+    command*: string
+    arguments*: seq[JsonNode]
+
+  ExecuteCommandRegistrationOptions* = ref object of RootObj
+    commands*: OptionalSeq[string]
+
+  ApplyWorkspaceEditParams* = ref object of RootObj
+    label*: Option[string]
+    edit*: WorkspaceEdit
+
+  ApplyWorkspaceEditResponse* = ref object of RootObj
+    applied*: bool
+
+  DidOpenTextDocumentParams* = ref object of RootObj
+    textDocument*: TextDocumentItem
+
+  DidChangeTextDocumentParams* = ref object of RootObj
+    textDocument*: VersionedTextDocumentIdentifier
+    contentChanges*: seq[TextDocumentContentChangeEvent]
+
+  TextDocumentContentChangeEvent* = ref object of RootObj
+    range*: Option[Range]
+    rangeLength*: Option[int]
+    text*: string
+
+  TextDocumentChangeRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    syncKind*: int
+
+  WillSaveTextDocumentParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    reason*: int
+
+  DidSaveTextDocumentParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    text*: Option[string]
+
+  TextDocumentSaveRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    includeText*: Option[bool]
+
+  DidCloseTextDocumentParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+
+  PublishDiagnosticsParams* = ref object of RootObj
+    uri*: string
+    diagnostics*: OptionalSeq[Diagnostic]
+
+  CompletionParams* = ref object of TextDocumentPositionParams
+    context*: Option[CompletionContext]
+
+  CompletionContext* = ref object of RootObj
+    triggerKind*: int
+    triggerCharacter*: Option[string]
+
+  CompletionList* = ref object of RootObj
+    isIncomplete*: bool
+    `items`*: OptionalSeq[CompletionItem]
+
+  CompletionItem* = ref object of RootObj
+    label*: string
+    kind*: Option[int]
+    detail*: Option[string]
+    documentation*: OptionalNode #Option[string or MarkupContent]
+    deprecated*: Option[bool]
+    preselect*: Option[bool]
+    sortText*: Option[string]
+    filterText*: Option[string]
+    insertText*: Option[string]
+    insertTextFormat*: Option[int]
+    textEdit*: Option[TextEdit]
+    additionalTextEdits*: Option[TextEdit]
+    commitCharacters*: OptionalSeq[string]
+    command*: Option[Command]
+    data*: OptionalNode
+
+  CompletionRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    triggerCharacters*: OptionalSeq[string]
+    resolveProvider*: Option[bool]
+
+  MarkedStringOption* = ref object of RootObj
+    language*: string
+    value*: string
+
+  Hover* = ref object of RootObj
+    contents*: OptionalNode # string or MarkedStringOption or [string] or [MarkedStringOption] or MarkupContent
+    range*: Option[Range]
+
+  HoverParams* = ref object of TextDocumentPositionParams
+
+  SignatureHelp* = ref object of RootObj
+    signatures*: OptionalSeq[SignatureInformation]
+    activeSignature*: Option[int]
+    activeParameter*: Option[int]
+
+  SignatureInformation* = ref object of RootObj
+    label*: string
+    documentation*: Option[string or MarkupContent]
+    parameters*: OptionalSeq[ParameterInformation]
+
+  ParameterInformation* = ref object of RootObj
+    label*: string
+    documentation*: Option[string or MarkupContent]
+
+  SignatureHelpRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    triggerCharacters*: OptionalSeq[string]
+
+  ReferenceParams* = ref object of TextDocumentPositionParams
+    context*: ReferenceContext
+
+  ReferenceContext* = ref object of RootObj
+    includeDeclaration*: bool
+
+  DocumentHighlight* = ref object of RootObj
+    `range`*: Range
+    kind*: Option[int]
+
+  DocumentSymbolParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+
+  SymbolInformation* = ref object of RootObj
+    name*: string
+    kind*: int
+    deprecated*: Option[bool]
+    location*: Location
+    containerName*: Option[string]
+
+  CodeActionParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    `range`*: Range
+    context*: CodeActionContext
+
+  CodeActionContext* = ref object of RootObj
+    diagnostics*: OptionalSeq[Diagnostic]
+
+  CodeLensParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+
+  CodeLens* = ref object of RootObj
+    `range`*: Range
+    command*: Option[Command]
+    data*: OptionalNode
+
+  CodeLensRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    resolveProvider*: Option[bool]
+
+  DocumentLinkParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+
+  DocumentLink* = ref object of RootObj
+    `range`*: Range
+    target*: Option[string]
+    data*: OptionalNode
+
+  DocumentLinkRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    resolveProvider*: Option[bool]
+
+  DocumentColorParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+
+  ColorInformation* = ref object of RootObj
+    `range`*: Range
+    color*: Color
+
+  Color* = ref object of RootObj
+    red*: int
+    green*: int
+    blue*: int
+    alpha*: int
+
+  ColorPresentationParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    color*: Color
+    `range`*: Range
+
+  ColorPresentation* = ref object of RootObj
+    label*: string
+    textEdit*: Option[TextEdit]
+    additionalTextEdits*: OptionalSeq[TextEdit]
+
+  DocumentFormattingParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    options*: OptionalNode
+
+  DocumentRangeFormattingParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    `range`*: Range
+    options*: OptionalNode
+
+  DocumentOnTypeFormattingParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    position*: Position
+    ch*: string
+    options*: OptionalNode
+
+  DocumentOnTypeFormattingRegistrationOptions* = ref object of TextDocumentRegistrationOptions
+    firstTriggerCharacter*: string
+    moreTriggerCharacter*: OptionalSeq[string]
+
+  RenameParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    position*: Position
+    newName*: string
+
+  PrepareRenameParams* = ref object of RootObj
+    textDocument*: TextDocumentIdentifier
+    position*: Position
+
+  PrepareRenameResponse* = ref object of RootObj
+    defaultBehaviour*: bool
+
+  SignatureHelpContext* = ref object of RootObj
+    triggerKind*: int
+    triggerCharacter*: Option[string]
+    isRetrigger*: bool
+    activeSignatureHelp*: SignatureHelp
+
+  SignatureHelpParams* = ref object of TextDocumentPositionParams
+    context*: SignatureHelpContext
+
+  ExpandResult* = ref object of RootObj
+    range*: Range
+    content*: string

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -1,0 +1,71 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[strutils, json]
+import pkg/results
+
+import ../independentutils
+import ../unicodeext
+
+import protocol/[enums, types]
+
+type
+  LspPosition* = types.Position
+
+  HoverContent* = object
+    title*: Runes
+    description*: seq[Runes]
+    range*: BufferRange
+
+proc toLspPosition*(p: BufferPosition): LspPosition {.inline.} =
+  LspPosition(line: p.line, character: p.column)
+
+proc parseTraceValue*(s: string): Result[TraceValue, string] =
+  try:
+    return Result[TraceValue, string].ok parseEnum[TraceValue](s)
+  except ValueError:
+    return Result[TraceValue, string].err "Invalid value"
+
+proc toHoverContent*(hover: Hover): HoverContent =
+  let contents = %*hover.contents
+  case contents.kind:
+    of JArray:
+      if contents.len == 1:
+        if contents[0].contains("value"):
+          result.description = contents[0]["value"].getStr.splitLines.toSeqRunes
+      else:
+        if contents[0].contains("value"):
+          result.title = contents[0]["value"].getStr.toRunes
+
+        for i in 1 ..< contents.len:
+          if contents[i].contains("value"):
+            result.description.add contents[i]["value"].getStr.splitLines.toSeqRunes
+            if i < contents.len - 1: result.description.add ru""
+    else:
+      result.description = contents["value"].getStr.splitLines.toSeqRunes
+
+  let range = %*hover.range
+  result.range.first = BufferPosition(
+    line: range["start"]["line"].getInt,
+    column: range["start"]["character"].getInt)
+  result.range.last = BufferPosition(
+    line: range["end"]["line"].getInt,
+    column: range["end"]["character"].getInt)
+
+

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -292,7 +292,7 @@ proc commandLineLoop*(status: var EditorStatus): Option[Rune] =
 
   while not isCancel:
     if suggestWin.isSome:
-        # Update suggestion window and command line.
+      # Update suggestion window and command line.
 
       suggestList.updateSuggestions
       if suggestList.suggestions.len == 0:

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -253,7 +253,7 @@ proc commandLineLoop*(status: var EditorStatus): Option[Rune] =
 
   proc openSuggestWindow(
     commandLine: var CommandLine,
-    suggestList: var SuggestList): Option[Window] =
+    suggestList: var SuggestList): Option[PopupWindow] =
       ## If there is only one candidate, insert it without opening a window.
 
       suggestList = commandLine.buffer.initSuggestList
@@ -262,9 +262,8 @@ proc commandLineLoop*(status: var EditorStatus): Option[Rune] =
       elif suggestList.suggestions.len > 1:
         return tryOpenSuggestWindow()
 
-  proc closeSuggestWindow(suggestWin: var Option[Window]) =
-    suggestWin.get.delete
-    suggestWin = none(Window)
+  proc closeSuggestWindow(suggestWin: var Option[PopupWindow]) {.inline.} =
+    suggestWin.get.close
 
   if currentBufStatus.isSearchMode:
     status.searchHistory.add "".toRunes
@@ -276,7 +275,7 @@ proc commandLineLoop*(status: var EditorStatus): Option[Rune] =
     isCancel = false
 
     # TODO: Change type to `SuggestionWindow`.
-    suggestWin = none(Window)
+    suggestWin = none(PopupWindow)
 
     # Use when Ex mode and search mode.
     # TODO: Move
@@ -332,8 +331,7 @@ proc commandLineLoop*(status: var EditorStatus): Option[Rune] =
     if isEscKey(key) or isControlC(key):
       isCancel = true
       if suggestWin.isSome:
-        suggestWin.get.delete
-        suggestWin = none(Window)
+        suggestWin.closeSuggestWindow
     elif isEnterKey(key):
       if suggestWin.isSome:
         suggestWin.closeSuggestWindow

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -234,6 +234,11 @@ proc writeInRecordingOperations*(
     commandLine.writeMessageOnCommandLine(mess)
     addMessageLog mess
 
+proc writeLspInitialized*(commandLine: var CommandLine, serverCommand: Runes) =
+  let mess = fmt"LSP client initialized: {$serverCommand}"
+  commandLine.writeMessageOnCommandLine(mess)
+  addMessageLog mess
+
 proc writeAutoBackupFailedMessage*(
   commandLine: var CommandLine,
   filename: Runes,
@@ -307,8 +312,11 @@ proc writeReadonlyModeWarning*(commandLine: var CommandLine) {.inline.} =
 proc writeManualCommandError*(
   commandLine: var CommandLine,
   message: string) {.inline.} =
+
     let mess = fmt"Error: No manual entry for {message}"
-    commandLine.writeMessageOnCommandLine(mess, EditorColorPairIndex.errorMessage)
+    commandLine.writeMessageOnCommandLine(
+      mess,
+      EditorColorPairIndex.errorMessage)
     addMessageLog mess
 
 proc writeSyntaxCheckError*(
@@ -316,17 +324,33 @@ proc writeSyntaxCheckError*(
   message: string) {.inline.} =
 
     let mess = fmt"Error: Syntax check failed: {message}"
-    commandLine.writeMessageOnCommandLine(mess, EditorColorPairIndex.errorMessage)
-    addMessageLog mess
-
-proc writeGitInfoUpdateError*(commandLine: var CommandLine, message: string) =
-    let mess = fmt"Error: Update Git info: {message}"
-    commandLine.writeMessageOnCommandLine(mess, EditorColorPairIndex.errorMessage)
-    addMessageLog mess
-
-proc writeBufferChangedWarn*(commandLine: var CommandLine, filename: Runes) =
-    let mess = fmt"Warn: File {filename} has changed and the buffer was changed in Moe as well."
     commandLine.writeMessageOnCommandLine(
       mess,
       EditorColorPairIndex.errorMessage)
     addMessageLog mess
+
+proc writeGitInfoUpdateError*(commandLine: var CommandLine, message: string) =
+  let mess = fmt"Error: Update Git info: {message}"
+  commandLine.writeMessageOnCommandLine(mess, EditorColorPairIndex.errorMessage)
+  addMessageLog mess
+
+proc writeBufferChangedWarn*(commandLine: var CommandLine, filename: Runes) =
+  let mess = fmt"Warn: File {filename} has changed and the buffer was changed in Moe as well."
+  commandLine.writeMessageOnCommandLine(mess, EditorColorPairIndex.errorMessage)
+  addMessageLog mess
+
+proc writeLspInitializeError*(
+  commandLine: var CommandLine,
+  serverCommand: Runes,
+  errorMessage: string) =
+
+    let mess = fmt"lsp: client initialize failed: {$serverCommand}: {errorMessage}"
+    commandLine.writeMessageOnCommandLine(
+      mess,
+      EditorColorPairIndex.errorMessage)
+    addMessageLog mess
+
+proc writeLspHoverError*(commandLine: var CommandLine, errorMessage: string) =
+  let mess = fmt"lsp: hover failed: {errorMessage}"
+  commandLine.writeMessageOnCommandLine(mess, EditorColorPairIndex.errorMessage)
+  addMessageLog mess

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -234,8 +234,8 @@ proc writeInRecordingOperations*(
     commandLine.writeMessageOnCommandLine(mess)
     addMessageLog mess
 
-proc writeLspInitialized*(commandLine: var CommandLine, serverCommand: Runes) =
-  let mess = fmt"LSP client initialized: {$serverCommand}"
+proc writeLspInitialized*(commandLine: var CommandLine, command: Runes) =
+  let mess = fmt"LSP client initialized: {$command}"
   commandLine.writeMessageOnCommandLine(mess)
   addMessageLog mess
 
@@ -341,10 +341,10 @@ proc writeBufferChangedWarn*(commandLine: var CommandLine, filename: Runes) =
 
 proc writeLspInitializeError*(
   commandLine: var CommandLine,
-  serverCommand: Runes,
+  command: Runes,
   errorMessage: string) =
 
-    let mess = fmt"lsp: client initialize failed: {$serverCommand}: {errorMessage}"
+    let mess = fmt"lsp: client initialize failed: {$command}: {errorMessage}"
     commandLine.writeMessageOnCommandLine(
       mess,
       EditorColorPairIndex.errorMessage)

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -1058,7 +1058,7 @@ proc hover(status: var EditorStatus) =
        return
 
   let r = status.lspClients[$currentBufStatus.extension].textDocumentHover(
-    currentBufStatus.buffer.high,
+    currentBufStatus.id,
     $currentBufStatus.path.absolutePath,
     currentMainWindowNode.bufferPosition)
   if r.isErr:

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -1051,12 +1051,12 @@ proc hover(status: var EditorStatus) =
   ## Display info on a hover. Get info from the LSP server.
   ## Call textDocument/hover.
 
-  if not status.lspClients.contains(currentBufStatus.languageId) or
-     not status.lspClients[currentBufStatus.languageId].isInitialized:
+  if not status.lspClients.contains($currentBufStatus.extension) or
+     not status.lspClients[$currentBufStatus.extension].isInitialized:
        debug "lsp client is not ready"
        return
 
-  let r = status.lspClients[currentBufStatus.languageId].textDocumentHover(
+  let r = status.lspClients[$currentBufStatus.extension].textDocumentHover(
     currentBufStatus.buffer.high,
     $currentBufStatus.path.absolutePath,
     currentMainWindowNode.bufferPosition)

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -25,9 +25,6 @@ import editorstatus, ui, gapbuffer, unicodeext, fileutils, windownode, movement,
        commandline, viewhighlight, messagelog, registers, independentutils,
        popupwindow
 
-type
-  WindowPosition = independentutils.Position
-
 proc changeModeToInsertMode(status: var EditorStatus) {.inline.} =
   if currentBufStatus.isReadonly:
     status.commandLine.writeReadonlyModeWarning
@@ -1068,8 +1065,15 @@ proc hover(status: var EditorStatus) =
     return
 
   # Display info on a popup window.
+
+  let hoverContent = r.get.toHoverContent
+  var buffer: seq[Runes]
+  if hoverContent.title.len > 0:
+    buffer = @[hoverContent.title, ru""]
+  for line in hoverContent.description:
+    buffer.add line
+
   let
-    buffer = r.get.toHoverContent.toRunes
     absPositon = currentMainWindowNode.absolutePosition
     expectPosition = Position(y: absPositon.y + 1, x: absPositon.x + 1)
   var hoverWin = initPopupWindow(
@@ -1543,8 +1547,6 @@ proc normalCommand(status: var EditorStatus, commands: Runes): Option[Rune] =
     return
 
   addOperationToNormalModeOperationsRegister(commands)
-
-  debug "End normalCommand"
 
 proc isNormalModeCommand*(
   command: Runes,

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -19,7 +19,7 @@
 
 import std/[times, strutils, sequtils, options, strformat, tables, logging]
 import pkg/results
-import lsp/client
+import lsp/[client, utils]
 import editorstatus, ui, gapbuffer, unicodeext, fileutils, windownode, movement,
        editor, searchutils, bufferstatus, quickrunutils, messages, visualmode,
        commandline, viewhighlight, messagelog, registers, independentutils,

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -1067,12 +1067,13 @@ proc hover(status: var EditorStatus) =
 
   # Display info on a popup window.
 
+  const Margin = ru" "
   let hoverContent = r.get.toHoverContent
   var buffer: seq[Runes]
   if hoverContent.title.len > 0:
-    buffer = @[hoverContent.title, ru""]
+    buffer = @[Margin & hoverContent.title & Margin, ru""]
   for line in hoverContent.description:
-    buffer.add line
+    buffer.add Margin & line & Margin
 
   let
     absPositon = currentMainWindowNode.absolutePosition
@@ -1092,7 +1093,8 @@ proc hover(status: var EditorStatus) =
 
   # Keep the cursor position on currentMainWindowNode and display the hover
   # window on the top.
-  hoverWin.overlay(currentMainWindowNode.window.get)
+  hoverWin.overwrite(currentMainWindowNode.window.get)
+  hoverWin.refresh
 
   # Wait until any key is pressed.
   discard status.getKeyFromMainWindow

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -1082,7 +1082,12 @@ proc hover(status: var EditorStatus) =
     Size(h: buffer.len, w: buffer.maxLen),
     buffer)
 
-  hoverWin.autoMoveAndResize(mainWindowNode.rect)
+  let
+    minPosition = Position(y: mainWindowNode.y, x: mainWindowNode.x)
+    maxPostion = Position(
+      y: mainWindowNode.y + mainWindowNode.h,
+      x: mainWindowNode.x + mainWindowNode.w)
+  hoverWin.autoMoveAndResize(minPosition, maxPostion)
   hoverWin.update
 
   # Wait until any key is pressed.

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -1050,6 +1050,7 @@ proc closeCurrentWindow(status: var EditorStatus) =
 proc hover(status: var EditorStatus) =
   ## Display info on a hover. Get info from the LSP server.
   ## Call textDocument/hover.
+  ## TODO: Add tests after resolving the forever key waiting problem.
 
   if not status.lspClients.contains($currentBufStatus.extension) or
      not status.lspClients[$currentBufStatus.extension].isInitialized:

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -1090,6 +1090,10 @@ proc hover(status: var EditorStatus) =
   hoverWin.autoMoveAndResize(minPosition, maxPostion)
   hoverWin.update
 
+  # Keep the cursor position on currentMainWindowNode and display the hover
+  # window on the top.
+  hoverWin.overlay(currentMainWindowNode.window.get)
+
   # Wait until any key is pressed.
   discard status.getKeyFromMainWindow
   hoverWin.close

--- a/src/moepkg/popupwindow.nim
+++ b/src/moepkg/popupwindow.nim
@@ -58,6 +58,9 @@ proc initPopupWindow*(): PopupWindow {.inline.} =
 proc refresh*(p: var PopupWindow) {.inline.} =
   p.window.refresh
 
+proc overlay*(p: var PopupWindow, destWin: var Window) {.inline.} =
+  overlay(p.window, destWin)
+
 proc resize*(p: var PopupWindow, h, w: Natural) =
   ## Resize the window in the same position.
 

--- a/src/moepkg/popupwindow.nim
+++ b/src/moepkg/popupwindow.nim
@@ -61,6 +61,9 @@ proc refresh*(p: var PopupWindow) {.inline.} =
 proc overlay*(p: var PopupWindow, destWin: var Window) {.inline.} =
   overlay(p.window, destWin)
 
+proc overwrite*(p: var PopupWindow, destWin: var Window) {.inline.} =
+  overwrite(p.window, destWin)
+
 proc resize*(p: var PopupWindow, h, w: Natural) =
   ## Resize the window in the same position.
 
@@ -72,6 +75,9 @@ proc resize*(p: var PopupWindow, h, w: Natural) =
 proc resize*(p: var PopupWindow, size: Size) {.inline.} =
   p.resize(size.h, size.w)
 
+proc resize*(p: var PopupWindow) {.inline.} =
+  p.resize(p.size)
+
 proc move*(p: var PopupWindow, y, x: Natural) =
   ## Move the popup window position.
 
@@ -82,6 +88,9 @@ proc move*(p: var PopupWindow, y, x: Natural) =
 
 proc move*(p: var PopupWindow, position: Position) {.inline.} =
   p.move(position.y, position.x)
+
+proc move*(p: var PopupWindow) {.inline.} =
+  p.window.move(p.position.y, p.position.x)
 
 proc autoMoveAndResize*(
   p: var PopupWindow,
@@ -131,7 +140,7 @@ proc autoMoveAndResize*(
     p.move(Position(y: y, x: x))
 
 proc update*(p: var PopupWindow) =
-  ## Write popup window to the UI.
+  ## Write a popup window to the UI.
   ##
   ## If buffer is larger than window size, display as much as possible.
   ##

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -451,7 +451,6 @@ proc initStartUpSettings(): StartUpSettings =
 
 proc initLspSettigns(): LspSettings =
   result.enable = false
-  result.languages = initTable[string, LspLanguageSettings]()
 
   result.languages["nim"] = LspLanguageSettings(
     extensions: @[ru"nim"],

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -219,7 +219,7 @@ type
 
   LspLanguageSettings* = object
     extensions*: seq[Runes]
-    serverCommand*: Runes
+    command*: Runes
     trace*: TraceValue
 
   LspSettings* = object
@@ -454,7 +454,7 @@ proc initLspSettigns(): LspSettings =
 
   result.languages["nim"] = LspLanguageSettings(
     extensions: @[ru"nim"],
-    serverCommand: ru"nimlsp",
+    command: ru"nimlsp",
     trace: TraceValue.verbose)
 
 proc initEditorSettings*(): EditorSettings =
@@ -1659,8 +1659,8 @@ proc parseLspTable(
               of "extensions":
                 for i in 0 ..< val.len:
                   langSettings.extensions.add val[i].getStr.toRunes
-              of "serverCommand":
-                langSettings.serverCommand = val.getStr.toRunes
+              of "command":
+                langSettings.command = val.getStr.toRunes
               of "trace":
                 langSettings.trace = val.getStr.parseTraceValue.get
 
@@ -2234,7 +2234,7 @@ proc validateLspSettings(table: TomlValueRef): Option[InvalidItem] =
             of "extensions":
               if val.kind != TomlValueKind.Array:
                 return some(InvalidItem(name: $key, val: $val))
-            of "serverCommand", "trace":
+            of "command", "trace":
               if val.kind != TomlValueKind.String and
                  val.getStr.parseTraceValue.isErr:
                    return some(InvalidItem(name: $key, val: $val))
@@ -2537,7 +2537,7 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
       if index < val.extensions.high: exts.insert(", ", exts.high - 1)
     result.addLine fmt "extensions = {exts}"
 
-    result.addLine fmt "serverCommand = \"{$val.serverCommand}\""
+    result.addLine fmt "command = \"{$val.command}\""
 
   result.addLine fmt "[Debug.WindowNode]"
   result.addLine fmt "enable = {$settings.debugMode.windowNode.enable}"

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -20,7 +20,7 @@
 import std/[os, json, options, strformat, osproc, strutils, sequtils, enumutils,
             tables]
 import pkg/[parsetoml, results, regex]
-import lsp/[protocol/enums, client]
+import lsp/[protocol/enums, utils]
 import ui, color, unicodeext, highlight, platform, independentutils, rgb, theme
 
 export TomlError

--- a/src/moepkg/suggestionwindow.nim
+++ b/src/moepkg/suggestionwindow.nim
@@ -18,9 +18,9 @@
 #[############################################################################]#
 
 import std/[sugar, options, sequtils]
-import ui, windownode, autocomplete, bufferstatus, gapbuffer, color, unicodeext,
-       osext, popupwindow
 import syntax/highlite
+import ui, windownode, autocomplete, bufferstatus, gapbuffer, unicodeext, osext,
+       popupwindow, independentutils
 
 type SuggestionWindow* = object
   wordDictionary: WordDictionary
@@ -29,7 +29,7 @@ type SuggestionWindow* = object
   firstColumn, lastColumn: int
   suggestoins: seq[Runes]
   selectedSuggestion: int
-  popUpWindow: Option[Window]
+  popupWindow: Option[PopupWindow]
   isPath: bool
 
 proc selectedWordOrInputWord(suggestionWindow: SuggestionWindow): Runes =
@@ -51,8 +51,8 @@ proc newLine*(suggestionWindow: SuggestionWindow): Runes =
           suggestionWindow.selectedWordOrInputWord)
 
 proc close*(suggestionWindow: var SuggestionWindow) =
-  suggestionWindow.popUpWindow.get.deleteWindow
-  suggestionWindow.popupwindow = none(Window)
+  suggestionWindow.popupWindow.get.close
+  suggestionWindow.popupwindow = none(PopupWindow)
 
 proc canHandleInSuggestionWindow*(key: Rune): bool {.inline.} =
   isTabKey(key) or
@@ -86,10 +86,10 @@ proc handleKeyInSuggestionWindow*(
         dec(suggestionWindow.selectedSuggestion)
     elif isPageDownKey(key):
       suggestionWindow.selectedSuggestion +=
-        suggestionWindow.popUpWindow.get.height - 1
+        suggestionWindow.popupWindow.get.size.h - 1
     elif isPageUpKey(key):
       suggestionWindow.selectedSuggestion -=
-        suggestionWindow.popUpWindow.get.height - 1
+        suggestionWindow.popupWindow.get.size.h - 1
 
     suggestionWindow.selectedSuggestion =
       suggestionWindow.selectedSuggestion.clamp(0, suggestionWindow.suggestoins.high)
@@ -282,6 +282,7 @@ proc calcSuggestionWindowPosition*(
   suggestionWindow: SuggestionWindow,
   windowNode: WindowNode,
   mainWindowHeight: int): tuple[y, x: int] =
+    # TODO: Use `popupwindow.autoMoveAndResize`
 
     let
       line = windowNode.currentLine
@@ -313,6 +314,7 @@ proc calcMaxSugestionWindowHeight(
   cursorYPosition: int,
   mainWindowNodeY: int,
   isEnableStatusLine: bool): int =
+    # TODO: Use `popupwindow.autoMoveAndResize`
 
     const CommanLineHeight = 1
     let statusLineHeight = if isEnableStatusLine: 1 else: 0
@@ -346,31 +348,26 @@ proc writeSuggestionWindow*(
       height = min(suggestionWindow.suggestoins.len, maxHeight)
       width = suggestionWindow.suggestoins.map(item => item.len).max + 2
 
-    if suggestionWindow.popUpWindow.isNone:
-      suggestionWindow.popUpWindow = initWindow(
-        height,
-        width,
-        if y < mainWindowNodeY: mainWindowNodeY else: y,
-        x,
-        EditorColorPairIndex.popUpWindow.int16)
+    if suggestionWindow.popupWindow.isNone:
+      let
+        y =
+          if y < mainWindowNodeY: mainWindowNodeY
+          else: y
+      suggestionWindow.popupWindow = initPopupWindow(
+        Position(y: y, x: x),
+        Size(h: height, w: width))
         .some
     else:
-      suggestionWindow.popUpWindow.get.height = height
-      suggestionWindow.popUpWindow.get.width = width
-      suggestionWindow.popUpWindow.get.y = y
-      suggestionWindow.popUpWindow.get.x = x
+      suggestionWindow.popupWindow.get.size = Size(h: height, w: width)
+      suggestionWindow.popupWindow.get.position = Position(y: y, x: x)
 
-    let currentLine =
+    suggestionWindow.popupWindow.get.currentLine =
       if suggestionWindow.selectedSuggestion == -1: none(int)
       else: suggestionWindow.selectedSuggestion.some
 
-    suggestionWindow.popUpWindow.get.writePopUpWindow(
-      suggestionWindow.popUpWindow.get.height,
-      suggestionWindow.popUpWindow.get.width,
-      suggestionWindow.popUpWindow.get.y,
-      suggestionWindow.popUpWindow.get.x,
-      currentLine,
-      suggestionWindow.suggestoins)
+    suggestionWindow.popupWindow.get.buffer = suggestionWindow.suggestoins
+
+    suggestionWindow.popupWindow.get.update
 
 proc isLineChanged*(suggestionWindow: SuggestionWindow): bool {.inline.} =
   suggestionWindow.newLine != suggestionWindow.oldLine

--- a/src/moepkg/suggestionwindow.nim
+++ b/src/moepkg/suggestionwindow.nim
@@ -310,9 +310,7 @@ proc calcSuggestionWindowPosition*(
     return (y, x)
 
 proc calcMaxSugestionWindowHeight(
-  y: int,
-  cursorYPosition: int,
-  mainWindowNodeY: int,
+  y, cursorYPosition, mainWindowNodeY: int,
   isEnableStatusLine: bool): int =
     # TODO: Use `popupwindow.autoMoveAndResize`
 
@@ -346,7 +344,7 @@ proc writeSuggestionWindow*(
         mainWindowNodeY,
         isEnableStatusLine)
       height = min(suggestionWindow.suggestoins.len, maxHeight)
-      width = suggestionWindow.suggestoins.map(item => item.len).max + 2
+      width = suggestionWindow.suggestoins.maxLen + 2
 
     if suggestionWindow.popupWindow.isNone:
       let
@@ -365,7 +363,9 @@ proc writeSuggestionWindow*(
       if suggestionWindow.selectedSuggestion == -1: none(int)
       else: suggestionWindow.selectedSuggestion.some
 
+    # Add margin to both sides.
     suggestionWindow.popupWindow.get.buffer = suggestionWindow.suggestoins
+      .mapIt(ru" " & it & ru" ")
 
     suggestionWindow.popupWindow.get.update
 

--- a/src/moepkg/ui.nim
+++ b/src/moepkg/ui.nim
@@ -342,6 +342,9 @@ proc refresh*(win: Window) {.inline.} = wrefresh(win.cursesWindow)
 proc overlay*(win, destWin: var Window) {.inline.} =
   overlay(win.cursesWindow, destWin.cursesWindow)
 
+proc overwrite*(win, destWin: var Window) {.inline.} =
+  overwrite(win.cursesWindow, destWin.cursesWindow)
+
 proc move*(win: Window, y, x: int) =
   mvwin(win.cursesWindow, cint(y), cint(x))
 

--- a/src/moepkg/ui.nim
+++ b/src/moepkg/ui.nim
@@ -339,6 +339,9 @@ proc erase*(win: var Window) =
 
 proc refresh*(win: Window) {.inline.} = wrefresh(win.cursesWindow)
 
+proc overlay*(win, destWin: var Window) {.inline.} =
+  overlay(win.cursesWindow, destWin.cursesWindow)
+
 proc move*(win: Window, y, x: int) =
   mvwin(win.cursesWindow, cint(y), cint(x))
 

--- a/src/moepkg/unicodeext.nim
+++ b/src/moepkg/unicodeext.nim
@@ -548,9 +548,7 @@ proc replace*(runes1, sub: Runes, by: Runes = ru""): Runes {.inline.} =
   replace($runes1, $sub, $by).toRunes
 
 proc maxLen*(lines: seq[Runes]): int {.inline.} =
-  for i in 0 .. lines.high:
-    if lines[i].len > result: result = lines[i].len
+  lines.mapIt(it.len).max
 
 proc maxHigh*(lines: seq[Runes]): int {.inline.} =
-  for i in 0 .. lines.high:
-    if lines[i].high > result: result = lines[i].high
+  lines.mapIt(it.high).max

--- a/src/moepkg/unicodeext.nim
+++ b/src/moepkg/unicodeext.nim
@@ -546,3 +546,7 @@ proc stripLineEnd*(runes: Runes): Runes =
 
 proc replace*(runes1, sub: Runes, by: Runes = ru""): Runes {.inline.} =
   replace($runes1, $sub, $by).toRunes
+
+proc maxLen*(lines: seq[Runes]): int {.inline.} =
+  for i in 0 .. lines.high:
+    if lines[i].len > result: result = lines[i].len

--- a/src/moepkg/unicodeext.nim
+++ b/src/moepkg/unicodeext.nim
@@ -550,3 +550,7 @@ proc replace*(runes1, sub: Runes, by: Runes = ru""): Runes {.inline.} =
 proc maxLen*(lines: seq[Runes]): int {.inline.} =
   for i in 0 .. lines.high:
     if lines[i].len > result: result = lines[i].len
+
+proc maxHigh*(lines: seq[Runes]): int {.inline.} =
+  for i in 0 .. lines.high:
+    if lines[i].high > result: result = lines[i].high

--- a/src/moepkg/windownode.nim
+++ b/src/moepkg/windownode.nim
@@ -416,17 +416,28 @@ proc absolutePosition*(
 
     return (y, x)
 
+proc absolutePosition*(node: WindowNode): tuple[y, x: int] {.inline.} =
+  ## Calculates the absolute position of the current position.
+
+  node.absolutePosition(node.currentLine, node.currentColumn)
+
+proc rect*(node: WindowNode): WindowRect {.inline.} =
+  Rect(y: node.y, x: node.x, w: node.w, h: node.h)
+
 proc moveCursor*(node: var WindowNode, line, column: int) =
   if node.window.isSome:
     node.currentLine = line
     node.currentColumn = column
     node.window.get.move(line, column)
+    node.window.get.refresh
 
 proc moveCursor*(node: var WindowNode, position: BufferPosition) {.inline.} =
   node.moveCursor(position.line, position.column)
 
 proc moveCursor*(node: var WindowNode) {.inline.} =
-  node.moveCursor(node.currentLine, node.currentColumn)
+  if node.window.isSome:
+    node.window.get.move(node.y, node.x)
+    node.window.get.refresh
 
 proc refreshWindow*(node: var WindowNode) {.inline.} =
   if node.window.isSome: node.window.get.refresh

--- a/tests/teditorstatus.nim
+++ b/tests/teditorstatus.nim
@@ -1074,7 +1074,7 @@ suite "editorstatus: initLsp":
     status.settings.lsp.enable = true
     status.settings.lsp.languages["nim"] = LspLanguageSettings(
       extensions: @[ru"nim"],
-      serverCommand: ru"nimlsp",
+      command: ru"nimlsp",
       trace: TraceValue.verbose)
 
     status.bufStatus.add initBufferStatus(path, Mode.normal).get

--- a/tests/teditorstatus.nim
+++ b/tests/teditorstatus.nim
@@ -17,11 +17,12 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[unittest, options, os, importutils, sequtils, oids]
+import std/[unittest, options, os, importutils, sequtils, oids, tables]
 import pkg/results
+import moepkg/lsp/protocol/enums
 import moepkg/[editor, gapbuffer, bufferstatus, editorview, unicodeext, ui,
                highlight, windownode, movement, build, backgroundprocess,
-               syntaxcheck, independentutils, tabline]
+               syntaxcheck, independentutils, tabline, settings]
 
 import moepkg/editorstatus {.all.}
 
@@ -1064,3 +1065,20 @@ suite "editorstatus: smoothScrollDownNumberOfLines":
     check status.smoothScrollDownNumberOfLines(TotalLines).isNone
 
     check currentMainWindowNode.currentLine == 10
+
+suite "editorstatus: initLsp":
+  test "Init wtih nimlsp":
+    let path = $genOid() & ".nim"
+    var status = initEditorStatus()
+
+    status.settings.lsp.enable = true
+    status.settings.lsp.languages["nim"] = LspLanguageSettings(
+      extensions: @[ru"nim"],
+      serverCommand: ru"nimlsp",
+      trace: TraceValue.verbose)
+
+    status.bufStatus.add initBufferStatus(path, Mode.normal).get
+
+    let workspaceRoot = getCurrentDir()
+    const LanguageId = "nim"
+    check status.initLsp(workspaceRoot, LanguageId).isOk

--- a/tests/tinsertmode.nim
+++ b/tests/tinsertmode.nim
@@ -526,5 +526,5 @@ suite "Insert mode":
 
     privateAccess(suggestionWindow.get.type)
 
-    check suggestionWindow.get.popUpWindow.get.y == 2
-    check suggestionWindow.get.popUpWindow.get.height == TerminalHeight - 4
+    check suggestionWindow.get.popUpWindow.get.position.y == 2
+    check suggestionWindow.get.popUpWindow.get.size.h == TerminalHeight - 4

--- a/tests/tlsp.nim
+++ b/tests/tlsp.nim
@@ -1,0 +1,139 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[json, unittest, importutils, os, options]
+import pkg/results
+import moepkg/independentutils
+
+import moepkg/lsp/client {.all.}
+
+suite "lsp: Send requests":
+  privateAccess(LspClient)
+
+  const ServerCommand = "nimlsp"
+
+  test "Send initialize":
+    var client = initLspClient(ServerCommand)
+
+    const
+      Id = 1
+      RootPath = ""
+    let params = initInitializeParams(RootPath)
+
+    check client.initialize(Id, params).isOk
+
+  test "Send shutdown":
+    var client = initLspClient(ServerCommand)
+
+    const
+      Id = 1
+      RootPath = ""
+    let params = initInitializeParams(RootPath)
+    assert client.initialize(Id, params).isOk
+    assert client.initialized.isOk
+
+    check client.shutdown(Id).isOk
+
+  test "Send textDocument/didOpen":
+    var client = initLspClient(ServerCommand)
+
+    const Id = 1
+    let
+      rootPath = getCurrentDir()
+      params = initInitializeParams(rootPath)
+    assert client.initialize(Id, params).isOk
+    assert client.initialized.isOk
+
+    const
+      LanguageId = "nim"
+      Version = 1
+    let
+      path = getCurrentDir() / "src/moe.nim"
+      text = readFile(path)
+
+    check client.textDocumentDidOpen(Version, path, LanguageId, text).isOk
+
+  test "Send textDocument/didChange":
+    var client = initLspClient(ServerCommand)
+
+    const Id = 1
+    let
+      rootPath = getCurrentDir()
+      params = initInitializeParams(rootPath)
+    assert client.initialize(Id, params).isOk
+    assert client.initialized.isOk
+
+    const
+      LanguageId = "nim"
+      FirstVersion = 1
+    let
+      path = getCurrentDir() / "src/moe.nim"
+      text = readFile(path)
+    assert client.textDocumentDidOpen(FirstVersion, path, LanguageId, text).isOk
+
+    block:
+      const SecondVersion = 1
+      let changedText = "echo 1"
+
+      check client.textDocumentDidChange(SecondVersion, changedText).isOk
+
+  test "Send textDocument/didClose":
+    var client = initLspClient(ServerCommand)
+
+    const Id = 1
+    let
+      rootPath = getCurrentDir()
+      params = initInitializeParams(rootPath)
+    assert client.initialize(Id, params).isOk
+    assert client.initialized.isOk
+
+    const
+      LanguageId = "nim"
+      Version = 1
+    let
+      path = getCurrentDir() / "src/moe.nim"
+      text = readFile(path)
+    assert client.textDocumentDidOpen(Version, path, LanguageId, text).isOk
+
+    check client.textDocumentDidClose(path).isOk
+
+  test "Send textDocument/hover":
+    var client = initLspClient(ServerCommand)
+
+    const Id = 1
+    let
+      rootPath = getCurrentDir()
+      params = initInitializeParams(rootPath)
+    assert client.initialize(Id, params).isOk
+    assert client.initialized.isOk
+
+    const
+      LanguageId = "nim"
+      Version = 1
+    let
+      path = getCurrentDir() / "src/moe.nim"
+      # Use simple text for the test.
+      text = "echo 1"
+    assert client.textDocumentDidOpen(Version, path, LanguageId, text).isOk
+
+    let position = BufferPosition(line: 0, column: 0)
+
+    let r = client.textDocumentHover(Id, path, position)
+    check r.isOk
+    check r.get.contents.get.len > 0

--- a/tests/tlsp.nim
+++ b/tests/tlsp.nim
@@ -91,7 +91,7 @@ suite "lsp: Send requests":
       const SecondVersion = 1
       let changedText = "echo 1"
 
-      check client.textDocumentDidChange(SecondVersion, changedText).isOk
+      check client.textDocumentDidChange(SecondVersion, path, changedText).isOk
 
   test "Send textDocument/didClose":
     var client = initLspClient(ServerCommand)

--- a/tests/tlsp.nim
+++ b/tests/tlsp.nim
@@ -53,6 +53,18 @@ suite "lsp: Send requests":
 
     check client.shutdown(Id).isOk
 
+  test "Send workspace/didChangeConfiguration":
+    var client = initLspClient(ServerCommand).get
+
+    const Id = 1
+    let
+      rootPath = getCurrentDir()
+      params = initInitializeParams(rootPath, Trace)
+    assert client.initialize(Id, params).isOk
+    assert client.initialized.isOk
+
+    check client.workspaceDidChangeConfiguration.isOk
+
   test "Send textDocument/didOpen":
     var client = initLspClient(ServerCommand).get
 

--- a/tests/tlsp.nim
+++ b/tests/tlsp.nim
@@ -20,43 +20,46 @@
 import std/[json, unittest, importutils, os, options]
 import pkg/results
 import moepkg/independentutils
+import moepkg/lsp/protocol/enums
 
 import moepkg/lsp/client {.all.}
 
 suite "lsp: Send requests":
   privateAccess(LspClient)
 
-  const ServerCommand = "nimlsp"
+  const
+    ServerCommand = "nimlsp"
+    Trace = TraceValue.verbose
 
   test "Send initialize":
-    var client = initLspClient(ServerCommand)
+    var client = initLspClient(ServerCommand).get
 
     const
       Id = 1
       RootPath = ""
-    let params = initInitializeParams(RootPath)
+    let params = initInitializeParams(RootPath, Trace)
 
     check client.initialize(Id, params).isOk
 
   test "Send shutdown":
-    var client = initLspClient(ServerCommand)
+    var client = initLspClient(ServerCommand).get
 
     const
       Id = 1
       RootPath = ""
-    let params = initInitializeParams(RootPath)
+    let params = initInitializeParams(RootPath, Trace)
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
     check client.shutdown(Id).isOk
 
   test "Send textDocument/didOpen":
-    var client = initLspClient(ServerCommand)
+    var client = initLspClient(ServerCommand).get
 
     const Id = 1
     let
       rootPath = getCurrentDir()
-      params = initInitializeParams(rootPath)
+      params = initInitializeParams(rootPath, Trace)
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
@@ -70,12 +73,12 @@ suite "lsp: Send requests":
     check client.textDocumentDidOpen(Version, path, LanguageId, text).isOk
 
   test "Send textDocument/didChange":
-    var client = initLspClient(ServerCommand)
+    var client = initLspClient(ServerCommand).get
 
     const Id = 1
     let
       rootPath = getCurrentDir()
-      params = initInitializeParams(rootPath)
+      params = initInitializeParams(rootPath, Trace)
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
@@ -94,12 +97,12 @@ suite "lsp: Send requests":
       check client.textDocumentDidChange(SecondVersion, path, changedText).isOk
 
   test "Send textDocument/didClose":
-    var client = initLspClient(ServerCommand)
+    var client = initLspClient(ServerCommand).get
 
     const Id = 1
     let
       rootPath = getCurrentDir()
-      params = initInitializeParams(rootPath)
+      params = initInitializeParams(rootPath, Trace)
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
@@ -114,12 +117,12 @@ suite "lsp: Send requests":
     check client.textDocumentDidClose(path).isOk
 
   test "Send textDocument/hover":
-    var client = initLspClient(ServerCommand)
+    var client = initLspClient(ServerCommand).get
 
     const Id = 1
     let
       rootPath = getCurrentDir()
-      params = initInitializeParams(rootPath)
+      params = initInitializeParams(rootPath, Trace)
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 

--- a/tests/tlspclient.nim
+++ b/tests/tlspclient.nim
@@ -28,11 +28,11 @@ suite "lsp: Send requests":
   privateAccess(LspClient)
 
   const
-    ServerCommand = "nimlsp"
+    Command = "nimlsp"
     Trace = TraceValue.verbose
 
   test "Send initialize":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const
       Id = 1
@@ -42,7 +42,7 @@ suite "lsp: Send requests":
     check client.initialize(Id, params).isOk
 
   test "Send shutdown":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const
       Id = 1
@@ -54,7 +54,7 @@ suite "lsp: Send requests":
     check client.shutdown(Id).isOk
 
   test "Send workspace/didChangeConfiguration":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const Id = 1
     let
@@ -66,7 +66,7 @@ suite "lsp: Send requests":
     check client.workspaceDidChangeConfiguration.isOk
 
   test "Send textDocument/didOpen":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const Id = 1
     let
@@ -83,7 +83,7 @@ suite "lsp: Send requests":
     check client.textDocumentDidOpen(path, LanguageId, text).isOk
 
   test "Send textDocument/didChange":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const Id = 1
     let
@@ -105,7 +105,7 @@ suite "lsp: Send requests":
       check client.textDocumentDidChange(SecondVersion, path, changedText).isOk
 
   test "Send textDocument/didClose":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const Id = 1
     let
@@ -123,7 +123,7 @@ suite "lsp: Send requests":
     check client.textDocumentDidClose(path).isOk
 
   test "Send textDocument/hover":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const Id = 1
     let
@@ -146,7 +146,7 @@ suite "lsp: Send requests":
     check r.get.contents.get.len > 0
 
   test "Send textDocument/hover 2":
-    var client = initLspClient(ServerCommand).get
+    var client = initLspClient(Command).get
 
     const Id = 1
     let

--- a/tests/tlspclient.nim
+++ b/tests/tlspclient.nim
@@ -99,7 +99,7 @@ suite "lsp: Send requests":
     assert client.textDocumentDidOpen(path, LanguageId, text).isOk
 
     block:
-      const SecondVersion = 1
+      const SecondVersion = 2
       let changedText = "echo 1"
 
       check client.textDocumentDidChange(SecondVersion, path, changedText).isOk

--- a/tests/tlspclient.nim
+++ b/tests/tlspclient.nim
@@ -75,14 +75,12 @@ suite "lsp: Send requests":
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
-    const
-      LanguageId = "nim"
-      Version = 1
+    const LanguageId = "nim"
     let
       path = getCurrentDir() / "src/moe.nim"
       text = readFile(path)
 
-    check client.textDocumentDidOpen(Version, path, LanguageId, text).isOk
+    check client.textDocumentDidOpen(path, LanguageId, text).isOk
 
   test "Send textDocument/didChange":
     var client = initLspClient(ServerCommand).get
@@ -94,13 +92,11 @@ suite "lsp: Send requests":
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
-    const
-      LanguageId = "nim"
-      FirstVersion = 1
+    const LanguageId = "nim"
     let
       path = getCurrentDir() / "src/moe.nim"
       text = readFile(path)
-    assert client.textDocumentDidOpen(FirstVersion, path, LanguageId, text).isOk
+    assert client.textDocumentDidOpen(path, LanguageId, text).isOk
 
     block:
       const SecondVersion = 1
@@ -118,13 +114,11 @@ suite "lsp: Send requests":
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
-    const
-      LanguageId = "nim"
-      Version = 1
+    const LanguageId = "nim"
     let
       path = getCurrentDir() / "src/moe.nim"
       text = readFile(path)
-    assert client.textDocumentDidOpen(Version, path, LanguageId, text).isOk
+    assert client.textDocumentDidOpen(path, LanguageId, text).isOk
 
     check client.textDocumentDidClose(path).isOk
 
@@ -138,14 +132,12 @@ suite "lsp: Send requests":
     assert client.initialize(Id, params).isOk
     assert client.initialized.isOk
 
-    const
-      LanguageId = "nim"
-      Version = 1
+    const LanguageId = "nim"
     let
       path = getCurrentDir() / "src/moe.nim"
       # Use simple text for the test.
       text = "echo 1"
-    assert client.textDocumentDidOpen(Version, path, LanguageId, text).isOk
+    assert client.textDocumentDidOpen(path, LanguageId, text).isOk
 
     let position = BufferPosition(line: 0, column: 0)
 
@@ -164,12 +156,11 @@ suite "lsp: Send requests":
     assert client.initialized.isOk
 
     const LanguageId = "nim"
-    var version = 1
     let
       path = getCurrentDir() / "src/moe.nim"
       # Use simple text for the test.
       text = "echo 1"
-    assert client.textDocumentDidOpen(version, path, LanguageId, text).isOk
+    assert client.textDocumentDidOpen(path, LanguageId, text).isOk
 
     block first:
       let position = BufferPosition(line: 0, column: 0)
@@ -178,9 +169,9 @@ suite "lsp: Send requests":
       check r.get.contents.get.len > 0
 
     block second:
-      version.inc
+      const SecondVersion = 2
       let changedText = "echo 1\necho 2"
-      assert client.textDocumentDidChange(version, path, changedText).isOk
+      assert client.textDocumentDidChange(SecondVersion, path, changedText).isOk
 
       let position = BufferPosition(line: 1, column: 0)
 

--- a/tests/tlspclient.nim
+++ b/tests/tlspclient.nim
@@ -20,7 +20,7 @@
 import std/[json, unittest, importutils, os, options]
 import pkg/results
 import moepkg/independentutils
-import moepkg/lsp/protocol/enums
+import moepkg/lsp/protocol/[enums, types]
 
 import moepkg/lsp/client {.all.}
 
@@ -141,9 +141,18 @@ suite "lsp: Send requests":
 
     let position = BufferPosition(line: 0, column: 0)
 
-    let r = client.textDocumentHover(Id, path, position)
-    check r.isOk
-    check r.get.contents.get.len > 0
+    var hoverResult = none(Hover)
+    for i in 0 .. 10:
+      # Wait for nimlsp to be ready.
+      sleep 1000
+
+      let r = client.textDocumentHover(Id, path, position)
+      if r.isOk:
+        hoverResult = some(r.get)
+        break
+
+    check hoverResult.isSome
+    check hoverResult.get.contents.get.len > 0
 
   test "Send textDocument/hover 2":
     var client = initLspClient(Command).get
@@ -165,8 +174,18 @@ suite "lsp: Send requests":
     block first:
       let position = BufferPosition(line: 0, column: 0)
 
-      let r = client.textDocumentHover(Id, path, position)
-      check r.get.contents.get.len > 0
+      var hoverResult = none(Hover)
+      for i in 0 .. 10:
+        # Wait for nimlsp to be ready.
+        sleep 1000
+
+        let r = client.textDocumentHover(Id, path, position)
+        if r.isOk:
+          hoverResult = some(r.get)
+          break
+
+      check hoverResult.isSome
+      check hoverResult.get.contents.get.len > 0
 
     block second:
       const SecondVersion = 2
@@ -175,5 +194,15 @@ suite "lsp: Send requests":
 
       let position = BufferPosition(line: 1, column: 0)
 
-      let r = client.textDocumentHover(Id, path, position)
-      check r.get.contents.get.len > 0
+      var hoverResult = none(Hover)
+      for i in 0 .. 10:
+        # Wait for nimlsp to be ready.
+        sleep 1000
+
+        let r = client.textDocumentHover(Id, path, position)
+        if r.isOk:
+          hoverResult = some(r.get)
+          break
+
+      check hoverResult.isSome
+      check hoverResult.get.contents.get.len > 0

--- a/tests/tlsputils.nim
+++ b/tests/tlsputils.nim
@@ -1,0 +1,76 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, json]
+import pkg/results
+import moepkg/[independentutils, unicodeext]
+import moepkg/lsp/protocol/[enums, types]
+
+import moepkg/lsp/utils {.all.}
+
+suite "lsp: toLspPosition":
+  test "toLspPosition 1":
+    check BufferPosition(line: 1, column: 2).toLspPosition[] ==
+      LspPosition(line: 1, character: 2)[]
+
+suite "lsp: parseTraceValue":
+  test "off":
+    check parseTraceValue("off").get == TraceValue.off
+  test "messages":
+    check parseTraceValue("messages").get == TraceValue.messages
+  test "off":
+    check parseTraceValue("verbose").get == TraceValue.verbose
+  test "Invalid value":
+    check parseTraceValue("a").isErr
+
+suite "lsp: toHoverContent":
+  test "Basic":
+    let hoverJson = %* {
+      "contents": [
+        {"language": "nim", "value": "title"},
+        {"language": "", "value": "line1\nline2"}
+      ],
+      "range": {
+        "start": {"line": 1, "character": 2},
+        "end": {"line": 3, "character": 4}
+      }
+    }
+
+    check toHoverContent(hoverJson.to(Hover)) == HoverContent(
+      title: ru"title",
+      description: @[ru"line1", ru"line2"],
+      range: BufferRange(
+        first: BufferPosition(line: 1, column: 2),
+        last: BufferPosition(line: 3, column: 4)))
+
+  test "Only description":
+    let hoverJson = %* {
+      "contents": {"language": "nim", "value": "description"},
+      "range": {
+        "start": {"line": 1, "character": 2},
+        "end": {"line": 3, "character": 4}
+      }
+    }
+
+    check toHoverContent(hoverJson.to(Hover)) == HoverContent(
+      title: ru"",
+      description: @[ru"description"],
+      range: BufferRange(
+        first: BufferPosition(line: 1, column: 2),
+        last: BufferPosition(line: 3, column: 4)))

--- a/tests/tmoe.nim
+++ b/tests/tmoe.nim
@@ -39,13 +39,15 @@ suite "moe: addBufferStatus":
 
   test "1 file":
     var status = initEditorStatus()
-    const ParsedList = CmdParsedList(path: @["test.nim"])
+    let
+      path = $genOid()
+      parsedList = CmdParsedList(path: @[path])
 
-    status.addBufferStatus(ParsedList)
+    status.addBufferStatus(parsedList)
 
     check status.bufStatus.len == 1
     check currentBufStatus.buffer.toSeqRunes == @[ru""]
-    check currentBufStatus.path == ru"test.nim"
+    check currentBufStatus.path == path.toRunes
     check currentBufStatus.mode == Mode.normal
 
     check mainWindowNode.getAllWindowNode.len == 1

--- a/tests/tnormalmode.nim
+++ b/tests/tnormalmode.nim
@@ -17,7 +17,8 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[unittest, importutils, sequtils, sugar, os, options, strformat]
+import std/[unittest, importutils, sequtils, sugar, os, options, strformat,
+            oids]
 import pkg/[ncurses, results]
 import moepkg/syntax/highlite
 import moepkg/[registers, settings, editorstatus, gapbuffer, unicodeext,

--- a/tests/tpopupwindow.nim
+++ b/tests/tpopupwindow.nim
@@ -1,0 +1,211 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, importutils, options, sequtils]
+import moepkg/[independentutils, unicodeext]
+
+import moepkg/popupwindow {.all.}
+
+suite "popupwindow: initWindow":
+  privateAccess(PopupWindow)
+
+  test "initWindow 1":
+    let p = initPopupWindow(
+      Position(y: 50, x: 100),
+      Size(h: 10, w: 20),
+      @[ru"test"])
+
+    check p.window != nil
+    check p.position.y == 50
+    check p.position.x == 100
+    check p.size.h == 10
+    check p.size.w == 20
+    check p.buffer == @[ru"test"]
+    check p.currentLine.isNone
+
+  test "initWindow 2":
+    let p = initPopupWindow(
+      Position(y: 50, x: 100),
+      Size(h: 10, w: 20))
+
+    check p.window != nil
+    check p.position.y == 50
+    check p.position.x == 100
+    check p.size.h == 10
+    check p.size.w == 20
+    check p.buffer.len == 0
+    check p.currentLine.isNone
+
+  test "initWindow 3":
+    let p = initPopupWindow()
+
+    check p.window != nil
+    check p.position.y == 0
+    check p.position.x == 0
+    check p.size.h == 1
+    check p.size.w == 1
+    check p.buffer.len == 0
+    check p.currentLine.isNone
+
+suite "popupwindow: resize":
+  test "resize 1":
+    var p = initPopupWindow()
+    p.resize(50, 100)
+    check p.size == Size(h: 50, w: 100)
+
+  test "resize 2":
+    var p = initPopupWindow()
+    p.resize(Size(h: 50, w: 100))
+    check p.size == Size(h: 50, w: 100)
+
+suite "popupwindow: move":
+  test "move 1":
+    var p = initPopupWindow()
+    p.move(50, 100)
+    check p.position == Position(y: 50, x: 100)
+
+  test "move 2":
+    var p = initPopupWindow()
+    p.move(Position(y: 50, x: 100))
+    check p.position == Position(y: 50, x: 100)
+
+suite "popupwindow: autoMoveAndResize":
+  test "autoMoveAndResize 1":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 10, w: 10),
+      @[ru"line1", ru"line2"])
+
+    let
+      min = Position(y: 1, x: 1)
+      max = Position(y: 100, x: 100)
+    p.autoMoveAndResize(min, max)
+
+    check p.position == Position(y: 1, x: 1)
+    check p.size == Size(h: 2, w: 5)
+
+  test "autoMoveAndResize 2":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 1, w: 1),
+      @[ru"line1", ru"line2"])
+
+    let
+      min = Position(y: 1, x: 1)
+      max = Position(y: 100, x: 100)
+    p.autoMoveAndResize(min, max)
+
+    check p.position == Position(y: 1, x: 1)
+    check p.size == Size(h: 2, w: 5)
+
+  test "autoMoveAndResize 3":
+    var p = initPopupWindow(
+      Position(y: 99, x: 1),
+      Size(h: 2, w: 5),
+      @[ru"line1", ru"line2"])
+
+    let
+      min = Position(y: 1, x: 1)
+      max = Position(y: 100, x: 100)
+    p.autoMoveAndResize(min, max)
+
+    check p.position == Position(y: 96, x: 1)
+    check p.size == Size(h: 2, w: 5)
+
+  test "autoMoveAndResize 4":
+    var p = initPopupWindow(
+      Position(y: 1, x: 99),
+      Size(h: 2, w: 5),
+      @[ru"line1", ru"line2"])
+
+    let
+      min = Position(y: 1, x: 1)
+      max = Position(y: 100, x: 100)
+    p.autoMoveAndResize(min, max)
+
+    check p.position == Position(y: 1, x: 93)
+    check p.size == Size(h: 2, w: 5)
+
+  test "autoMoveAndResize 5":
+    var p = initPopupWindow(
+      Position(y: 99, x: 99),
+      Size(h: 2, w: 5),
+      @[ru"line1", ru"line2"])
+
+    let
+      min = Position(y: 1, x: 1)
+      max = Position(y: 100, x: 100)
+    p.autoMoveAndResize(min, max)
+
+    check p.position == Position(y: 96, x: 93)
+    check p.size == Size(h: 2, w: 5)
+
+suite "popupwindow: update":
+  test "update 1":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 2, w: 5),
+      @[ru"line1", ru"line2"])
+
+    p.update
+
+suite "popupwindow: update":
+  test "update 1":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 2, w: 5),
+      @[ru"line1", ru"line2"])
+
+    p.update
+
+  test "update 2":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 1, w: 5),
+      @[ru"line1", ru"line2"])
+
+    p.update
+
+  test "update 3":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 2, w: 1),
+      @[ru"line1", ru"line2"])
+
+    p.update
+
+  test "update 4":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 5, w: 2),
+      toSeq(0..10).mapIt(toRunes($it)))
+
+    p.currentLine = some(5)
+
+    p.update
+
+  test "update 5":
+    var p = initPopupWindow(
+      Position(y: 1, x: 1),
+      Size(h: 5, w: 1),
+      toSeq(0..10).mapIt(toRunes($it)))
+
+    p.currentLine = some(5)
+
+    p.update

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -152,17 +152,17 @@ const TomlStr = """
   [StartUp.FileOpen]
   autoSplit = false
   splitType = "horizontal"
-  
+
   [Lsp]
   enable = true
 
   [Lsp.nim]
   extensions = ["nim"]
-  serverCommand = "nimlangserver"
+  command = "nimlangserver"
 
   [Lsp.rust]
   extensions = ["rs"]
-  serverCommand = "rust-analyzer"
+  command = "rust-analyzer"
 
   [Debug.WindowNode]
   enable = false
@@ -487,11 +487,11 @@ suite "Parse configuration file":
     check settings.lsp.enable
     check settings.lsp.languages["nim"] == LspLanguageSettings(
       extensions: @[ru"nim"],
-      serverCommand: ru"nimlangserver")
+      command: ru"nimlangserver")
 
     check settings.lsp.languages["rust"] == LspLanguageSettings(
       extensions: @[ru"rs"],
-      serverCommand: ru"rust-analyzer")
+      command: ru"rust-analyzer")
 
     check not settings.debugMode.windowNode.enable
     check not settings.debugMode.windowNode.currentWindow

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -149,6 +149,17 @@ const TomlStr = """
   minDelay = 1
   maxDelay = 1
 
+  [Lsp]
+  enable = true
+
+  [Lsp.nim]
+  extensions = ["nim"]
+  serverCommand = "nimlangserver"
+
+  [Lsp.rust]
+  extensions = ["rs"]
+  serverCommand = "rust-analyzer"
+
   [Debug.WindowNode]
   enable = false
   currentWindow = false
@@ -465,6 +476,15 @@ suite "Parse configuration file":
     check not settings.smoothScroll.enable
     check settings.smoothScroll.minDelay == 1
     check settings.smoothScroll.maxDelay == 1
+
+    check settings.lsp.enable
+    check settings.lsp.languages["nim"] == LspLanguageSettings(
+      extensions: @[ru"nim"],
+      serverCommand: ru"nimlangserver")
+
+    check settings.lsp.languages["rust"] == LspLanguageSettings(
+      extensions: @[ru"rs"],
+      serverCommand: ru"rust-analyzer")
 
     check not settings.debugMode.windowNode.enable
     check not settings.debugMode.windowNode.currentWindow


### PR DESCRIPTION
Add LSP client support. It's an experimental and incomplete feature.
I'm testing with [nimlsp](https://github.com/PMunch/nimlsp) but it probably still doesn't work on many servers.

- Add LSP client
- Add settings for LSP
- Add `K` command (Hover) to Normal mode

### Screenshots

![lsp](https://github.com/fox0430/moe/assets/15966436/9e1f78d7-c52d-4bf7-bb51-7d86659ffeb5)

### Supported LSP Commands
- `Initialize`
- `shutdown`
- `workspace/didChangeConfiguration`
- `textDocument/didOpen`
- `textDocument/didChange`
- `textDocument/didClose`
- `textDocument/hover`


Close #610 

## TODO
- [x] Send `textDocument/didChange` after changing buffers
- [x] Send `textDocument/didClose` after removing buffer
- [x] Check server capabilities
- [x] Error handling
- [x] Improve debug logs
- [x] Force enable debug logs when enabled LSP
- [x] Add immutable id
- [x] Fix that freeze when suggestions are not found
- [x] Fix popup window bugs
- [x] ~~Fix that too slow when sending `textDocument/didChange` at second time~~
- [x] Fix that cannot receive response from the server after timeout
- [x] Tests
- [x] help
- [x] Docs
