### PR TITLE
lsp: Add support for textDocument/publishDiagnostics

### DIFF
--- a/changelog.d/20231230_152037_GitHub_Actions_textdocument-publishdiagnostics.rst
+++ b/changelog.d/20231230_152037_GitHub_Actions_textdocument-publishdiagnostics.rst
@@ -1,0 +1,7 @@
+.. _#1983:  https://github.com/fox0430/moe/pull/1983
+
+Added
+.....
+
+- `#1983`_ lsp: Add support for textDocument/publishDiagnostics
+

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -11,6 +11,7 @@ Please feedback, bug reports and PRs.
 - `Initialize`
 - `shutdown`
 - `window/showMessage`
+- `textDocument/publishDiagnostics`
 - `workspace/didChangeConfiguration`
 - `textDocument/didOpen`
 - `textDocument/didChange`
@@ -33,6 +34,9 @@ extensions = ["nim"]
 
 # The LSP server command
 command = "nimlsp"
+
+# The level of verbosity 
+trace = "verbose"
 ```
 
 Configure each language by adding table `[Lsp.{languageId}]`.
@@ -44,10 +48,12 @@ enable = true
 [Lsp.nim]
 extensions = ["nim"]
 command = "nimlsp"
+trace = "off"
 
 [Lsp.rust]
 extensions = ["rs"]
 command = "rust-analyzer"
+trace = "messages"
 ```
 
 ## Uses
@@ -57,3 +63,9 @@ command = "rust-analyzer"
 Press `K` on the word in Normal mode.
 
 ![hover](https://github.com/fox0430/moe/assets/15966436/9e1f78d7-c52d-4bf7-bb51-7d86659ffeb5)
+
+### Diagnostics
+
+Results will be received from the LPS server and displayed automatically.
+
+![diagnostics](https://github.com/fox0430/moe/assets/15966436/3cc99b32-c53a-4878-846d-8fd44b4a6fb2)

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -78,26 +78,6 @@ type
 
   LspInitializeResult* = R[(), string]
 
-proc pathToUri(path: string): string =
-  ## This is a modified copy of encodeUrl in the uri module. This doesn't encode
-  ## the / character, meaning a full file path can be passed in without breaking
-  ## it.
-
-  # Assume 12% non-alnum-chars
-  result = "file://" & newStringOfCap(path.len + path.len shr 2)
-
-  for c in path:
-    case c
-      # https://tools.ietf.org/html/rfc3986#section-2.3
-      of 'a'..'z', 'A'..'Z', '0'..'9', '-', '.', '_', '~', '/':
-        result.add c
-      of '\\':
-        result.add '%'
-        result.add toHex(ord(c), 2)
-      else:
-        result.add '%'
-        result.add toHex(ord(c), 2)
-
 proc running*(c: LspClient): bool {.inline.} =
   ## Return true if the LSP server process running.
 

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -269,6 +269,9 @@ proc initInitializeParams*(
           hover: some(HoverCapability(
             dynamicRegistration: some(true),
             contentFormat: some(@["plaintext"])
+          )),
+          publishDiagnostics: some(PublishDiagnosticsCapability(
+            dynamicRegistration: some(true)
           ))
         ))
       ),

--- a/src/moepkg/syntaxcheck.nim
+++ b/src/moepkg/syntaxcheck.nim
@@ -43,6 +43,17 @@ type
     filePath*: Runes
     process*: BackgroundProcess
 
+proc toSyntaxCheckMessageType*(
+  severity: int): SyntaxCheckMessageType {.inline.} =
+    ## Convert LSP DiagnosticSeverity to SyntaxCheckMessageType.
+
+    case severity:
+      of 1: return SyntaxCheckMessageType.error
+      of 2: return SyntaxCheckMessageType.warning
+      of 3: return SyntaxCheckMessageType.info
+      of 4: return SyntaxCheckMessageType.hint
+      else: doAssert(false, "Invalid DiagnosticSeverity")
+
 proc isSyntaxCheckFormatedMessage*(m: string | Runes): bool {.inline.} =
   startsWith($m, "SyntaxError: ")
 

--- a/tests/tlsputils.nim
+++ b/tests/tlsputils.nim
@@ -276,6 +276,60 @@ suite "lsp: parseTextDocumentHoverResponse":
       }
     }
 
+suite "lsp: parseTextDocumentPublishDiagnosticsNotify":
+  test "Invalid":
+    let res = %*{"jsonrpc": "2.0", "params": nil}
+    check parseTextDocumentPublishDiagnosticsNotify(res).isErr
+
+  test "Basic":
+    check %*parseTextDocumentPublishDiagnosticsNotify(%*{
+      "jsonrpc": "2.0",
+      "method": "textDocument/publishDiagnostics",
+      "params": {
+        "uri": "file:///tmp/test.nim",
+        "diagnostics": [
+          {
+            "range": {
+              "start": {
+                "line": 0,
+                "character": 0
+              },
+              "end": {
+                "line": 0,
+                "character": 2
+              }
+            },
+            "severity": 1,
+            "code": "nimsuggest chk",
+            "source": "nim",
+            "message": "undeclared identifier: 'cho'",
+            "relatedInformation": nil
+          }
+        ]
+      }
+    }).get.get == %*{
+      "path": "/tmp/test.nim",
+      "diagnostics": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 2
+            }
+          },
+          "severity": 1,
+          "code": "nimsuggest chk",
+          "source": "nim",
+          "message": "undeclared identifier: 'cho'",
+          "relatedInformation": nil
+        }
+      ]
+    }
+
 suite "lsp: toHoverContent":
   test "Basic":
     let hoverJson = %* {


### PR DESCRIPTION
- Add support for `textDocument/publishDiagnostics` notification
- Show error, info, etc on the editor

## TODO

- [x] clean up
- [x] tests
- [x] docs