### PR TITLE
Rename color configs for selection area

### DIFF
--- a/changelog.d/20231218_220335_GitHub_Actions_rename-color-name.rst
+++ b/changelog.d/20231218_220335_GitHub_Actions_rename-color-name.rst
@@ -1,0 +1,7 @@
+.. _#1974:  https://github.com/fox0430/moe/pull/1974
+
+Changed
+.......
+
+- `#1974`_ Rename color configs for selection area
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -1084,10 +1084,10 @@ searchResultBg
 
 Character color selected in visual mode
 ```
-visualMode
+selectArea
 ```
 ```
-visualModeBg
+selectAreaBg
 ```
 
 Syntax highlighting color

--- a/example/themes/dark.toml
+++ b/example/themes/dark.toml
@@ -73,8 +73,8 @@ warnMessageBg = "#000000"
 searchResult = "#ffffff"
 searchResultBg = "#ff0000"
 
-visualMode = "#ffffff"
-visualModeBg = "#800080"
+selectArea = "#ffffff"
+selectAreaBg = "#800080"
 
 keyword = "#87d7ff"
 functionName = "#00b7ce"

--- a/example/themes/light.toml
+++ b/example/themes/light.toml
@@ -73,8 +73,8 @@ warnMessageBg = "#ffffff"
 searchResult = "#000000"
 searchResultBg = "#ff0000"
 
-visualMode = "#000000"
-visualModeBg = "#800080"
+selectArea = "#000000"
+selectAreaBg = "#800080"
 
 keyword = "#00b16b"
 functionName = "#0040ff"

--- a/example/themes/vivid.toml
+++ b/example/themes/vivid.toml
@@ -73,8 +73,8 @@ warnMessageBg = "#000000"
 searchResult = "#ffffff"
 searchResultBg = "#ff0087"
 
-visualMode = "#ffffff"
-visualModeBg = "#ff0087"
+selectArea = "#ffffff"
+selectAreaBg = "#ff0087"
 
 keyword = "#ff0087"
 functionName = "#ffd700"

--- a/src/moepkg/color.nim
+++ b/src/moepkg/color.nim
@@ -392,9 +392,8 @@ type
     # search result highlighting
     searchResult
     searchResultBg
-    # selected area in visual mode
-    visualMode
-    visualModeBg
+    selectArea
+    selectAreaBg
 
     # color scheme
     keyword
@@ -569,8 +568,9 @@ type
 
     # search result highlighting
     searchResult
+
     # selected area in visual mode
-    visualMode
+    selectArea
 
     # Color scheme
     keyword

--- a/src/moepkg/editorview.nim
+++ b/src/moepkg/editorview.nim
@@ -462,7 +462,7 @@ proc writeAllLines*[T](
         if view.editorMode.isVisualMode and
            (view.originalLine[y] >= view.selectedRange.first and
            view.selectedRange.last >= view.originalLine[y]):
-             view.write(win, y, x, ru" ", EditorColorPairIndex.visualMode)
+             view.write(win, y, x, ru" ", EditorColorPairIndex.selectArea)
         else:
           view.write(win, y, x, view.lines[y], EditorColorPairIndex.default)
 

--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -421,5 +421,5 @@ proc overwriteColorSegmentBlock*[T](
         firstColumn: startColumn,
         lastRow: i,
         lastColumn: min(endColumn, buffer[i].high),
-        color: EditorColorPairIndex.visualMode)
+        color: EditorColorPairIndex.selectArea)
       highlight.overwrite(colorSegment)

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -598,7 +598,7 @@ proc makeColorThemeFromVSCodeThemeFile(jsonNode: JsonNode): ThemeColors =
     result[EditorColorPairIndex.searchResult].foreground.rgb =
       colorFromNode(jsonNode{"colors", "editor.foreground"})
 
-    result[EditorColorPairIndex.visualMode].foreground.rgb =
+    result[EditorColorPairIndex.selectArea].foreground.rgb =
       colorFromNode(jsonNode{"colors", "editor.foreground"})
 
   if jsonNode["colors"].contains("editor.background"):
@@ -963,7 +963,7 @@ proc makeColorThemeFromVSCodeThemeFile(jsonNode: JsonNode): ThemeColors =
     result[EditorColorPairIndex.searchResult].background.rgb =
       colorFromNode(jsonNode{"colors", "tab.activeBorder"})
 
-    result[EditorColorPairIndex.visualMode].background.rgb =
+    result[EditorColorPairIndex.selectArea].background.rgb =
       colorFromNode(jsonNode{"colors", "tab.activeBorder"})
 
   if jsonNode["colors"].contains("dir.inserted"):

--- a/src/moepkg/theme.nim
+++ b/src/moepkg/theme.nim
@@ -255,12 +255,12 @@ const
         rgb: "#ff0000".hexToRgb.get)),
 
     # Selected area in Visual mode
-    EditorColorPairIndex.visualMode: ColorPair(
+    EditorColorPairIndex.selectArea: ColorPair(
       foreground: Color(
-        index: EditorColorIndex.visualMode,
+        index: EditorColorIndex.selectArea,
         rgb: "#ffffff".hexToRgb.get),
       background: Color(
-        index: EditorColorIndex.visualModeBg,
+        index: EditorColorIndex.selectAreaBg,
         rgb: "#800080".hexToRgb.get)),
 
     # Color scheme

--- a/src/moepkg/viewhighlight.nim
+++ b/src/moepkg/viewhighlight.nim
@@ -93,7 +93,7 @@ proc highlightSelectedArea(
 
     var colorSegment = initSelectedAreaColorSegment(
       position,
-      EditorColorPairIndex.visualMode)
+      EditorColorPairIndex.selectArea)
 
     if area.startLine == area.endLine:
       colorSegment.firstRow = area.startLine

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -19,7 +19,7 @@
 
 import std/[unittest, strformat, os, options]
 import pkg/results
-import moepkg/[unicodeext, editorstatus, bufferstatus, color, ui, rgb, theme]
+import moepkg/[unicodeext, editorstatus, bufferstatus, ui]
 
 import moepkg/settings {.all.}
 import moepkg/configmode {.all.}

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -19,7 +19,7 @@
 
 import std/[unittest, options, importutils]
 import pkg/[parsetoml, results]
-import moepkg/[unicodeext, ui, color, rgb]
+import moepkg/[unicodeext, ui, rgb, color]
 
 import moepkg/settings {.all.}
 
@@ -279,8 +279,8 @@ warnMessageBg = "#111111"
 searchResult = "#111111"
 searchResultBg = "#111111"
 
-visualMode = "#111111"
-visualModeBg = "#111111"
+selectArea = "#111111"
+selectAreaBg = "#111111"
 
 keyword = "#111111"
 functionName = "#111111"


### PR DESCRIPTION
## Breaking change

### Rename color configs
- `Colors.visualMode` -> `Colors.selectArea` 
- `Colors.visualModeBg` `Colors.selectAreaBg`

Before
```toml
[Colors]
foreground = "#f8f5e3"
background = "#000000"

visualMode = "#ffffff"
visualModeBg = "#800080"
```

After
```toml
[Colors]
foreground = "#f8f5e3"
background = "#000000"


selectArea = "#ffffff"
selectAreaBg = "#800080"
```