### PR TITLE
Rewrite clipboard

### DIFF
--- a/changelog.d/20231213_235050_GitHub_Actions_rewrite-clipboard.rst
+++ b/changelog.d/20231213_235050_GitHub_Actions_rewrite-clipboard.rst
@@ -1,2 +1,6 @@
 .. _#1966:  https://github.com/fox0430/moe/pull/1966
 
+Changed
+.....
+
+- `#1966`_ Rewrite clipboard

--- a/changelog.d/20231213_235050_GitHub_Actions_rewrite-clipboard.rst
+++ b/changelog.d/20231213_235050_GitHub_Actions_rewrite-clipboard.rst
@@ -1,0 +1,2 @@
+.. _#1966:  https://github.com/fox0430/moe/pull/1966
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -152,10 +152,10 @@ enable
 Set clipboard tool for Linux (string)  
 default is xsel
 
-`xsel` or `xclip` or `wl-clipboard`.
+`xsel`, `xclip`, `wl-clipboard`, `wsl-default`, `macOS-default`.
 
 ```
-toolOnLinux
+tool
 ```
 
 ### TabLine table

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -49,9 +49,10 @@ liveReloadOfFile = false
 colorMode = "24bit"
 
 [Clipboard]
+
 enable = true
 
-# toolOnLinux = "xsel"
+tool = "xsel"
 
 [BuildOnSave]
 

--- a/src/moepkg/configmode.nim
+++ b/src/moepkg/configmode.nim
@@ -298,7 +298,7 @@ proc getClipboardTableSettingsValues(
           result = @[ru "true", ru "false"]
         else:
           result = @[ru "false", ru "true"]
-      of "toolOnLinux":
+      of "tool":
         for toolName in ClipboardTool:
           if $toolName == "wlClipboard":
             result.add ru "wl-clipboard"
@@ -776,9 +776,9 @@ proc changeClipBoardTableSettings(
     case settingName:
       of "enable":
         settings.enable = parseBool(settingVal)
-      of "toolOnLinux":
+      of "tool":
         let name = if settingVal == "wl-clipboard": "wlClipboard" else: settingVal
-        settings.toolOnLinux = parseEnum[ClipboardTool](name)
+        settings.tool = parseEnum[ClipboardTool](name)
       else:
         discard
 
@@ -1181,7 +1181,7 @@ proc getSettingType(table, name: string): SettingType =
     case name:
       of "enable":
         result = SettingType.bool
-      of "toolOnLinux":
+      of "tool":
         result = SettingType.enums
       else:
         result = SettingType.none
@@ -1886,8 +1886,8 @@ proc initClipBoardTableBuffer(settings: ClipboardSettings): seq[Runes] =
     case $name:
       of "enable":
         result.add(ru nameStr & space & $settings.enable)
-      of "toolOnLinux":
-        result.add(ru nameStr & space & $settings.toolOnLinux)
+      of "tool":
+        result.add(ru nameStr & space & $settings.tool)
 
 proc initBuildOnSaveTableBuffer(settings: BuildOnSaveSettings): seq[Runes] =
   result.add(ru"BuildOnSave")

--- a/src/moepkg/init.nim
+++ b/src/moepkg/init.nim
@@ -136,7 +136,8 @@ proc initEditor*(): EditorStatus =
 
   result.initSidebar
 
-  result.registers.setClipBoardTool(result.settings.clipboard.toolOnLinux)
+  if result.settings.clipboard.enable:
+    result.registers.setClipBoardTool(result.settings.clipboard.tool)
 
   disableControlC()
   catchTerminalResize()

--- a/src/moepkg/registers.nim
+++ b/src/moepkg/registers.nim
@@ -114,9 +114,8 @@ proc initRegisters*(): Registers =
 proc setClipboardTool*(r: var Registers, tool: ClipboardTool) {.inline.} =
   ## Set the clipboard tool for Linux and init the clipboard register.
 
-  if tool != ClipboardTool.none:
-    r.clipboardTool = some(tool)
-    r.clipboard = initClipBoardRegister(now())
+  r.clipboardTool = some(tool)
+  r.clipboard = initClipBoardRegister(now())
 
 proc isNamedRegisterName*(c: char): bool {.inline.} =
   c in Letters
@@ -167,7 +166,7 @@ proc setNoNamedRegister*(
     r.noNamed.set(buffer)
 
     if r.clipboardTool.isSome:
-      buffer.sendToClipboard(r.clipboardTool.get)
+      discard buffer.sendToClipboard(r.clipboardTool.get)
 
 proc set(
   r: var NumberRegisters,
@@ -308,7 +307,7 @@ proc trySetClipBoardRegister(r: var Registers): bool =
   if r.clipboardTool.isSome:
     # Check the OS clipboard and update clipboard and no named registers.
 
-    let buf = getBufferFromClipboard(r.clipboardTool.get)
+    let buf = getFromClipboard(r.clipboardTool.get)
     if buf.isOk and buf.get.len > 0:
       let lines = buf.get.splitLines
       if r.isUpdateClipBoardRegister(lines):

--- a/src/moepkg/unicodeext.nim
+++ b/src/moepkg/unicodeext.nim
@@ -285,6 +285,8 @@ proc startsWith*(r1: Runes, r2: Runes | Rune): bool {.inline.} =
 proc endsWith*(r1: Runes, r2: Runes | Rune): bool {.inline.} =
   endsWith($r1, $r2)
 
+proc toString*(runes: Runes): string {.inline.} = $runes
+
 proc toString*(lines: seq[Runes]): string =
   for i, runes in lines: result &= $runes & '\n'
 
@@ -625,3 +627,13 @@ proc maxLen*(lines: seq[Runes]): int {.inline.} =
 
 proc maxHigh*(lines: seq[Runes]): int {.inline.} =
   lines.mapIt(it.high).max
+
+proc removeNewLineAtEnd*(runes: Runes): Runes =
+  result = runes
+
+  var countNewline = 0
+  for i in countdown(runes.high, 0):
+    if runes[i] in [ru'\n', ru'\r']: countNewline.inc
+    else: break
+
+  if countNewline > 0: return result[0 .. countNewline]

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -17,7 +17,7 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[unittest, strformat, os]
+import std/[unittest, strformat, os, options]
 import pkg/results
 import moepkg/[unicodeext, editorstatus, bufferstatus, color, ui, rgb, theme]
 
@@ -71,13 +71,13 @@ suite "Config mode: Init buffer":
   test "Init ClipBoard table buffer":
     var status = initEditorStatus()
     status.settings.clipboard.enable = true
-    status.settings.clipboard.toolOnLinux = ClipboardTool.none
+    status.settings.clipboard.tool = ClipboardTool.xsel
     let buffer = status.settings.clipboard.initClipBoardTableBuffer
 
     const Sample = @[
       "ClipBoard",
       "  enable                         true",
-      "  toolOnLinux                    none"].toSeqRunes
+      "  toolOnLinux                    xsel"].toSeqRunes
 
     for index, line in buffer:
       check Sample[index] == line
@@ -862,14 +862,14 @@ suite "Config mode: Get ClipBoard table setting values":
 
     checkBoolSettingValue(default, values)
 
-  test "Get toolOnLinux value":
+  test "Get tool value (none)":
     var status = initEditorStatus()
-    status.settings.clipboard.toolOnLinux = ClipboardTool.none
+    status.settings.clipboard.tool = ClipboardTool.xsel
     let clipboardSettings = status.settings.clipboard
 
-    const Name = "toolOnLinux"
+    const Name = "tool"
     let
-      default = clipboardSettings.toolOnLinux
+      default = clipboardSettings.tool
       values = clipboardSettings.getClipboardTableSettingsValues(Name)
 
     check $default == $values[0]
@@ -1850,9 +1850,9 @@ suite "Config mode: Chaging ClipBoard table settings":
       clipboardSettings = settings.clipboard
 
     let val = ClipboardTool.xclip
-    clipboardSettings.changeClipBoardTableSettings("toolOnLinux", $val)
+    clipboardSettings.changeClipBoardTableSettings("tool", $val)
 
-    check val == clipboardSettings.toolOnLinux
+    check val == clipboardSettings.tool
 
   test "Set invalid value":
     var

--- a/tests/tregisters.nim
+++ b/tests/tregisters.nim
@@ -20,43 +20,12 @@
 import std/[unittest, options, tables, importutils, osproc, os]
 import pkg/results
 import moepkg/[unicodeext, settings, independentutils]
+import utils
 
 import moepkg/registers {.all.}
 
-proc isXAvailable(): bool {.inline.} =
-  execCmdExNoOutput("xset q") == 0
-
-template isXselAvailable(): bool =
-  isXAvailable() and execCmdExNoOutput("xsel --version") == 0
-
-template isXclipAvailable(): bool =
-  isXAvailable() and execCmdExNoOutput("xclip -version") == 0
-
-template isWlClipboardAvailable(): bool =
-  isXAvailable() and execCmdExNoOutput("wl-paste --version") == 0
-
-template setBufferToXsel(buf: string): bool =
-  execShellCmd("printf '" & buf & "' | xsel -pi") == 0
-
-template setBufferToXclip(buf: string): bool =
-  execShellCmd("printf '" & buf & "' | xclip") == 0
-
-template setBufferToWlClipboard(buf: string): bool =
-  execShellCmd("printf '" & buf & "' | wl-copy") == 0
-
-template clearXsel(): bool =
-  execShellCmd("printf '' | xsel") == 0
-
-template clearXclip(): bool =
-  execShellCmd("printf '' | xclip") == 0
-
-template clearWlClipboard(): bool =
-  execShellCmd("printf '' | wl-copy") == 0
-
 proc getClipboardBuffer(tool: ClipboardTool): string =
   case tool:
-    of none:
-      discard
     of xsel:
       let r = execCmdEx("xsel -o")
       return r.output[0 .. r.output.high - 1]

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -50,7 +50,7 @@ const TomlStr = """
 
   [Clipboard]
   enable = false
-  toolOnLinux = "xclip"
+  tool = "xclip"
 
   [BuildOnSave]
   enable = true
@@ -404,7 +404,7 @@ suite "Parse configuration file":
     check settings.standard.colorMode == ColorMode.none
 
     check not settings.clipboard.enable
-    check settings.clipboard.toolOnLinux == ClipboardTool.xclip
+    check settings.clipboard.tool == ClipboardTool.xclip
 
     check settings.buildOnSave.enable
     check settings.buildOnSave.workspaceRoot == ru"/home/fox/git/moe"
@@ -546,37 +546,61 @@ suite "Parse configuration file":
     const Str = """
       [Clipboard]
       enable = true
-      toolOnLinux = "xclip""""
+      tool = "xclip""""
 
     let toml = parsetoml.parseString(Str)
     let settings = parseTomlConfigs(toml)
 
     check settings.clipboard.enable
-    check settings.clipboard.toolOnLinux == ClipboardTool.xclip
+    check settings.clipboard.tool == ClipboardTool.xclip
 
   test "Parse Clipboard setting 2":
     const Str = """
       [Clipboard]
       enable = true
-      toolOnLinux = "xsel""""
+      tool = "xsel""""
 
     let toml = parsetoml.parseString(Str)
     let settings = parseTomlConfigs(toml)
 
     check settings.clipboard.enable
-    check settings.clipboard.toolOnLinux == ClipboardTool.xsel
+    check settings.clipboard.tool == ClipboardTool.xsel
 
   test "Parse Clipboard setting 3":
     const Str = """
       [Clipboard]
       enable = true
-      toolOnLinux = "wl-clipboard""""
+      tool = "wl-clipboard""""
 
     let toml = parsetoml.parseString(Str)
     let settings = parseTomlConfigs(toml)
 
     check settings.clipboard.enable
-    check settings.clipboard.toolOnLinux == ClipboardTool.wlClipboard
+    check settings.clipboard.tool == ClipboardTool.wlClipboard
+
+  test "Parse Clipboard setting 4":
+    const Str = """
+      [Clipboard]
+      enable = true
+      tool = "wsl-default""""
+
+    let toml = parsetoml.parseString(Str)
+    let settings = parseTomlConfigs(toml)
+
+    check settings.clipboard.enable
+    check settings.clipboard.tool == ClipboardTool.wslDefault
+
+  test "Parse Clipboard setting 5":
+    const Str = """
+      [Clipboard]
+      enable = true
+      tool = "macOS-default""""
+
+    let toml = parsetoml.parseString(Str)
+    let settings = parseTomlConfigs(toml)
+
+    check settings.clipboard.enable
+    check settings.clipboard.tool == ClipboardTool.macOsDefault
 
   test "Parse color Mode setting 1":
     const Str = """

--- a/tests/utils.nim
+++ b/tests/utils.nim
@@ -1,0 +1,95 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[options, os, strutils]
+import moepkg/[independentutils, platform]
+
+proc removeLineEnd*(buf: string): string =
+  result = buf
+  result.stripLineEnd
+
+template isXAvailable*(): bool =
+  execCmdExNoOutput("xset q") == 0
+
+template isWaylandAvailable*(): bool =
+  let r = execCmdEx("echo $XDG_SESSION_TYPE")
+  if r.exitCode != 0: assert false
+
+  r.output.contains("wayland")
+
+template isXselAvailable*(): bool =
+  isXAvailable() and execCmdExNoOutput("xsel --version") == 0
+
+template isXclipAvailable*(): bool =
+  isXAvailable() and execCmdExNoOutput("xclip -version") == 0
+
+template isWlClipboardAvailable*(): bool =
+  isWaylandAvailable() and execCmdExNoOutput("wl-paste --version") == 0
+
+template setBufferToXsel*(buf: string): bool =
+  execShellCmd("printf '" & buf & "' | xsel -pi") == 0
+
+template setBufferToXclip*(buf: string): bool =
+  execShellCmd("printf '" & buf & "' | xclip") == 0
+
+template setBufferToWlClipboard*(buf: string): bool =
+  execShellCmd("printf '" & buf & "' | wl-copy") == 0
+
+template setBufferToWslDefaultClipboard*(buf: string): bool =
+  execShellCmd(
+    "printf '" & buf & "' | powershell.exe -Command Get-Clipboard") == 0
+
+template getXselBuffer*(): string =
+  let r = execCmdEx("xsel -o")
+  if r.exitCode != 0: assert false
+
+  r.output
+
+template getXclipBuffer*(): string =
+  let r = execCmdEx("xclip -o")
+  if r.exitCode != 0: assert false
+
+  r.output
+
+template getWlClipboardBuffer*(): string =
+  let r = execCmdEx("wl-paste")
+  if r.exitCode != 0: assert false
+
+  r.output
+
+template getWslDefaultBuffer*(): string =
+  let r = execCmdEx("powershell.exe -Command Get-Clipboard")
+  if r.exitCode != 0: assert false
+
+  r.output
+
+template clearXsel*(): bool =
+  execShellCmd("printf '' | xsel") == 0
+
+template clearXclip*(): bool =
+  execShellCmd("printf '' | xclip") == 0
+
+template clearWlClipboard*(): bool =
+  execShellCmd("printf '' | wl-copy") == 0
+
+template clearWslDefaultClipboard*(): bool =
+  execShellCmd("printf '' | clip.exe") == 0
+
+template isWsl*(): bool =
+  platform.currentPlatform == Platforms.wsl


### PR DESCRIPTION
## Breaking changes

- Rename clipboard config: `ClipBoard.toolOnLinux` -> `Clipboard.tool`

Before
```toml
[Clipboard]
enable = true
toolOnLinux = "xsel"
```
After
```toml
[Clipboard]
enable = true
tool = "xsel"
```

-  Add values to `Clipboard.tool`: Add `wsl-default` and `macOS-default`