### PR TITLE
lsp: Add workspace/semanticTokens/refresh support

### DIFF
--- a/changelog.d/20240809_225834_github-actions[bot]_semantic-tokens-refresh.rst
+++ b/changelog.d/20240809_225834_github-actions[bot]_semantic-tokens-refresh.rst
@@ -1,0 +1,7 @@
+.. _#2126:  https://github.com/fox0430/moe/pull/2126
+
+Added
+.....
+
+- `#2126`_ lsp: Add workspace/semanticTokens/refresh support
+

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -23,6 +23,7 @@ Please feedback, bug reports and PRs.
 - `textDocument/hover`
 - `textDocument/completion`
 - `textDocument/semanticTokens/full`
+- `workspace/semanticTokens/refresh`
 - `textDocument/inlayHint`
 - `workspace/inlayHint/refresh`
 - `textDocument/declaration`

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -462,6 +462,9 @@ proc initInitializeParams*(
           codeLens: some(CodeLensWorkspaceClientCapabilities(
             refreshSupport: some(false)
           )),
+          semanticTokens: some(SemanticTokensWorkspaceClientCapabilities(
+            refreshSupport: some(true)
+          )),
           inlayHint: some(InlayHintWorkspaceClientCapabilities(
             refreshSupport: some(true)
           ))

--- a/src/moepkg/lsp/handler.nim
+++ b/src/moepkg/lsp/handler.nim
@@ -877,15 +877,18 @@ proc handleLspServerRequest(
       return Result[(), string].err fmt"Invalid server request: {req}"
 
     case lspMethod.get:
+      of LspMethod.workspaceSemanticTokensRefresh:
+        lspClient.sendLspSemanticTokenRequest(currentBufStatus)
       of LspMethod.workspaceInlayHintRefresh:
         lspClient.sendLspInlayHintRequest(
           currentBufStatus,
           status.bufferIndexInCurrentWindow,
           mainWindowNode)
-        return Result[(), string].ok ()
       else:
         # Ignore
         return Result[(), string].err fmt"Not supported: {req}"
+
+    return Result[(), string].ok ()
 
 proc handleLspServerNotify(
   status: var EditorStatus,

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -164,6 +164,9 @@ type
   ExecuteCommandClientCapability* = ref object of RootObj
     dynamicRegistration*: Option[bool]
 
+  SemanticTokensWorkspaceClientCapabilities* = ref object of RootObj
+    refreshSupport*: Option[bool]
+
   InlayHintWorkspaceClientCapabilities* = ref object of RootObj
     refreshSupport*: Option[bool]
 
@@ -177,6 +180,7 @@ type
     workspaceFolders*: Option[bool]
     configuration*: Option[bool]
     codeLens*: Option[CodeLensWorkspaceClientCapabilities]
+    semanticTokens*: Option[SemanticTokensWorkspaceClientCapabilities]
     inlayHint*: Option[InlayHintWorkspaceClientCapabilities]
 
   SynchronizationCapability* = ref object of RootObj

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -56,6 +56,7 @@ type
     textDocumentCompletion
     textDocumentSemanticTokensFull
     textDocumentSemanticTokensDelta
+    workspaceSemanticTokensRefresh
     textDocumentInlayHint
     workspaceInlayHintRefresh
     textDocumentDefinition
@@ -162,6 +163,7 @@ proc toLspMethodStr*(m: LspMethod): string =
     of textDocumentCompletion: "textDocument/completion"
     of textDocumentSemanticTokensFull: "textDocument/semanticTokens/full"
     of textDocumentSemanticTokensDelta: "textDocument/semanticTokens/delta"
+    of workspaceSemanticTokensRefresh: "workspace/semanticTokens/refresh"
     of textDocumentInlayHint: "textDocument/inlayHint"
     of workspaceInlayHintRefresh: "workspace/inlayHint/refresh"
     of textDocumentDefinition: "textDocument/definition"
@@ -234,6 +236,8 @@ proc lspMethod*(j: JsonNode): LspMethodResult =
       LspMethodResult.ok textDocumentSemanticTokensFull
     of "textDocument/semanticTokens/delta":
       LspMethodResult.ok textDocumentSemanticTokensDelta
+    of "workspace/semanticTokens/refresh":
+      LspMethodResult.ok workspaceSemanticTokensRefresh
     of "textDocument/inlayHint":
       LspMethodResult.ok textDocumentInlayHint
     of "workspace/inlayHint/refresh":


### PR DESCRIPTION
Add LSP `workspace/semanticTokens/refresh` request support.

Send a `semanticTokens` request to a server when receiving this request from a server.