### PR TITLE
Fix replace command performance in Ex mode

### DIFF
--- a/changelog.d/20231023_220739_GitHub_Actions_fix-replace-performance.rst
+++ b/changelog.d/20231023_220739_GitHub_Actions_fix-replace-performance.rst
@@ -1,0 +1,7 @@
+.. _#1900:  https://github.com/fox0430/moe/pull/1900
+
+Fixed
+.....
+
+- `#1900`_ Fix replace command performance in Ex mode
+

--- a/src/moepkg/exmodeutils.nim
+++ b/src/moepkg/exmodeutils.nim
@@ -35,6 +35,8 @@ type
     description*: string
     argsType*: ArgsType
 
+  ReplaceCommandInfo* = tuple[searhWord, replaceWord: Runes]
+
 const
   ExCommandInfoList* = [
     ExCommandInfo(
@@ -832,3 +834,11 @@ proc getDescription*(command: Runes): Result[Runes, string] =
 
   return Result[Runes, string].err "Invalid command"
 
+proc parseReplaceCommand*(command: Runes): ReplaceCommandInfo =
+  ## Parse the replace command.
+  ## Examples: "/xxx/yyy", "/xxx/yyy/"
+
+  let commandSplit = command.split(ru'/')
+  if commandSplit.len < 2: return
+
+  return (searhWord: commandSplit[0], replaceWord: commandSplit[1])

--- a/src/moepkg/searchutils.nim
+++ b/src/moepkg/searchutils.nim
@@ -40,7 +40,7 @@ proc compare(rune, sub: Runes, isIgnorecase, isSmartcase: bool): bool =
   else:
     return rune == sub
 
-proc searchLine(
+proc searchLine*(
   line: Runes,
   keyword: Runes,
   isIgnorecase, isSmartcase: bool): Option[int] =


### PR DESCRIPTION
Fix the replace command performance in Ex mode. (`%s/xxx/yyy/`)

Speed up over about 1500x.

Executed `%s/proc/abc/` command in  `src/moepkg/editorstatus.nim`.
|Before|After|
|---|---|
|9 seconds, 365 milliseconds|5 milliseconds|