### PR TITLE
(fix) directly call getEnv to get XDG_SESSION_TYPE

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -80,4 +80,4 @@ jobs:
 
     - name: Run unit test
       run: |
-        xvfb-run nimble test --verbose -y
+        xvfb-run env XDG_SESSION_TYPE=x11 nimble test --verbose -y

--- a/src/moepkg/clipboard.nim
+++ b/src/moepkg/clipboard.nim
@@ -64,11 +64,10 @@ template wslDefaultPasteCommand(): string =
 template macOsDefaultPasteCommand(): string = "pbpaste"
 
 template isXAvailable*(): bool =
-  execCmdEx("xset q").exitCode == 0
+  getEnv("XDG_SESSION_TYPE") == "x11"
 
 template isWaylandAvailable*(): bool =
-  let r = execCmdEx("echo $XDG_SESSION_TYPE")
-  r.exitCode == 0 and r.output.contains("wayland")
+  getEnv("XDG_SESSION_TYPE") == "wayland"
 
 template isXselAvailable*(): bool =
   isXAvailable() and execCmdEx("xsel --version").exitCode == 0


### PR DESCRIPTION
Moe currently invokes the shell to get whether the session type is Wayland or not. This is not necessary as `XDG_SESSION_TYPE` can be directly fetched using `getEnv` and we don't even need to call `contains`, we can directly equate it to "wayland" (lowercase) or "x11" (lowercase). This PR makes Moe now depend on `XDG_SESSION_TYPE` on X11 as well instead of evoking another program.