### PR TITLE
lsp: Add workspace/inlayHint/refresh support

### DIFF
--- a/changelog.d/20240809_223834_github-actions[bot]_inlay-hint-refresh.rst
+++ b/changelog.d/20240809_223834_github-actions[bot]_inlay-hint-refresh.rst
@@ -1,0 +1,7 @@
+.. _#2125:  https://github.com/fox0430/moe/pull/2125
+
+Added
+.....
+
+- `#2125`_ lsp: Add workspace/inlayHint/refresh support
+

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -24,6 +24,7 @@ Please feedback, bug reports and PRs.
 - `textDocument/completion`
 - `textDocument/semanticTokens/full`
 - `textDocument/inlayHint`
+- `workspace/inlayHint/refresh`
 - `textDocument/declaration`
 - `textDocument/definition`
 - `textDocument/typeDefinition`

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -304,7 +304,11 @@ proc read*(c: var LspClient): JsonRpcResponseResult =
 
 template isLspError*(res: JsonNode): bool = res.contains("error")
 
-template isServerNotify*(res: JsonNode): bool = res.contains("method")
+template isRequest*(res: JsonNode): bool =
+  res.contains("id") and res.contains("method")
+
+template isNotify*(res: JsonNode): bool =
+  res.contains("method")
 
 proc parseLspError*(res: JsonNode): LspErrorParseResult =
   try:
@@ -457,6 +461,9 @@ proc initInitializeParams*(
           )),
           codeLens: some(CodeLensWorkspaceClientCapabilities(
             refreshSupport: some(false)
+          )),
+          inlayHint: some(InlayHintWorkspaceClientCapabilities(
+            refreshSupport: some(true)
           ))
         )),
         textDocument: some(TextDocumentClientCapabilities(

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -164,6 +164,9 @@ type
   ExecuteCommandClientCapability* = ref object of RootObj
     dynamicRegistration*: Option[bool]
 
+  InlayHintWorkspaceClientCapabilities* = ref object of RootObj
+    refreshSupport*: Option[bool]
+
   WorkspaceClientCapabilities* = ref object of RootObj
     applyEdit*: Option[bool]
     workspaceEdit*: Option[WorkspaceEditCapability]
@@ -174,6 +177,7 @@ type
     workspaceFolders*: Option[bool]
     configuration*: Option[bool]
     codeLens*: Option[CodeLensWorkspaceClientCapabilities]
+    inlayHint*: Option[InlayHintWorkspaceClientCapabilities]
 
   SynchronizationCapability* = ref object of RootObj
     dynamicRegistration*: Option[bool]

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -57,6 +57,7 @@ type
     textDocumentSemanticTokensFull
     textDocumentSemanticTokensDelta
     textDocumentInlayHint
+    workspaceInlayHintRefresh
     textDocumentDefinition
     textDocumentReferences
     textDocumentRename
@@ -162,6 +163,7 @@ proc toLspMethodStr*(m: LspMethod): string =
     of textDocumentSemanticTokensFull: "textDocument/semanticTokens/full"
     of textDocumentSemanticTokensDelta: "textDocument/semanticTokens/delta"
     of textDocumentInlayHint: "textDocument/inlayHint"
+    of workspaceInlayHintRefresh: "workspace/inlayHint/refresh"
     of textDocumentDefinition: "textDocument/definition"
     of textDocumentReferences: "textDocument/references"
     of textDocumentRename: "textDocument/rename"
@@ -234,6 +236,8 @@ proc lspMethod*(j: JsonNode): LspMethodResult =
       LspMethodResult.ok textDocumentSemanticTokensDelta
     of "textDocument/inlayHint":
       LspMethodResult.ok textDocumentInlayHint
+    of "workspace/inlayHint/refresh":
+      LspMethodResult.ok workspaceInlayHintRefresh
     of "textDocument/definition":
       LspMethodResult.ok textDocumentDefinition
     of "textDocument/references":


### PR DESCRIPTION
Add LSP `workspace/inlayHint/refresh` request support.

Send a `inlayHint` request to a server when receiving this request from a server.