### PR TITLE
fix: Add safe guards to allow the editor to proceed.

### DIFF
--- a/src/moepkg/insertmode.nim
+++ b/src/moepkg/insertmode.nim
@@ -137,6 +137,8 @@ proc insertToBuffer(status: var EditorStatus, r: Rune) {.inline.} =
          error err.error
 
 proc execInsertModeCommand*(status: var EditorStatus, command: Runes) =
+  if command.len == 0:
+      return
   let key = command[0]
 
   if isCtrlC(key) or isEscKey(key):

--- a/src/moepkg/insertmode.nim
+++ b/src/moepkg/insertmode.nim
@@ -138,7 +138,7 @@ proc insertToBuffer(status: var EditorStatus, r: Rune) {.inline.} =
 
 proc execInsertModeCommand*(status: var EditorStatus, command: Runes) =
   if command.len == 0:
-      return
+    return
   let key = command[0]
 
   if isCtrlC(key) or isEscKey(key):

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -378,7 +378,6 @@ proc incrementalReplace(
 template isOpenCompletionWindowInCommandLine(
   status: EditorStatus,
   key: Rune): bool =
-
     status.completionwindow.isNone and
     currentBufStatus.isExmode and
     status.settings.standard.popupWindowInExmode and
@@ -853,7 +852,8 @@ proc editorMainLoop*(status: var EditorStatus) =
               status.confirmCompletion
               isClosedCompletionWindow = true
 
-        command.add key.get
+        if key.isSome:
+            command.add key.get
 
         let inputState = invokeCommand(
           currentBufStatus.mode,

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -853,7 +853,7 @@ proc editorMainLoop*(status: var EditorStatus) =
               isClosedCompletionWindow = true
 
         if key.isSome:
-            command.add key.get
+          command.add key.get
 
         let inputState = invokeCommand(
           currentBufStatus.mode,

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -838,7 +838,7 @@ proc editorMainLoop*(status: var EditorStatus) =
               key.get)
             key.resetKeyAndContinue
           else:
-            if isEnterKey(key.get):
+            if isEnterKey(key.get) and listLen(status.completionWindow.get) > 0:
               status.confirmCompletion
               key = none(Rune)
               isClosedCompletionWindow = true
@@ -851,7 +851,6 @@ proc editorMainLoop*(status: var EditorStatus) =
             elif not isCompletionCharacter(key.get):
               status.confirmCompletion
               isClosedCompletionWindow = true
-
         if key.isSome:
           command.add key.get
 


### PR DESCRIPTION
Due to the fact that the console breaks on the exceptions, I find it hard to post exact exception messages. See pictures for detailed exception.

## Changes in `mainloop.nim`

As outlined in #2028 

![image](https://github.com/fox0430/moe/assets/32035685/666d4467-7d86-4ed9-90b2-b8db513bb35d)

## The changes in `insertmode.nim`

I added them after fixing the one in `mainloop` and meeting another exception, in summary `Index out of bound` but I attach a picture with the whole exception.

![image](https://github.com/fox0430/moe/assets/32035685/4e4bc01f-ac18-4df1-b168-9742454bdcd0)


This is my best guess at fixing those issues. Locally it behaves good now and allows me to write in it without a problem.