### PR TITLE
lsp: Add Find References support

### DIFF
--- a/changelog.d/20240523_230507_41898282+github-actions[bot]_find_references.rst
+++ b/changelog.d/20240523_230507_41898282+github-actions[bot]_find_references.rst
@@ -1,0 +1,34 @@
+.. A new scriv changelog fragment.
+..
+.. Uncomment the header that is right (remove the leading dots).
+..
+.. Added
+.. .....
+..
+.. - A bullet item for the Added category.
+..
+.. Changed
+.. .......
+..
+.. - A bullet item for the Changed category.
+..
+.. Deprecated
+.. ..........
+..
+.. - A bullet item for the Deprecated category.
+..
+.. Fixed
+.. .....
+..
+.. - A bullet item for the Fixed category.
+..
+.. Removed
+.. .......
+..
+.. - A bullet item for the Removed category.
+..
+.. Security
+.. ........
+..
+.. - A bullet item for the Security category.
+..

--- a/changelog.d/20240523_230507_41898282+github-actions[bot]_find_references.rst
+++ b/changelog.d/20240523_230507_41898282+github-actions[bot]_find_references.rst
@@ -1,34 +1,6 @@
-.. A new scriv changelog fragment.
-..
-.. Uncomment the header that is right (remove the leading dots).
-..
-.. Added
-.. .....
-..
-.. - A bullet item for the Added category.
-..
-.. Changed
-.. .......
-..
-.. - A bullet item for the Changed category.
-..
-.. Deprecated
-.. ..........
-..
-.. - A bullet item for the Deprecated category.
-..
-.. Fixed
-.. .....
-..
-.. - A bullet item for the Fixed category.
-..
-.. Removed
-.. .......
-..
-.. - A bullet item for the Removed category.
-..
-.. Security
-.. ........
-..
-.. - A bullet item for the Security category.
-..
+.. _#2060: https://github.com/fox0430/moe/pull/2060
+
+Added
+.....
+
+- `#2060`_ lsp: Add Find References support

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -825,6 +825,13 @@ defaut is `true`
 enable
 ```
 
+### Lsp.References table
+Enable/Disable LSP Find References (bool)  
+defaut is `true`
+```
+enable
+```
+
 ### Lsp.SemanticTokens table
 Enable/Disable LSP SemanticTokens (bool)  
 defaut is `true`

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -65,6 +65,7 @@
 | <kbd>**H**</kbd></br> Move to the top line of the screen | <kbd>**M**</kbd></br> Move to the center line of the screen | <kbd>**L**</kbd></br> Move to the bottom line of the screen | <kbd>**%**</kbd></br> Move to matching pair of paren |
 | <kbd>**q**</kbd> <kbd>**Any key**</kbd></br> Start recording operations for Macros | <kbd>**q**</kbd></br> Stop recording operations | <kbd>**@**</kbd> <kbd>**Any key**</kbd></br> Exce a macro | <kbd>**c**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key and enter Insert mode |
 | <kbd>**d**</kbd> <kbd>**t**</kbd> <kbd>**Any Key**</kbd></br> Delete characters until the any key | <kbd>**.**</kbd></br> Repeat the last normal mode command | <kbd>**K**</kbd></br> Hover (LSP) | <kbd>**g**</kbd> <kbd>**d**</kbd></br> Goto definition (LSP) |
+| <kbd>**g**</kbd> <kbd>**r**</kbd> Open References mode (LSP Find References) | | | |
 
 </details>
 
@@ -143,10 +144,21 @@
 
 |                               |                             |                               |                             |
 |:-----------------------------:|:---------------------------:|:-----------------------------:|:---------------------------:|
-| <kbd>**j**</kbd><br> Go Down :arrow_down: | <kbd>**k**</kbd><br> Go Up :arrow_up: | <kbd>**g**</kbd> <kbd>**g**</kbd><br> Go to the first line :arrow_up: | <kbd>**G**</kbd><br> Go to the last line :arrow_down: |
+| <kbd>**j**</kbd><br> Go Down :arrow_down: | <kbd>**k**</kbd><br> Go Up :arrow_up: | <kbd>**g**</kbd><br> Go to the first line :arrow_up: | <kbd>**G**</kbd><br> Go to the last line :arrow_down: |
 
 </details>
 
+## References mode
+
+<details open>
+  <summary>References mode</summary>
+
+|                               |                             |                               |                             |
+|:-----------------------------:|:---------------------------:|:-----------------------------:|:---------------------------:|
+| <kbd>**j**</kbd><br> Go Down :arrow_down: | <kbd>**k**</kbd><br> Go Up :arrow_up: | <kbd>**g**</kbd><br> Go to the first line :arrow_up: | <kbd>**G**</kbd><br> Go to the last line :arrow_down:
+| <kbd>**Enter**</kbd><br> Go to the destination | <kbd>**ESC**</kbd><br> Quit References mode |
+
+</details>
 
 ## Filer mode
 

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -25,6 +25,7 @@ Please feedback, bug reports and PRs.
 - `textDocument/semanticTokens/full`
 - `textDocument/inlayHint`
 - `textDocument/definition`
+- `textDocument/references`
 - `$/progress`
 
 ## Configuration
@@ -99,3 +100,9 @@ Display types at the end of lines with LSP InlayHint.
 ### Goto definition
 
 `gd` command in Normal mode. If the file is not currently, it will open in a new window.
+
+### Find References
+
+`gr` command in Normal mode. Open References mode.
+
+![moe-references](https://github.com/fox0430/moe/assets/15966436/fe34a5f9-a68b-4300-ad82-7c8bd7150d01)

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -250,6 +250,9 @@ enable = true
 [Lsp.SemanticTokens]
 enable = true
 
+[Lsp.References]
+enable = true
+
 [Lsp.nim]
 extensions = ["nim"]
 command = "nimlangserver"

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -247,10 +247,10 @@ enable = true
 [Lsp.InlayHint]
 enable = true
 
-[Lsp.SemanticTokens]
+[Lsp.References]
 enable = true
 
-[Lsp.References]
+[Lsp.SemanticTokens]
 enable = true
 
 [Lsp.nim]

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -267,7 +267,7 @@ proc isCursor*(mode: Mode): bool {.inline.} =
   ## Return true if a mode in which it uses the cursor.
 
   case mode:
-    of filer, bufManager, recentFile, backup, config, debug:
+    of filer, bufManager, recentFile, backup, config, debug, references:
       # Don't use the cursor.
       return false
     else:

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -1,6 +1,6 @@
 #[###################### GNU General Public License 3.0 ######################]#
 #                                                                              #
-#  Copyright (C) 2017─2023 Shuhei Nogawa                                       #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
 #                                                                              #
 #  This program is free software: you can redistribute it and/or modify        #
 #  it under the terms of the GNU General Public License as published by        #
@@ -48,6 +48,7 @@ type
     debug
     searchForward
     searchBackward
+    references
 
   BufferStatus* = ref object
     buffer*: GapBuffer[Runes]

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -890,10 +890,10 @@ proc update*(status: var EditorStatus) =
 
         if isSendLspInlayHintRequest():
           exitUi()
-          let err = lspClient.sendLspInlayHintRequest(
+          let err = status.lspClients[b.langId].sendLspInlayHintRequest(
             b,
             node.bufferIndex,
-            mainWindowNode)
+            node)
           if err.isErr: error "lsp: {err.error}"
 
         # The highlight for the view.

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -1154,6 +1154,8 @@ proc closeWindow*(status: var EditorStatus, node: WindowNode) =
   status.mainWindow.currentMainWindowNode = node
 
 proc deleteBuffer*(status: var EditorStatus, deleteIndex: int) =
+  ## Delete the buffer with windows.
+
   let beforeWindowIndex = currentMainWindowNode.windowIndex
 
   let langId = status.bufStatus[beforeWindowIndex].langId

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -896,7 +896,10 @@ proc update*(status: var EditorStatus) =
           status.lspClients.contains(b.langId) and
           status.lspClients[b.langId].capabilities.isSome and
           status.lspClients[b.langId].capabilities.get.inlayHint and
-          node.view.rangeOfOriginalLineInView != b.inlayHints.range
+          node.view.rangeOfOriginalLineInView != b.inlayHints.range and
+          not status.lspClients[b.langId].isWaitingResponse(
+            b.id,
+            LspMethod.textDocumentInlayHint)
 
         if isSendLspInlayHintRequest():
           let err = status.lspClients[b.langId].sendLspInlayHintRequest(

--- a/src/moepkg/helputils.nim
+++ b/src/moepkg/helputils.nim
@@ -204,6 +204,15 @@ k  - Go up
 gg - Go to the first line
 G  - Go to the last line
 
+# References mode
+
+j     - Go down
+k     - Go down
+g     - Go to the first line
+G     - Go to the last line
+Enter - Jump to the destination
+ESC   - Quit References mode
+
 # Filer mode
 
 j  - Go down

--- a/src/moepkg/lsp/handler.nim
+++ b/src/moepkg/lsp/handler.nim
@@ -460,7 +460,7 @@ proc lspReferences(
   status: var EditorStatus,
   res: JsonNode): Result[(), string] =
     ## textDocument/references
-    ## Start (Open) references mode.
+    ## Open a references mode window.
 
     let parseResult = parseTextDocumentReferencesResponse(res)
 

--- a/src/moepkg/lsp/handler.nim
+++ b/src/moepkg/lsp/handler.nim
@@ -598,5 +598,6 @@ proc handleLspResponse*(status: var EditorStatus) =
         if r.isErr: status.commandLine.writeLspDefinitionError(r.error)
       of LspMethod.textDocumentReferences:
         let r = status.lspReferences(resJson.get)
+        if r.isErr: status.commandLine.writeLspReferencesError(r.error)
       else:
         info fmt"lsp: Ignore response: {resJson}"

--- a/src/moepkg/lsp/handler.nim
+++ b/src/moepkg/lsp/handler.nim
@@ -460,6 +460,7 @@ proc lspReferences(
   status: var EditorStatus,
   res: JsonNode): Result[(), string] =
     ## textDocument/references
+    ## Start (Open) references mode.
 
     let parseResult = parseTextDocumentReferencesResponse(res)
 
@@ -483,6 +484,8 @@ proc lspReferences(
       .toGapBuffer
 
     status.resize
+
+    return Result[(), string].ok ()
 
 proc handleLspServerNotify(
   status: var EditorStatus,

--- a/src/moepkg/lsp/handler.nim
+++ b/src/moepkg/lsp/handler.nim
@@ -36,10 +36,11 @@ import
   ../syntaxcheck,
   ../completion,
   ../highlight,
-  ../movement
+  ../movement,
+  ../referencesmode
 
 import client, utils, hover, message, diagnostics, semantictoken, progress,
-       inlayhint, definition
+       inlayhint, definition, references
 
 # Workaround for Nim 1.6.2
 import completion as lspcompletion
@@ -455,8 +456,35 @@ proc lspDefinition(
 
     return Result[(), string].ok ()
 
-proc handleLspServerNotify(
+proc lspReferences(
+  status: var EditorStatus,
+  res: JsonNode): Result[(), string] =
+    ## textDocument/references
 
+    let parseResult = parseTextDocumentReferencesResponse(res)
+
+    let requestId =
+      try: res["id"].getInt
+      except CatchableError as e: return Result[(), string].err e.msg
+
+    lspClient.deleteWaitingResponse(requestId)
+
+    if parseResult.isErr:
+      return Result[(), string].err parseResult.error
+    elif parseResult.get.len == 0:
+      return Result[(), string].err "References not found"
+
+    # Open a new window with references mode.
+    status.horizontalSplitWindow
+    status.moveNextWindow
+
+    discard status.addNewBufferInCurrentWin(Mode.references)
+    currentBufStatus.buffer = initReferencesModeBuffer(parseResult.get)
+      .toGapBuffer
+
+    status.resize
+
+proc handleLspServerNotify(
   status: var EditorStatus,
   notify: JsonNode): Result[(), string] =
     ## Handle the notification from the server.
@@ -565,5 +593,7 @@ proc handleLspResponse*(status: var EditorStatus) =
       of LspMethod.textDocumentDefinition:
         let r = status.lspDefinition(resJson.get)
         if r.isErr: status.commandLine.writeLspDefinitionError(r.error)
+      of LspMethod.textDocumentReferences:
+        let r = status.lspReferences(resJson.get)
       else:
         info fmt"lsp: Ignore response: {resJson}"

--- a/src/moepkg/lsp/hover.nim
+++ b/src/moepkg/lsp/hover.nim
@@ -43,8 +43,6 @@ proc initHoverParams*(
       textDocument: TextDocumentIdentifier(uri: path.pathToUri),
       position: position)
 
-
-
 proc parseTextDocumentHoverResponse*(res: JsonNode): LspHoverResult =
   ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#hover
   if not res.contains("result"):

--- a/src/moepkg/lsp/references.nim
+++ b/src/moepkg/lsp/references.nim
@@ -1,0 +1,66 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[json, strformat]
+
+import pkg/results
+
+import ../independentutils
+
+import protocol/types
+import utils
+
+type
+  LspReference* = object
+    path*: string
+    position*: BufferPosition
+
+  LspReferencesResult* = Result[seq[LspReference], string]
+
+proc initReferenceParams*(
+  path: string,
+  position: LspPosition): ReferenceParams =
+
+    ReferenceParams(
+      textDocument: TextDocumentIdentifier(uri: path.pathToUri),
+      position: position,
+      context: ReferenceContext(includeDeclaration: true))
+
+proc parseTextDocumentReferencesResponse*(res: JsonNode): LspReferencesResult =
+  if not res.contains("result"):
+    return LspReferencesResult.err fmt"Invalid response: {res}"
+
+  let locations =
+    try:
+      res["result"].to(seq[Location])
+    except CatchableError as e:
+      let msg = fmt"json to location failed {e.msg}"
+      return LspReferencesResult.err fmt"Invalid response: {msg}"
+
+  var references: seq[LspReference] = @[]
+  for l in locations:
+    let path = l.uri.uriToPath
+    if path.isErr:
+      return LspReferencesResult.err fmt"Invalid response: {path.error}"
+
+    references.add LspReference(
+      path: path.get,
+      position: l.range.start.toBufferPosition)
+
+  return LspReferencesResult.ok references

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -52,6 +52,7 @@ type
     textDocumentSemanticTokensDelta
     textDocumentInlayHint
     textDocumentDefinition
+    textDocumentReferences
 
   LspMethodResult* = Result[LspMethod, string]
   LspShutdownResult* = Result[(), string]
@@ -121,6 +122,7 @@ proc toLspMethodStr*(m: LspMethod): string =
     of textDocumentSemanticTokensDelta: "textDocument/semanticTokens/delta"
     of textDocumentInlayHint: "textDocument/inlayHint"
     of textDocumentDefinition: "textDocument/definition"
+    of textDocumentReferences: "textDocument/references"
 
 proc parseTraceValue*(s: string): Result[TraceValue, string] =
   ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue
@@ -178,6 +180,8 @@ proc lspMethod*(j: JsonNode): LspMethodResult =
       LspMethodResult.ok textDocumentInlayHint
     of "textDocument/definition":
       LspMethodResult.ok textDocumentDefinition
+    of "textDocument/references":
+      LspMethodResult.ok textDocumentReferences
     else:
       LspMethodResult.err "Not supported: " & j["method"].getStr
 

--- a/src/moepkg/mainloop.nim
+++ b/src/moepkg/mainloop.nim
@@ -28,7 +28,7 @@ import editorstatus, bufferstatus, windownode, unicodeext, gapbuffer, ui,
        debugmode, commandline, search, commandlineutils, popupwindow, messages,
        filermodeutils, editor, registers, exmodeutils, movement, searchutils,
        independentutils, viewhighlight, completion, completionwindow,
-       worddictionary
+       worddictionary, referencesmode
 
 type
   BeforeLine = object
@@ -70,6 +70,8 @@ proc invokeCommand(
         isConfigModeCommand(command)
       of Mode.debug:
         isDebugModeCommand(command)
+      of Mode.references:
+        isReferencesModeCommand(command)
 
 proc execCommand(status: var EditorStatus, command: Runes): Option[Rune] =
   ## Exec editor commands.
@@ -103,6 +105,8 @@ proc execCommand(status: var EditorStatus, command: Runes): Option[Rune] =
       status.execConfigCommand(command)
     of Mode.debug:
       status.execDebugModeCommand(command)
+    of Mode.references:
+      status.execReferencesModeCommand(command)
 
 proc assignNextExCommandHistory(
   status: var EditorStatus,

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -402,6 +402,10 @@ proc writeLspDefinitionError*(commandLine: var CommandLine, message: string) =
   let mess = fmt"lsp: Error: definition failed: {message}"
   commandLine.writeError(mess)
 
+proc writeLspReferencesError*(commandLine: var CommandLine, message: string) =
+  let mess = fmt"lsp: Error: references failed: {message}"
+  commandLine.writeError(mess)
+
 proc writePasteIgnoreWarn*(commandLine: var CommandLine) =
   const Mess = "Paste is ignored in this mode"
   commandLine.writeWarn(Mess)

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -473,6 +473,19 @@ proc requestGotoDefinition(status: var EditorStatus) =
     # TODO: Show error
     error fmt"Goto definition failed: {r.error}"
 
+proc requestFindReferences(status: var EditorStatus) =
+  if not status.lspClients.contains(currentBufStatus.langId):
+    debug "lsp client is not ready"
+    return
+
+  let r = lspClient.textDocumentReferences(
+    currentBufStatus.id,
+    $currentBufStatus.path.absolutePath,
+    currentMainWindowNode.bufferPosition)
+  if r.isErr:
+    # TODO: Show error
+    error fmt"Find references failed: {r.error}"
+
 proc yankLines(
   status: var EditorStatus,
   start, last: int,
@@ -1245,6 +1258,8 @@ proc normalCommand(status: var EditorStatus, commands: Runes): Option[Rune] =
       status.showCurrentCharInfoCommand(currentMainWindowNode)
     elif secondKey == ord('d'):
       status.requestGotoDefinition
+    elif secondKey == ord('r'):
+      status.requestFindReferences
   elif key == ord('G'):
     currentBufStatus.moveToLastLine(currentMainWindowNode)
   elif isCtrlU(key):
@@ -1580,7 +1595,8 @@ proc isNormalModeCommand*(
           if command[1] == ord('g') or
              command[1] == ord('_') or
              command[1] == ord('a') or
-             command[1] == ord('d'):
+             command[1] == ord('d') or
+             command[1] == ord('r'):
                result = InputState.Valid
 
       elif command[0] == ord('z'):

--- a/src/moepkg/referencesmode.nim
+++ b/src/moepkg/referencesmode.nim
@@ -49,15 +49,13 @@ proc parseDestinationLine(line: Runes): Result[Destination, string] =
       try:
         parseInt(lineSplited[1])
       except ValueError:
-        # TODO: Error message
-        return
+        return Result[Destination, string].err "Invalid format: line"
 
     column =
       try:
         parseInt(lineSplited[3])
       except ValueError:
-        # TODO: Error message
-        return
+        return Result[Destination, string].err "Invalid format: column"
 
   return Result[Destination, string].ok (lineSplited[0], line, column)
 

--- a/src/moepkg/referencesmode.nim
+++ b/src/moepkg/referencesmode.nim
@@ -117,6 +117,12 @@ template isMoveUp(command: Runes): bool =
 template isMoveDown(command: Runes): bool =
   command == ru"j" or isDownKey(command)
 
+template isMoveToFirstLine(command: Runes): bool =
+  command == ru"g"
+
+template isMoveToLastLine(command: Runes): bool =
+  command == ru"G"
+
 proc isReferencesModeCommand*(command: Runes): InputState =
   result = InputState.Invalid
 
@@ -136,5 +142,9 @@ proc execReferencesModeCommand*(status: var EditorStatus, command: Runes) =
     currentBufStatus.keyUp(currentMainWindowNode)
   elif isMoveDown(command):
     currentBufStatus.keyDown(currentMainWindowNode)
+  elif isMoveToFirstLine(command):
+    currentBufStatus.moveToFirstLine(currentMainWindowNode)
+  elif isMoveToLastLine(command):
+    currentBufStatus.moveToLastLine(currentMainWindowNode)
   elif isEnterKey(command):
     status.openWindowAndJumpToReference

--- a/src/moepkg/referencesmode.nim
+++ b/src/moepkg/referencesmode.nim
@@ -22,7 +22,7 @@ import std/[os, options, strformat, sequtils]
 import pkg/results
 
 import independentutils, ui, unicodeext, editorstatus, movement, gapbuffer,
-       bufferstatus
+       bufferstatus, messages
 
 import lsp/references
 
@@ -66,11 +66,11 @@ proc openWindowAndJumpToReference(status: var EditorStatus) =
     currentBufStatus.buffer[currentMainWindowNode.currentLine])
 
   if d.isErr:
-    # TODO: Error message
+    status.commandLine.writeLspReferencesError(d.error)
     return
 
   if not fileExists($d.get.path):
-    # TODO: Error message
+    status.commandLine.writeLspReferencesError("File not found")
     return
 
   # Close references mode
@@ -91,16 +91,16 @@ proc openWindowAndJumpToReference(status: var EditorStatus) =
     # Already exist.
     status.changeCurrentBuffer(bufferIndex.get)
     if not canMove():
-      # TODO: Error message
+      status.commandLine.writeLspReferencesError("Destination not found")
       return
   else:
     let r = status.addNewBufferInCurrentWin($d.get.path)
     if r.isErr:
-      # TODO: Error message
+      status.commandLine.writeLspReferencesError(r.error)
       return
 
     if not canMove():
-      # TODO: Error message
+      status.commandLine.writeLspReferencesError("Destination not found")
       return
 
   status.resize

--- a/src/moepkg/referencesmode.nim
+++ b/src/moepkg/referencesmode.nim
@@ -1,0 +1,140 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[os, strformat, sequtils]
+
+import pkg/results
+
+import independentutils, ui, unicodeext, editorstatus, movement, gapbuffer,
+       bufferstatus
+
+import lsp/references
+
+type
+  Destination = tuple[path: Runes, line, column: int]
+
+proc initReferencesModeBuffer*(references: seq[LspReference]): seq[Runes] =
+  for r in references:
+    result.add toRunes(
+      fmt"{r.path} {r.position.line} Line {r.position.column} Col")
+
+proc closeReferencesMode(status: var EditorStatus) =
+  ## Close the window and remove the buffer.
+
+  let bufIndex = currentMainWindowNode.bufferIndex
+  status.closeWindow(currentMainWindowNode)
+  status.deleteBuffer(bufIndex)
+
+proc parseDestinationLine(line: Runes): Result[Destination, string] =
+  let lineSplited = line.split(ru' ').filterIt(it.len > 0)
+  if lineSplited.len != 5:
+    return Result[Destination, string].err "Invalid destination"
+
+  let
+    line =
+      try:
+        parseInt(lineSplited[1])
+      except ValueError:
+        # TODO: Error message
+        return
+
+    column =
+      try:
+        parseInt(lineSplited[3])
+      except ValueError:
+        # TODO: Error message
+        return
+
+  return Result[Destination, string].ok (lineSplited[0], line, column)
+
+proc openWindowAndJumpToReference(status: var EditorStatus) =
+  let d = parseDestinationLine(
+    currentBufStatus.buffer[currentMainWindowNode.currentLine])
+
+  if d.isErr:
+    # TODO: Error message
+    return
+
+  if not fileExists($d.get.path):
+    # TODO: Error message
+    return
+
+  # Close references mode
+  status.closeReferencesMode
+
+  # Open a window for the destination.
+  status.verticalSplitWindow
+  status.moveNextWindow
+
+  for i, b in status.bufStatus:
+    if b.absolutePath == d.get.path:
+      status.changeCurrentBuffer(i)
+      return
+
+  let r = status.addNewBufferInCurrentWin($d.get.path)
+  if r.isErr:
+    # TODO: Error message
+    return
+
+  template canMove(): bool =
+    d.get.line < currentBufStatus.buffer.len and
+    d.get.column < currentBufStatus.buffer[d.get.line].len
+
+  if not canMove():
+    # TODO: Error message
+    return
+
+  status.resize
+  status.update
+
+  jumpLine(currentBufStatus, currentMainWindowNode, d.get.line)
+  currentMainWindowNode.currentColumn = d.get.column
+
+template isCancel(command: Runes): bool =
+  command.len == 1 and (isCtrlC(command[0]) or isEscKey(command[0]))
+
+template isMoveUp(command: Runes): bool =
+  command == ru"k" or isUpKey(command)
+
+template isMoveDown(command: Runes): bool =
+  command == ru"j" or isDownKey(command)
+
+proc isReferencesModeCommand*(command: Runes): InputState =
+  result = InputState.Invalid
+
+  if command.len == 0:
+    return InputState.Continue
+  else:
+    if isCancel(command) or
+       isMoveUp(command) or
+       isMoveDown(command) or
+       isEnterKey(command):
+         return InputState.Valid
+
+proc execReferencesModeCommand*(status: var EditorStatus, command: Runes) =
+  if isCancel(command):
+    let bufIndex = currentMainWindowNode.bufferIndex
+    status.closeWindow(currentMainWindowNode)
+    status.deleteBuffer(bufIndex)
+  elif isMoveUp(command):
+    currentBufStatus.keyUp(currentMainWindowNode)
+  elif isMoveDown(command):
+    currentBufStatus.keyDown(currentMainWindowNode)
+  elif isEnterKey(command):
+    status.openWindowAndJumpToReference

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -252,6 +252,9 @@ type
   LspInlayHintSettings* = object
     enable*: bool
 
+  LspReferencesSettings* = object
+    enable*: bool
+
   LspSemanticTokesnSettings* = object
     enable*: bool
 
@@ -261,6 +264,7 @@ type
     diagnostics*: LspDiagnosticsSettings
     hover*: LspHoverSettings
     inlayHint*: LspInlayHintSettings
+    references*: LspReferencesSettings
     semanticTokens*: LspSemanticTokesnSettings
 
   LspSettings* = object
@@ -523,6 +527,9 @@ proc initLspHoverSettings(): LspHoverSettings =
 proc initLspInlayHintSettings(): LspInlayHintSettings =
   result.enable = true
 
+proc initLspReferencesSettings(): LspReferencesSettings =
+  result.enable = true
+
 proc initLspSemanticTokesnSettings(): LspSemanticTokesnSettings =
   result.enable = true
 
@@ -532,6 +539,7 @@ proc initLspFeatureSettings(): LspFeatureSettings =
   result.diagnostics = initLspDiagnosticsSettings()
   result.hover = initLspHoverSettings()
   result.inlayHint = initLspInlayHintSettings()
+  result.references = initLspReferencesSettings()
   result.semanticTokens = initLspSemanticTokesnSettings()
 
 proc initLspSettigns(): LspSettings =
@@ -1777,6 +1785,13 @@ proc parseLspTable(s: var EditorSettings, lspConfigs: TomlValueRef) =
               s.lsp.features.inlayHint.enable = val.getBool
             else:
               discard
+      of "References":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              s.lsp.features.references.enable = val.getBool
+            else:
+              discard
       of "SemanticTokens":
         for key, val in val.getTable:
           case key:
@@ -2756,6 +2771,9 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
 
   result.addLine fmt "[Lsp.InlayHint]"
   result.addLine fmt "enable = {$settings.lsp.features.inlayHint.enable}"
+
+  result.addLine fmt "[Lsp.References]"
+  result.addLine fmt "enable = {$settings.lsp.features.references.enable}"
 
   result.addLine fmt "[Lsp.SemanticTokens]"
   result.addLine fmt "enable = {$settings.lsp.features.semanticTokens.enable}"

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -2367,6 +2367,14 @@ proc validateLspTable(table: TomlValueRef): Option[InvalidItem] =
                 return some(InvalidItem(name: $key, val: $val))
             else:
               return some(InvalidItem(name: $key, val: $val))
+      of "References":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              if val.kind != TomlValueKind.Bool:
+                return some(InvalidItem(name: $key, val: $val))
+            else:
+              return some(InvalidItem(name: $key, val: $val))
       of "SemanticTokens":
         for key, val in val.getTable:
           case key:

--- a/src/moepkg/statusline.nim
+++ b/src/moepkg/statusline.nim
@@ -435,6 +435,8 @@ proc modeLablel(mode: Mode): string =
       "CONFIG"
     of Mode.debug:
       "DEBUG"
+    of Mode.references:
+      "REFERENCES"
     else:
       "NORMAL"
 

--- a/tests/tlspreferences.nim
+++ b/tests/tlspreferences.nim
@@ -1,0 +1,59 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, json, options]
+
+import pkg/results
+
+import moepkg/independentutils
+
+import moepkg/lsp/references {.all.}
+
+suite "lsp: parseTextDocumentReferencesResponse":
+  test "Not found":
+    check parseTextDocumentReferencesResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": []
+    }).get.len == 0
+
+  test "Basic":
+    check parseTextDocumentReferencesResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": [
+        {
+          "uri":  "file:///home/user/text.txt",
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 1,
+            },
+            "end": {
+              "line": 0,
+              "character": 2,
+            }
+          }
+        }
+      ]
+    }).get == @[
+      LspReference(
+        path: "/home/user/text.txt",
+        position: BufferPosition(line: 0, column: 1))
+    ]

--- a/tests/tlsputils.nim
+++ b/tests/tlsputils.nim
@@ -196,3 +196,11 @@ suite "lsp: lspMetod":
       "method": "textDocument/inlayHint",
       "params": nil
     }).get
+
+  test "textDocument/references":
+    check LspMethod.textDocumentReferences == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "textDocument/references",
+      "params": nil
+    }).get

--- a/tests/treferencesmode.nim
+++ b/tests/treferencesmode.nim
@@ -1,0 +1,143 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, oids, os]
+
+import pkg/results
+
+import utils
+
+import moepkg/lsp/references
+import moepkg/[bufferstatus, editorstatus, independentutils, gapbuffer,
+               windownode, unicodeext]
+
+import moepkg/referencesmode {.all.}
+
+suite "references: initReferencesModeBuffer":
+  test "Basic":
+    let r = @[
+      LspReference(
+        path: "/home/user/test1.nim",
+        position: BufferPosition(line: 0, column: 0)
+      ),
+      LspReference(
+        path: "/home/user/test1.nim",
+        position: BufferPosition(line: 1, column: 0)
+      ),
+      LspReference(
+        path: "/home/user/test2.nim",
+        position: BufferPosition(line: 10, column: 5)
+      )
+    ]
+
+    check initReferencesModeBuffer(r) == @[
+      "/home/user/test1.nim 0 Line 0 Col",
+      "/home/user/test1.nim 1 Line 0 Col",
+      "/home/user/test2.nim 10 Line 5 Col",
+    ]
+    .toSeqRunes
+
+suite "references: parseDestinationLine":
+  test "Basic 1":
+    check parseDestinationLine(ru"/home/user/test.nim 0 Line 0 Col").get == (
+     ru"/home/user/test.nim", 0, 0)
+
+  test "Basic 1":
+    check parseDestinationLine(ru"/home/user/test.nim 100 Line 999 Col").get == (
+     ru"/home/user/test.nim", 100, 999)
+
+suite "references: openWindowAndJumpToReference":
+  template openReferencesMode(
+    status: var EditorStatus,
+    references: seq[LspReference]) =
+
+      status.horizontalSplitWindow
+      status.moveNextWindow
+
+      discard status.addNewBufferInCurrentWin(Mode.references)
+      currentBufStatus.buffer = initReferencesModeBuffer(references)
+        .toGapBuffer
+
+      status.resize(100, 100)
+
+  var status: EditorStatus
+
+  let testDir = getCurrentDir() / "referencesTest"
+
+  setup:
+    status = initEditorStatus()
+
+    createDir(testDir)
+
+  teardown:
+    if dirExists(testDir):
+      removeDir(testDir)
+
+  test "Same buffer":
+    let filePath = testDir / $genOid() & ".nim"
+    writeFile(filePath, "echo 1\necho 2")
+
+    assert status.addNewBufferInCurrentWin(filePath).isOk
+
+    status.resize(100, 100)
+    status.update
+
+    let references = @[
+      LspReference(path: filePath, position: BufferPosition(line: 1, column: 0))
+    ]
+
+    status.openReferencesMode(references)
+
+    status.openWindowAndJumpToReference
+
+    check status.bufStatus.len == 1
+    check currentBufStatus.mode == Mode.normal
+    check $currentBufStatus.absolutePath == filePath
+
+    check currentMainWindowNode.bufferPosition == BufferPosition(
+      line: 1,
+      column: 0)
+
+  test "Other buffer":
+    let origFilePath = testDir / $genOid() & ".nim"
+    writeFile(origFilePath, "echo 1")
+
+    let destFilePath = testDir / $genOid() & ".nim"
+    writeFile(destFilePath, "echo 1\necho 2")
+
+    assert status.addNewBufferInCurrentWin(origFilePath).isOk
+
+    status.resize(100, 100)
+    status.update
+
+    let references = @[
+      LspReference(path: destFilePath, position: BufferPosition(line: 1, column: 0))
+    ]
+
+    status.openReferencesMode(references)
+
+    status.openWindowAndJumpToReference
+
+    check status.bufStatus.len == 2
+    check currentBufStatus.mode == Mode.normal
+    check $currentBufStatus.absolutePath == destFilePath
+
+    check currentMainWindowNode.bufferPosition == BufferPosition(
+      line: 1,
+      column: 0)

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -175,6 +175,9 @@ enable = false
 [Lsp.InlayHint]
 enable = false
 
+[Lsp.References]
+enable = false
+
 [Lsp.SemanticTokens]
 enable = false
 
@@ -583,6 +586,8 @@ suite "settings: Parse configuration file":
     check not settings.lsp.features.hover.enable
 
     check not settings.lsp.features.inlayHint.enable
+
+    check not settings.lsp.features.references.enable
 
     check not settings.lsp.features.semanticTokens.enable
 


### PR DESCRIPTION
Add LSP Find References support.

Add `gr` command to normal mode

## TODO

- [x] Hide cursor and current line highlighting on references mode
- [x] Fix status line on references mode
- [x] Fix inlayhit bug after open from references mode
- [x] Error messages
- [x] Tests
- [x] Docs