### PR TITLE
lsp: Fix highlighting when enabled Semantic tokens

### DIFF
--- a/changelog.d/20240430_205232_GitHub_Actions_highlight-when-empty-lsp-semantic-tokens.rst
+++ b/changelog.d/20240430_205232_GitHub_Actions_highlight-when-empty-lsp-semantic-tokens.rst
@@ -1,0 +1,7 @@
+.. _#2051:  https://github.com/fox0430/moe/pull/2051
+
+Fixed
+.....
+
+- `#2051`_ lsp: Fix highlighting when enabled Semantic tokens
+


### PR DESCRIPTION
Use standard syntax highlighting if receive an empty result with SemanticTokens.