### PR TITLE
lsp: Add Goto Definition support

### DIFF
--- a/changelog.d/20240508_214002_GitHub_Actions_goto-definition.rst
+++ b/changelog.d/20240508_214002_GitHub_Actions_goto-definition.rst
@@ -1,0 +1,7 @@
+.. _#2054:  https://github.com/fox0430/moe/pull/2054
+
+Added
+.....
+
+- `#2054`_ lsp: Add Goto Definition support
+

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -64,7 +64,7 @@
 | <kbd>**t**</kbd><kbd>**x**</kbd><br> Move to the left of the next ```x``` (any character) on the current line | <kbd>**T**</kbd><kbd>**x**</kbd><br> Move to the right of the back ```x ``` (any character) on the current line | <kbd>**y**</kbd><kbd>**t**</kbd><br><kbd>**Any key**</kbd><br> Yank characters to an any character | <kbd>**c**</kbd><kbd>**f**</kbd><br><kbd>**Any key**</kbd><br> Delete characters to an any character and enter insert mode |
 | <kbd>**H**</kbd></br> Move to the top line of the screen | <kbd>**M**</kbd></br> Move to the center line of the screen | <kbd>**L**</kbd></br> Move to the bottom line of the screen | <kbd>**%**</kbd></br> Move to matching pair of paren |
 | <kbd>**q**</kbd> <kbd>**Any key**</kbd></br> Start recording operations for Macros | <kbd>**q**</kbd></br> Stop recording operations | <kbd>**@**</kbd> <kbd>**Any key**</kbd></br> Exce a macro | <kbd>**c**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key and enter Insert mode |
-| <kbd>**d**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key | <kbd>**.**</kbd></br> Repeat the last normal mode command | <kbd>**K**</kbd></br> Hover (Need LSP) |
+| <kbd>**d**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key | <kbd>**.**</kbd></br> Repeat the last normal mode command | <kbd>**K**</kbd></br> Hover (LSP) | <kbd>**g**</kbd> <kbd>**d**</kbd></br> Goto definition (LSP) |
 
 </details>
 

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -24,6 +24,7 @@ Please feedback, bug reports and PRs.
 - `textDocument/completion`
 - `textDocument/semanticTokens/full`
 - `textDocument/inlayHint`
+- `textDocument/definition`
 - `$/progress`
 
 ## Configuration
@@ -94,3 +95,7 @@ Syntax highlighting with Semantic Tokens. Currently, only full is supported.
 Display types at the end of lines with LSP InlayHint.
 
 ![moe-inlayhint](https://github.com/fox0430/moe/assets/15966436/6e096bf4-0561-457d-944f-2526177fe33a)
+
+### Goto definition
+
+`gd` command in Normal mode. If the file is not currently, it will open in a new window.

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -235,6 +235,9 @@ enable = false
 [Lsp.Completion]
 enable = true
 
+[Lsp.Definition]
+enable = true
+
 [Lsp.Diagnostics]
 enable = true
 

--- a/src/moepkg/helputils.nim
+++ b/src/moepkg/helputils.nim
@@ -127,7 +127,8 @@ ga         - Show current character info
 q any      - Start recording operations for Macros
 q          - Stop recoding operations
 @ any      - Exec a macro
-K          - Hover (Need LSP)
+K          - Hover (LSP)
+gd         - Goto definition (LSP)
 
 # Register
 

--- a/src/moepkg/lsp.nim
+++ b/src/moepkg/lsp.nim
@@ -25,7 +25,7 @@ import lsp/[client, utils]
 import syntax/highlite
 import editorstatus, windownode, popupwindow, unicodeext, independentutils, ui,
        gapbuffer, messages, commandline, bufferstatus, syntaxcheck, completion,
-       highlight
+       highlight, movement
 
 template isLspResponse*(status: EditorStatus): bool =
   status.lspClients.contains(currentBufStatus.langId) and
@@ -376,7 +376,6 @@ proc lspInlayHint(status: var EditorStatus, res: JsonNode): Result[(), string] =
   if waitingRes.isNone:
     return Result[(), string].err fmt"Not found id: {requestId}"
 
-
   lspClient.deleteWaitingResponse(requestId)
 
   let hints = parseTextDocumentInlayHint(res)
@@ -390,7 +389,50 @@ proc lspInlayHint(status: var EditorStatus, res: JsonNode): Result[(), string] =
 
   return Result[(), string].ok ()
 
+proc lspDefinition(
+  status: var EditorStatus,
+  res: JsonNode): Result[(), string] =
+    ## textDocument/definition
+
+    let d = parseTextDocumentDefinition(res)
+    if d.isErr:
+      return Result[(), string].err d.error
+
+    let requestId =
+      try: res["id"].getInt
+      except CatchableError as e: return Result[(), string].err e.msg
+
+    lspClient.deleteWaitingResponse(requestId)
+
+    if d.get.path == $currentBufStatus.absolutePath:
+      currentMainWindowNode.currentLine = d.get.position.line
+      currentMainWindowNode.currentColumn = d.get.position.column
+    else:
+      # Open a buffer in a new window.
+      status.verticalSplitWindow
+      status.moveNextWindow
+
+      let r = status.addNewBufferInCurrentWin(d.get.path)
+      if r.isErr:
+        return Result[(), string].err fmt"Cannot open file: {d.get.path}"
+
+      status.changeCurrentBuffer(status.bufStatus.high)
+
+      template canMove(): bool =
+        d.get.position.line < currentBufStatus.buffer.len and
+        d.get.position.column < currentBufStatus.buffer[d.get.position.line].len
+
+      if not canMove():
+        return Result[(), string].err fmt"Invalid position: {$d.get.position.line}, {$d.get.position.column}"
+
+      status.resize
+      status.update
+
+      jumpLine(currentBufStatus, currentMainWindowNode, d.get.position.line)
+      currentMainWindowNode.currentColumn = d.get.position.column
+
 proc handleLspServerNotify(
+
   status: var EditorStatus,
   notify: JsonNode): Result[(), string] =
     ## Handle the notification from the server.
@@ -493,5 +535,8 @@ proc handleLspResponse*(status: var EditorStatus) =
       of LspMethod.textDocumentInlayHint:
         let r = status.lspInlayHint(resJson.get)
         if r.isErr: status.commandLine.writeLspInlayHintError(r.error)
+      of LspMethod.textDocumentDefinition:
+        let r = status.lspDefinition(resJson.get)
+        # TODO: Show error
       else:
         info fmt"lsp: Ignore response: {resJson}"

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -135,6 +135,9 @@ type
     token*: OptionalNode # int or string (ProgressToken)
     value*: OptionalNode # T
 
+  WorkDoneProgressParams* = ref object of RootObj
+    workDoneToken*: OptionalNode # ProgressToken
+
   ConfigurationItem* = ref object of RootObj
     scopeUri*: Option[string]
     section*: Option[string]
@@ -738,3 +741,7 @@ type
     paddingLeft*: Option[bool]
     paddingRight*: Option[bool]
     #data*: OptionalNode
+
+  DefinitionParams* = ref object of TextDocumentPositionParams
+    workDoneToken*: OptionalNode # ProgressToken
+    workDoneProgress*: Option[bool]

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -398,6 +398,10 @@ proc writeLspInlayHintError*(commandLine: var CommandLine, message: string) =
   let mess = fmt"lsp: Error: inlayHint failed: {message}"
   commandLine.writeError(mess)
 
+proc writeLspDefinitionError*(commandLine: var CommandLine, message: string) =
+  let mess = fmt"lsp: Error: definition failed: {message}"
+  commandLine.writeError(mess)
+
 proc writePasteIgnoreWarn*(commandLine: var CommandLine) =
   const Mess = "Paste is ignored in this mode"
   commandLine.writeWarn(Mess)

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -460,7 +460,7 @@ proc showCurrentCharInfoCommand(
 
     status.commandLine.writeCurrentCharInfo(currentChar)
 
-proc gotoDefinition(status: var EditorStatus) =
+proc requestGotoDefinition(status: var EditorStatus) =
   if not status.lspClients.contains(currentBufStatus.langId):
     debug "lsp client is not ready"
     return
@@ -1244,7 +1244,7 @@ proc normalCommand(status: var EditorStatus, commands: Runes): Option[Rune] =
     elif secondKey == ord('a'):
       status.showCurrentCharInfoCommand(currentMainWindowNode)
     elif secondKey == ord('d'):
-      status.gotoDefinition
+      status.requestGotoDefinition
   elif key == ord('G'):
     currentBufStatus.moveToLastLine(currentMainWindowNode)
   elif isCtrlU(key):

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -24,6 +24,8 @@ import editorstatus, ui, gapbuffer, unicodeext, fileutils, windownode, movement,
        editor, searchutils, bufferstatus, quickrunutils, messages, visualmode,
        commandline, viewhighlight, messagelog, registers, independentutils
 
+import std/json
+
 proc changeModeToInsertMode(status: var EditorStatus) {.inline.} =
   if currentBufStatus.isReadonly:
     status.commandLine.writeReadonlyModeWarning
@@ -457,6 +459,19 @@ proc showCurrentCharInfoCommand(
       currentChar = currentBufStatus.buffer[currentLine][currentColumn]
 
     status.commandLine.writeCurrentCharInfo(currentChar)
+
+proc gotoDefinition(status: var EditorStatus) =
+  if not status.lspClients.contains(currentBufStatus.langId):
+    debug "lsp client is not ready"
+    return
+
+  let r = lspClient.textDocumentDefinition(
+    currentBufStatus.id,
+    $currentBufStatus.absolutePath,
+    currentMainWindowNode.bufferPosition)
+  if r.isErr:
+    # TODO: Show error
+    error fmt"Goto definition failed: {r.error}"
 
 proc yankLines(
   status: var EditorStatus,
@@ -1228,6 +1243,8 @@ proc normalCommand(status: var EditorStatus, commands: Runes): Option[Rune] =
       currentBufStatus.moveToLastNonBlankOfLine(currentMainWindowNode)
     elif secondKey == ord('a'):
       status.showCurrentCharInfoCommand(currentMainWindowNode)
+    elif secondKey == ord('d'):
+      status.gotoDefinition
   elif key == ord('G'):
     currentBufStatus.moveToLastLine(currentMainWindowNode)
   elif isCtrlU(key):
@@ -1562,7 +1579,8 @@ proc isNormalModeCommand*(
         elif command.len == 2:
           if command[1] == ord('g') or
              command[1] == ord('_') or
-             command[1] == ord('a'):
+             command[1] == ord('a') or
+             command[1] == ord('d'):
                result = InputState.Valid
 
       elif command[0] == ord('z'):

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -240,6 +240,9 @@ type
   LspCompletionSettings* = object
     enable*: bool
 
+  LspDefinitionSettings* = object
+    enable*: bool
+
   LspDiagnosticsSettings* = object
     enable*: bool
 
@@ -254,6 +257,7 @@ type
 
   LspFeatureSettings* = object
     completion*: LspCompletionSettings
+    definition*: LspDefinitionSettings
     diagnostics*: LspDiagnosticsSettings
     hover*: LspHoverSettings
     inlayHint*: LspInlayHintSettings
@@ -507,6 +511,9 @@ proc initThemeSettings(): ThemeSettings =
 proc initLspCompletionSettings(): LspCompletionSettings =
   result.enable = true
 
+proc initLspDefinitionSettings(): LspDefinitionSettings =
+  result.enable = true
+
 proc initLspDiagnosticsSettings(): LspDiagnosticsSettings =
   result.enable = true
 
@@ -521,6 +528,7 @@ proc initLspSemanticTokesnSettings(): LspSemanticTokesnSettings =
 
 proc initLspFeatureSettings(): LspFeatureSettings =
   result.completion = initLspCompletionSettings()
+  result.definition = initLspDefinitionSettings()
   result.diagnostics = initLspDiagnosticsSettings()
   result.hover = initLspHoverSettings()
   result.inlayHint = initLspInlayHintSettings()
@@ -1739,6 +1747,13 @@ proc parseLspTable(s: var EditorSettings, lspConfigs: TomlValueRef) =
           case key:
             of "enable":
               s.lsp.features.completion.enable = val.getBool
+            else:
+              discard
+      of "Definition":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              s.lsp.features.definition.enable = val.getBool
             else:
               discard
       of "Diagnostics":

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -2320,6 +2320,14 @@ proc validateLspTable(table: TomlValueRef): Option[InvalidItem] =
                 return some(InvalidItem(name: $key, val: $val))
             else:
               return some(InvalidItem(name: $key, val: $val))
+      of "Definition":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              if val.kind != TomlValueKind.Bool:
+                return some(InvalidItem(name: $key, val: $val))
+            else:
+              return some(InvalidItem(name: $key, val: $val))
       of "Diagnostics":
         for key, val in val.getTable:
           case key:
@@ -2736,6 +2744,9 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
 
   result.addLine fmt "[Lsp.Completion]"
   result.addLine fmt "enable = {$settings.lsp.features.completion.enable}"
+
+  result.addLine fmt "[Lsp.Definition]"
+  result.addLine fmt "enable = {$settings.lsp.features.definition.enable}"
 
   result.addLine fmt "[Lsp.Diagnostics]"
   result.addLine fmt "enable = {$settings.lsp.features.diagnostics.enable}"

--- a/tests/tlsp.nim
+++ b/tests/tlsp.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #
@@ -648,6 +648,65 @@ suite "lsp: lspInlayHint":
     check hints[0].tooltip.get == ""
     check hints[0].paddingLeft.get == false
     check hints[0].paddingRight.get == false
+
+suite "lsp: lspDefinition":
+  var status = initEditorStatus()
+
+  setup:
+    status = initEditorStatus()
+    status.settings.lsp.enable = true
+
+    let filename = $genOid() & ".nim"
+    assert status.addNewBufferInCurrentWin(filename).isOk
+    currentBufStatus.buffer = @[
+      "type number = int",
+      "var a: number"
+    ]
+    .toSeqRunes
+    .toGapBuffer
+
+    status.lspClients["nim"] = LspClient()
+
+  test "Not found":
+    lspClient.waitingResponses[0] = WaitLspResponse(
+      bufferId: currentBufStatus.id,
+      requestId: 0,
+      lspMethod: LspMethod.textDocumentDefinition)
+
+    check status.lspDefinition(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": []
+    }).isErr
+
+  test "Basic":
+    lspClient.waitingResponses[0] = WaitLspResponse(
+      bufferId: currentBufStatus.id,
+      requestId: 0,
+      lspMethod: LspMethod.textDocumentDefinition)
+
+    check status.lspDefinition(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": [
+        {
+          "uri": pathToUri($currentBufStatus.absolutePath),
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 5,
+            },
+            "end": {
+              "line": 0,
+              "character": 5,
+            }
+          }
+        }
+      ]
+    }).isOk
+
+    check currentMainWindowNode.currentLine == 0
+    check currentMainWindowNode.currentColumn == 5
 
 suite "lsp: handleLspServerNotify":
   setup:

--- a/tests/tlsputils.nim
+++ b/tests/tlsputils.nim
@@ -894,3 +894,35 @@ suite "lsp: parseTextDocumentInlayHint":
     check r[1].tooltip.get == ""
     check r[1].paddingLeft.get == false
     check r[1].paddingRight.get == false
+
+suite "lsp: parseTextDocumentInlayHint":
+  test "Not found":
+    check parseTextDocumentDefinition(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": []
+    }).get.isNone
+
+  test "Basic":
+    check parseTextDocumentDefinition(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": [
+        {
+          "uri":  "file:///home/user/text.txt",
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 1,
+            },
+            "end": {
+              "line": 0,
+              "character": 2,
+            }
+          }
+        }
+      ]
+    }).get.get == LspDefinition(
+      path: "/home/user/text.txt",
+      position: BufferPosition(line: 0, column: 1))
+

--- a/tests/tnormalmode.nim
+++ b/tests/tnormalmode.nim
@@ -3594,3 +3594,19 @@ suite "Normal mode: requestHover":
     status.requestHover
 
     status.update
+
+suite "Normal mode: requestGotoDefinition":
+  test "Disable LSP":
+    var status = initEditorStatus()
+    status.settings.lsp.enable = false
+
+    discard status.addNewBufferInCurrentWin.get
+    currentBufStatus.buffer = @["echo 1"].toSeqRunes.toGapBuffer
+
+    status.resize(100, 100)
+    status.update
+
+    # Nothing to do
+    status.requestGotoDefinition
+
+    status.update

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -163,6 +163,9 @@ enable = true
 [Lsp.Completion]
 enable = false
 
+[Lsp.Definition]
+enable = false
+
 [Lsp.Diagnostics]
 enable = false
 
@@ -572,6 +575,8 @@ suite "settings: Parse configuration file":
     check settings.lsp.enable
 
     check not settings.lsp.features.completion.enable
+
+    check not settings.lsp.features.definition.enable
 
     check not settings.lsp.features.diagnostics.enable
 


### PR DESCRIPTION
Add LSP Goto Definition support.

- Add `gd` command to normal mode

## TODO
- [x] Tests
- [x] Docs