### PR TITLE
lsp: Check character before cursor when completion

### DIFF
--- a/changelog.d/20240109_235425_GitHub_Actions_fix-completion.rst
+++ b/changelog.d/20240109_235425_GitHub_Actions_fix-completion.rst
@@ -1,0 +1,7 @@
+.. _#2005:  https://github.com/fox0430/moe/pull/2005
+
+Fixed
+.....
+
+- `#2005`_ lsp: Check character before cursor when completion
+

--- a/src/moepkg/suggestionwindow.nim
+++ b/src/moepkg/suggestionwindow.nim
@@ -211,6 +211,14 @@ proc wordExistsBeforeCursor(
     let wordFirstLast = extractWordBeforeCursor(bufStatus, windowNode)
     wordFirstLast.isSome and wordFirstLast.get.word.len > 0
 
+template characterExistBeforeCursor(
+  bufStatus: BufferStatus,
+  currentPosition: BufferPosition): bool =
+
+    currentPosition.column > 0 and
+    not isWhiteSpace(
+      bufStatus.buffer[currentPosition.line][currentPosition.column - 1])
+
 proc getBufferAndLangKeyword(
   checkBuffers: seq[BufferStatus],
   firstDeletedIndex, lastDeletedIndex: int,
@@ -331,9 +339,10 @@ proc tryOpenSuggestionWindow*(
 
 proc tryOpenLspSuggestionWindow*(
   bufStatus: BufferStatus,
-  currenWindowNode: WindowNode): Option[SuggestionWindow] =
+  currentWindowNode: WindowNode): Option[SuggestionWindow] =
 
-    return buildLspSuggestionWindow(bufStatus, currenWindowNode)
+    if characterExistBeforeCursor(bufStatus, currentWindowNode.bufferPosition):
+      return buildLspSuggestionWindow(bufStatus, currentWindowNode)
 
 proc calcSuggestionWindowPosition*(
   suggestionWindow: SuggestionWindow,


### PR DESCRIPTION
Don't start completion if the first character in a line or the before cursor character is whitespace.