### PR TITLE
lsp: Add support for window/showMessage

### DIFF
--- a/changelog.d/20231227_002341_GitHub_Actions_window-showmessage.rst
+++ b/changelog.d/20231227_002341_GitHub_Actions_window-showmessage.rst
@@ -1,0 +1,7 @@
+.. _#1977:  https://github.com/fox0430/moe/pull/1977
+
+Added
+.....
+
+- `#1977`_ lsp: Add support for window/showMessage
+

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -10,6 +10,7 @@ Please feedback, bug reports and PRs.
 
 - `Initialize`
 - `shutdown`
+- `window/showMessage`
 - `workspace/didChangeConfiguration`
 - `textDocument/didOpen`
 - `textDocument/didChange`

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -89,7 +89,7 @@ proc parseShutdownResponse*(res: JsonNode): LspShutdownResult =
   if res["result"].kind == JNull: return LspShutdownResult.ok ()
   else: return LspShutdownResult.err fmt"Shutdown request failed: {res}"
 
-proc lspMetod*(j: JsonNode): LspMethodResult =
+proc lspMethod*(j: JsonNode): LspMethodResult =
   if not j.contains("method"): return LspMethodResult.err "Invalid value"
 
   case j["method"].getStr:
@@ -115,6 +115,8 @@ proc lspMetod*(j: JsonNode): LspMethodResult =
       LspMethodResult.err "Not supported: " & j["method"].getStr
 
 proc parseLspMessageType*(num: int): parseLspMessageTypeResult =
+  ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#messageType
+
   case num:
     of 1: parseLspMessageTypeResult.ok LspMessageType.error
     of 2: parseLspMessageTypeResult.ok LspMessageType.warn

--- a/src/moepkg/lsputils.nim
+++ b/src/moepkg/lsputils.nim
@@ -147,11 +147,16 @@ proc showLspServerLog(status: var EditorStatus, notify: JsonNode) =
     return
 
   case m.get.messageType:
-    of error: status.commandLine.writeLspServerError(m.get.message)
-    of warn: status.commandLine.writeLspServerWarn(m.get.message)
-    of info: status.commandLine.writeLspServerInfo(m.get.message)
-    of log: status.commandLine.writeLspServerLog(m.get.message)
-    of debug: status.commandLine.writeLspServerDebug(m.get.message)
+    of LspMessageType.error:
+      status.commandLine.writeLspServerError(m.get.message)
+    of LspMessageType.warn:
+      status.commandLine.writeLspServerWarn(m.get.message)
+    of LspMessageType.info:
+      status.commandLine.writeLspServerInfo(m.get.message)
+    of LspMessageType.log:
+      status.commandLine.writeLspServerLog(m.get.message)
+    of LspMessageType.debug:
+      status.commandLine.writeLspServerDebug(m.get.message)
 
 proc handleLspServerNotify(status: var EditorStatus, notify: JsonNode) =
   # TODO: Add server notification supports.

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -41,6 +41,11 @@ proc writeInfo*(c: var CommandLine, message: string) =
   c.writeMessageOnCommandLine(mess, EditorColorPairIndex.commandLine)
   addMessageLog message
 
+proc writeLog*(c: var CommandLine, message: string) =
+  let mess = fmt"LOG: {message}"
+  c.writeMessageOnCommandLine(mess, EditorColorPairIndex.commandLine)
+  addMessageLog message
+
 proc writeDebug*(c: var CommandLine, message: string) =
   let mess = fmt"DEBUG: {message}"
   c.writeMessageOnCommandLine(mess, EditorColorPairIndex.commandLine)
@@ -393,7 +398,7 @@ proc writeLspServerInfo*(commandLine: var CommandLine, message: string) =
   commandLine.writeInfo(fmt"lsp: {message}")
 
 proc writeLspServerLog*(commandLine: var CommandLine, message: string) =
-  commandLine.writeStandard(fmt"lsp: {message}")
+  commandLine.writeLog(fmt"lsp: {message}")
 
 proc writeLspServerDebug*(commandLine: var CommandLine, message: string) =
   commandLine.writeDebug(fmt"lsp: {message}")

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -32,13 +32,27 @@ proc writeMessageOnCommandLine*(
   message: string) {.inline.} =
     commandLine.writeMessageOnCommandLine(message, EditorColorPairIndex.commandLine)
 
+proc writeStandard*(c: var CommandLine, message: string) =
+  c.writeMessageOnCommandLine(message, EditorColorPairIndex.commandLine)
+  addMessageLog message
+
+proc writeInfo*(c: var CommandLine, message: string) =
+  let mess = fmt"INFO: {message}"
+  c.writeMessageOnCommandLine(mess, EditorColorPairIndex.commandLine)
+  addMessageLog message
+
+proc writeDebug*(c: var CommandLine, message: string) =
+  let mess = fmt"DEBUG: {message}"
+  c.writeMessageOnCommandLine(mess, EditorColorPairIndex.commandLine)
+  addMessageLog message
+
 proc writeError*(c: var CommandLine, message: string) =
   # TODO: Add "Error:" prefix.
   c.writeMessageOnCommandLine(message, EditorColorPairIndex.errorMessage)
   addMessageLog message
 
 proc writeWarn*(c: var CommandLine, message: string) =
-  let mess = "WARN: " & message
+  let mess = fmt"WARN: {message}"
   c.writeMessageOnCommandLine(mess, EditorColorPairIndex.warnMessage)
   addMessageLog message
 
@@ -368,3 +382,18 @@ proc writeLspHoverError*(commandLine: var CommandLine, errorMessage: string) =
 proc writePasteIgnoreWarn*(commandLine: var CommandLine) =
   const Mess = "Paste is ignored in this mode"
   commandLine.writeWarn(Mess)
+
+proc writeLspServerError*(commandLine: var CommandLine, message: string) =
+  commandLine.writeError(fmt"ERR: lsp: {message}")
+
+proc writeLspServerWarn*(commandLine: var CommandLine, message: string) =
+  commandLine.writeWarn(fmt"lsp: {message}")
+
+proc writeLspServerInfo*(commandLine: var CommandLine, message: string) =
+  commandLine.writeInfo(fmt"lsp: {message}")
+
+proc writeLspServerLog*(commandLine: var CommandLine, message: string) =
+  commandLine.writeStandard(fmt"lsp: {message}")
+
+proc writeLspServerDebug*(commandLine: var CommandLine, message: string) =
+  commandLine.writeDebug(fmt"lsp: {message}")

--- a/tests/tlsplsputils.nim
+++ b/tests/tlsplsputils.nim
@@ -41,6 +41,119 @@ suite "lsp: parseTraceValue":
   test "Invalid value":
     check parseTraceValue("a").isErr
 
+suite "lsp: lspMetod":
+  test "Invalid":
+    check lspMethod(%*{"jsonrpc": "2.0", "result": nil}).isErr
+
+  test "initialize":
+    check LspMethod.initialize == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "initialize",
+      "params": nil
+    }).get
+
+  test "initialized":
+    check LspMethod.initialized == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "initialized",
+      "params": nil
+    }).get
+
+  test "shutdown":
+    check LspMethod.shutdown == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "shutdown",
+      "params": nil
+    }).get
+
+  test "window/showMessage":
+    check LspMethod.windowShowMessage == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "window/showMessage",
+      "params": nil
+    }).get
+
+  test "workspace/didChangeConfiguration":
+    check LspMethod.workspaceDidChangeConfiguration == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "workspace/didChangeConfiguration",
+      "params": nil
+    }).get
+
+  test "textDocument/didOpen":
+    check LspMethod.textDocumentDidOpen == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "textDocument/didOpen",
+      "params": nil
+    }).get
+
+  test "textDocument/didChange":
+    check LspMethod.textDocumentDidChange == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "textDocument/didChange",
+      "params": nil
+    }).get
+
+  test "textDocument/didClose":
+    check LspMethod.textDocumentDidClose == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "textDocument/didClose",
+      "params": nil
+    }).get
+
+  test "textDocument/hover":
+    check LspMethod.textDocumentHover == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "textDocument/hover",
+      "params": nil
+    }).get
+
+suite "lsp: parseLspMessageType":
+  test "Invalid":
+    check parseLspMessageType(-1).isErr
+    check parseLspMessageType(0).isErr
+    check parseLspMessageType(6).isErr
+
+  test "Error":
+    check LspMessageType.error == parseLspMessageType(1).get
+
+  test "Warning":
+    check LspMessageType.warn == parseLspMessageType(2).get
+
+  test "Info":
+    check LspMessageType.info == parseLspMessageType(3).get
+
+  test "Log":
+    check LspMessageType.log == parseLspMessageType(4).get
+
+  test "Debug":
+    check LspMessageType.debug == parseLspMessageType(5).get
+
+suite "lsp: parseWindowShowMessageNotify":
+  test "Invalid":
+    check parseWindowShowMessageNotify(%*{"jsonrpc": "2.0", "result": nil}).isErr
+
+  test "Basic":
+    check ServerMessage(
+      messageType: LspMessageType.info,
+      message: "Nimsuggest initialized for test.nim") == parseWindowShowMessageNotify(%*{
+        "jsonrpc": "2.0",
+        "method": "window/showMessage",
+        "params": {
+          "type": 3,
+          "message": "Nimsuggest initialized for test.nim"
+        }
+      }).get
+
 suite "lsp: parseTextDocumentHoverResponse":
   test "Invalid":
     let res = %*{"jsonrpc": "2.0", "params": nil}

--- a/tests/tregisters.nim
+++ b/tests/tregisters.nim
@@ -19,7 +19,7 @@
 
 import std/[unittest, options, tables, importutils, osproc, os]
 import pkg/results
-import moepkg/[unicodeext, settings, independentutils]
+import moepkg/[unicodeext, settings]
 import utils
 
 import moepkg/registers {.all.}


### PR DESCRIPTION
- Add `window/showMessage` notification support
- Show messages from LSP servers on the command line


## TODO

- [x] tests
- [x] docs