### PR TITLE
lsp: Add Selection Range support

### DIFF
--- a/changelog.d/20240902_000307_github-actions[bot]_selection-range.rst
+++ b/changelog.d/20240902_000307_github-actions[bot]_selection-range.rst
@@ -1,0 +1,7 @@
+.. _#2169:  https://github.com/fox0430/moe/pull/2169
+
+Added
+.....
+
+- `#2169`_ lsp: Add Selection Range support
+

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -372,6 +372,13 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 | enable | bool | true | LSP Folding Range |
 
 
+### Lsp.SelectionRange table
+
+| Name | Type | Default Value | Description |
+|:-----------------------------|:-----------------------------|:---------------------------|:---------------------------|
+| enable | bool | true | LSP Selection Range |
+
+
 ### Lsp.Hover table
 
 | Name | Type | Default Value | Description |

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -137,6 +137,7 @@
 | <kbd>**\\**</kbd> <kbd>**c**</kbd></br> | Code Lens (LSP) |
 | <kbd>**z**</kbd> <kbd>**d**</kbd></br> | Delete fold lines |
 | <kbd>**z**</kbd> <kbd>**R**</kbd></br> | Delete fold lines |
+| <kbd>**Ctrl**</kbd> <kbd>**s**</kbd></br> | Selection Range (LSP) |
 
 </details>
 
@@ -190,6 +191,7 @@
 | <kbd>**Ctrl**</kbd> <kbd>**x**</kbd><br> | Decrease number |
 | <kbd>**I**</kbd><br> | Insert characters to multiple lines |
 | <kbd>**z**</kbd> <kbd>**f**</kbd><br> | Fold lines |
+| <kbd>**Ctrl**</kbd> <kbd>**s**</kbd></br> | Selection Range (LSP) |
 
 </details>
 

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -45,6 +45,7 @@ Please feedback, bug reports and PRs.
 - `$/progress`
 - `$/cancelRequest`
 - `textDocument/foldingRange`
+- `textDocument/selectionRange`
 
 ## Configuration
 
@@ -97,9 +98,15 @@ Results will be received from the LPS server and displayed automatically.
 
 ![diagnostics](https://github.com/fox0430/moe/assets/15966436/3cc99b32-c53a-4878-846d-8fd44b4a6fb2)
 
+### Folding Range
+
 `lspFold` in Ex mode. All existing folds will be expande.
 
 ![moe](https://github.com/user-attachments/assets/9fac0f03-fa70-49f8-9da0-ea9ae0c0ce04)
+
+### Selection Range
+
+`Ctrl-s` in Normal mode. Enter Visual mode and you can repeat it.
 
 ### Completion
 

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -253,6 +253,9 @@ enable = true
 [Lsp.FoldingRange]
 enable = true
 
+[Lsp.SelectionRange]
+enable = true
+
 [Lsp.Hover]
 enable = true
 

--- a/src/moepkg/bufferstatus.nim
+++ b/src/moepkg/bufferstatus.nim
@@ -97,6 +97,7 @@ type
     callHierarchyInfo*: CallHierarchyInfo # Use only in callhierarchyViewer
     documentHighlightInfo*: DocumentHighlightInfo # Lsp DocumentHighlight
     codeLenses*: seq[CodeLens] # Lsp CodeLens
+    selectionRanges*: seq[SelectionRange] # Lsp SelectionRange
 
 var
   countAddedBuffer = 0

--- a/src/moepkg/helputils.nim
+++ b/src/moepkg/helputils.nim
@@ -139,6 +139,7 @@ Space r    - Rename (LSP)
 \ r        - Code Lens (LSP)
 zd         - Delete folding lines
 zD         - Delete all folding lines
+Ctrl-s     - Selection Range (LSP)
 
 # Register
 
@@ -174,10 +175,11 @@ U       - Convert to uppercase
 >       - Indent
 <       - Unindent
 ~       - Toggle case of character under cursor
-Ctrl, a - Increase number under cursor
-Ctrl, x - Decrease number under cursor
+Ctrl-a  - Increase number under cursor
+Ctrl-x  - Decrease number under cursor
 I       - Insert character, multiple lines
 zf      - Fold selected lines
+Ctrl-s  - Selection Range (LSP)
 Esc     - Go to Normal mode
 
 # Replace mode

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -33,7 +33,7 @@ import protocol/[enums, types]
 import jsonrpc, utils, completion, progress, hover, semantictoken, inlayhint,
        definition, references, rename, typedefinition, implementation,
        callhierarchy, documenthighlight, documentlink, codelens,
-       executecommand, foldingrange
+       executecommand, foldingrange, selectionrange
 
 type
   LspError* = object
@@ -62,6 +62,7 @@ type
     codeLens*: bool
     executeCommand*: Option[seq[string]]
     foldingRange*: bool
+    selectionRange*: bool
 
   LspProgressTable* = Table[ProgressToken, ProgressReport]
 
@@ -488,6 +489,9 @@ proc initInitializeParams*(
             )),
             contextSupport: some(true)
           )),
+          selectionRange: some(SelectionRangeClientCapabilities(
+            dynamicRegistration: some(true),
+          )),
           semanticTokens: some(SemanticTokensClientCapabilities(
             dynamicRegistration: some(true),
             tokenTypes: @[],
@@ -765,6 +769,27 @@ proc setCapabilities(
            except CatchableError:
              # Invalid foldingRangeProvider
              discard
+
+    if settings.selectionRange.enable and
+       initResult.capabilities.selectionRangeProvider.isSome:
+         if initResult.capabilities.selectionRangeProvider.get.kind == JBool:
+           capabilities.selectionRange =
+             initResult.capabilities.selectionRangeProvider.get.getBool
+         else:
+           try:
+             discard initResult.capabilities.selectionRangeProvider.get.to(
+               SelectionRangeOptions)
+             capabilities.selectionRange = true
+           except CatchableError:
+             discard
+           if not capabilities.selectionRange:
+            try:
+              discard initResult.capabilities.selectionRangeProvider.get.to(
+                SelectionRangeRegistrationOptions)
+              capabilities.selectionRange = true
+            except CatchableError:
+              # Invalid selectionRangeProvider
+              discard
 
     c.capabilities = some(capabilities)
 
@@ -1561,5 +1586,31 @@ proc textDocumentFoldingRange*(
     let r = c.request(bufferId, LspMethod.textDocumentFoldingRange, params)
     if r.isErr:
       return R[(), string].err fmt"textDocument/foldingRange request failed: {r.error}"
+
+    return R[(), string].ok ()
+
+proc textDocumentSelectionRange*(
+  c: var LspClient,
+  bufferId: int,
+  path: string,
+  positions: seq[BufferPosition]): LspSendRequestResult =
+    ## Send a textDocument/selectionRange request to the server.
+    ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_selectionRange
+
+    if not c.serverProcess.running:
+      if not c.closed: c.closed = true
+      return R[(), string].err "server crashed"
+
+    if not c.isInitialized:
+      return R[(), string].err "lsp unavailable"
+
+    if not c.capabilities.get.selectionRange:
+      return R[(), string].err "textDocument/foldingRange unavailable"
+
+    let params = %* initSelectionRangeParams(path, positions)
+
+    let r = c.request(bufferId, LspMethod.textDocumentSelectionRange, params)
+    if r.isErr:
+      return R[(), string].err fmt"textDocument/selectionRange request failed: {r.error}"
 
     return R[(), string].ok ()

--- a/src/moepkg/lsp/handler.nim
+++ b/src/moepkg/lsp/handler.nim
@@ -932,15 +932,8 @@ proc lspSelectionRange(
 
     let r = selectRange.range
 
-    if r.start.line > currentBufStatus.buffer.high or
-       r.start.character > currentBufStatus.buffer[r.start.line].high:
-         return Result[(), string].err fmt"Invalid position: {r.start.line}, {r.start.character}"
-    if r.`end`.line > currentBufStatus.buffer.high or
-       r.`end`.character > currentBufStatus.buffer[r.`end`.line].high:
-         return Result[(), string].err fmt"Invalid position: {r.end.line}, {r.end.character}"
-
-    currentMainWindowNode.currentLine = r.start.line
-    currentMainWindowNode.currentColumn = r.start.character
+    # The start position
+    currentMainWindowNode.moveCursor(currentBufStatus, r.start)
 
     # Enter to Visual mode
     status.changeMode(Mode.visual)
@@ -949,8 +942,8 @@ proc lspSelectionRange(
       currentMainWindowNode.currentColumn)
       .some
 
-    currentMainWindowNode.currentLine = r.`end`.line
-    currentMainWindowNode.currentColumn = r.`end`.character
+    # The end position
+    currentMainWindowNode.moveCursor(currentBufStatus, r.`end`)
 
     if selectRange.parent.isSome:
       currentBufStatus.selectionRanges = @[selectRange.parent.get]

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -277,6 +277,9 @@ type
     foldingRangeKind*: Option[FoldingRangeKindValueSet]
     foldingRange*: Option[FoldingRangeFoldingRange]
 
+  SelectionRangeClientCapabilities* = ref object of RootObj
+    dynamicRegistration*: Option[bool]
+
   SemanticTokensClientCapabilitiesRequest* = ref object of RootObj
     range*: Option[bool]
     full*: Option[bool]
@@ -331,6 +334,7 @@ type
     rename*: Option[RenameCapability]
     publishDiagnostics*: Option[PublishDiagnosticsCapability]
     foldingRange*: Option[FoldingRangeClientCapabilities]
+    selectionRange*: Option[SelectionRangeClientCapabilities]
     semanticTokens*: Option[SemanticTokensClientCapabilities]
     inlayHint*: Option[InlayHintClientCapabilities]
     declaration*: Option[DeclarationClientCapabilities]
@@ -446,6 +450,13 @@ type
 
   FoldingRangeOptions* = ref object of WorkDoneProgressOptions
 
+  SelectionRangeOptions* = ref object of WorkDoneProgressOptions
+
+  SelectionRangeRegistrationOptions* = ref object of WorkDoneProgressParams
+    workDoneProgress*: Option[bool]
+    documentSelector*: Option[DocumentSelector]
+    id*: Option[string]
+
   ImplementationOptions* = ref object of WorkDoneProgressOptions
 
   DeclarationOptions* = ref object of WorkDoneProgressOptions
@@ -503,6 +514,7 @@ type
     inlayHintProvider*: OptionalNode # bool | InlayHintOptions | InlayHintRegistrationOptions
     diagnosticProvider*: OptionalNode # DiagnosticOptions | DiagnosticRegistrationOptions
     foldingRangeProvider*: OptionalNode # bool | FoldingRangeOptions
+    selectionRangeProvider*: OptionalNode # bool | SelectionRangeOptions | SelectionRangeRegistrationOptions
     callHierarchyProvider*: OptionalNode # bool | CallHierarchyOptions | CallHierarchyRegistrationOptions
     executeCommandProvider*: Option[ExecuteCommandOptions]
     experimental*: OptionalNode
@@ -892,3 +904,11 @@ type
     endCharacter*: Option[uint]
     kind*: Option[FoldingRangeKind]
     collapsedText*: Option[string]
+
+  SelectionRangeParams* = ref object of WorkDoneProgressParams
+    textDocument*: TextDocumentIdentifier
+    positions*: seq[Position]
+
+  SelectionRange* = ref object of RootObj
+    range*: Range
+    parent*: Option[SelectionRange]

--- a/src/moepkg/lsp/selectionrange.nim
+++ b/src/moepkg/lsp/selectionrange.nim
@@ -1,0 +1,60 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[strformat, json, sequtils]
+
+import pkg/results
+
+import ../independentutils
+
+import protocol/types
+import utils
+
+export SelectionRange, Range
+
+type
+  LspSelectionRangeResult* = Result[seq[SelectionRange], string]
+
+proc initSelectionRangeParams*(
+  path: string,
+  positions: seq[BufferPosition]): SelectionRangeParams =
+
+    SelectionRangeParams(
+      textDocument: TextDocumentIdentifier(uri: path.pathToUri),
+      positions: positions.mapIt(it.toLspPosition))
+
+proc parseTextDocumentSelectionRangeResponse*(
+  res: JsonNode): LspSelectionRangeResult =
+
+    if res["result"].kind == JNull:
+      # Not found
+      return LspSelectionRangeResult.ok @[]
+    elif res["result"].kind != JArray:
+      return LspSelectionRangeResult.err "Invalid response"
+    elif res["result"].len == 0:
+      # Not found
+      return LspSelectionRangeResult.ok @[]
+
+    let selectionRanges =
+      try:
+        res["result"].to(seq[SelectionRange])
+      except CatchableError as e:
+        return LspSelectionRangeResult.err fmt"Invalid response: {e.msg}"
+
+    return LspSelectionRangeResult.ok selectionRanges

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -76,6 +76,7 @@ type
     workspaceCodeLensRefresh
     workspaceExecuteCommand
     textDocumentFoldingRange
+    textDocumentSelectionRange
 
   CallHierarchyType* = enum
     prepare
@@ -185,6 +186,7 @@ proc toLspMethodStr*(m: LspMethod): string =
     of workspaceCodeLensRefresh: "workspace/codeLens/refresh"
     of workspaceExecuteCommand: "workspace/executeCommand"
     of textDocumentFoldingRange: "textDocument/foldingRange"
+    of textDocumentSelectionRange: "textDocument/selectionRange"
 
 proc parseTraceValue*(s: string): Result[TraceValue, string] =
   ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue
@@ -280,6 +282,8 @@ proc lspMethod*(j: JsonNode): LspMethodResult =
      LspMethodResult.ok workspaceExecuteCommand
     of "textDocument/foldingRange":
       LspMethodResult.ok textDocumentFoldingRange
+    of "textDocument/selectionRange":
+       LspMethodResult.ok textDocumentSelectionRange
     else:
       LspMethodResult.err "Not supported: " & j["method"].getStr
 
@@ -310,6 +314,7 @@ proc getWaitingType*(lspMethod: LspMethod): Option[WaitType] =
     of codeLensResolve: some(WaitType.foreground)
     of workspaceExecuteCommand: some(WaitType.foreground)
     of textDocumentFoldingRange: some(WaitType.foreground)
+    of textDocumentSelectionRange: some(WaitType.foreground)
     else: none(WaitType)
 
 proc isForegroundWait*(lspMethod: LspMethod): bool {.inline.} =

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -459,6 +459,10 @@ proc writeLspFoldingRangeError*(commandLine: var CommandLine, message: string) =
   let mess = fmt"lsp: Error: folding range: {message}"
   commandLine.writeError(mess)
 
+proc writeLspSelectionRangeError*(commandLine: var CommandLine, message: string) =
+  let mess = fmt"lsp: Error: selection range: {message}"
+  commandLine.writeError(mess)
+
 proc writePasteIgnoreWarn*(commandLine: var CommandLine) =
   const Mess = "Paste is ignored in this mode"
   commandLine.writeWarn(Mess)

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -258,6 +258,9 @@ type
   LspFoldingRangeSettings* = object
     enable*: bool
 
+  LspSelectionRangeSettings* = object
+    enable*: bool
+
   LspHoverSettings* = object
     enable*: bool
 
@@ -296,6 +299,7 @@ type
     implementation*: LspImplementationSettings
     diagnostics*: LspDiagnosticsSettings
     foldingRange*: LspFoldingRangeSettings
+    selectionRange*: LspSelectionRangeSettings
     hover*: LspHoverSettings
     inlayHint*: LspInlayHintSettings
     references*: LspReferencesSettings
@@ -581,6 +585,9 @@ proc initLspDiagnosticsSettings(): LspDiagnosticsSettings =
 proc initFoldingRangeSettings(): LspFoldingRangeSettings =
   result.enable = true
 
+proc initSelectionRangeSettings(): LspSelectionRangeSettings =
+  result.enable = true
+
 proc initLspHoverSettings(): LspHoverSettings =
   result.enable = true
 
@@ -619,6 +626,7 @@ proc initLspFeatureSettings(): LspFeatureSettings =
   result.implementation = initLspImplementationSettings()
   result.diagnostics = initLspDiagnosticsSettings()
   result.foldingRange = initFoldingRangeSettings()
+  result.selectionRange = initSelectionRangeSettings()
   result.hover = initLspHoverSettings()
   result.inlayHint = initLspInlayHintSettings()
   result.references = initLspReferencesSettings()
@@ -1896,6 +1904,13 @@ proc parseLspTable(s: var EditorSettings, lspConfigs: TomlValueRef) =
               s.lsp.features.foldingRange.enable = val.getBool
             else:
               discard
+      of "SelectionRange":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              s.lsp.features.selectionRange.enable = val.getBool
+            else:
+              discard
       of "Hover":
         for key, val in val.getTable:
           case key:
@@ -2575,6 +2590,14 @@ proc validateLspTable(table: TomlValueRef): Option[InvalidItem] =
                 return some(InvalidItem(name: $key, val: $val))
             else:
               return some(InvalidItem(name: $key, val: $val))
+      of "SelectionRange":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              if val.kind != TomlValueKind.Bool:
+                return some(InvalidItem(name: $key, val: $val))
+            else:
+              return some(InvalidItem(name: $key, val: $val))
       of "Hover":
         for key, val in val.getTable:
           case key:
@@ -3060,6 +3083,9 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
 
   result.addLine fmt "[Lsp.FoldingRange]"
   result.addLine fmt "enable = {$settings.lsp.features.foldingRange.enable}"
+
+  result.addLine fmt "[Lsp.SelectionRange]"
+  result.addLine fmt "enable = {$settings.lsp.features.selectionRange.enable}"
 
   result.addLine fmt "[Lsp.Hover]"
   result.addLine fmt "enable = {$settings.lsp.features.hover.enable}"

--- a/tests/tlspclient.nim
+++ b/tests/tlspclient.nim
@@ -897,6 +897,48 @@ suite "lsp: setCapabilities":
 
     check not client.capabilities.get.foldingRange
 
+  test "Enable Selection Range":
+    let
+      r = InitializeResult(
+        capabilities: ServerCapabilities(
+          selectionRangeProvider: some(%*true)))
+
+      s = LspFeatureSettings(
+        selectionRange: LspSelectionRangeSettings(
+          enable: true))
+
+    client.setCapabilities(r, s)
+
+    check client.capabilities.get.selectionRange
+
+  test "Disable Selection Range":
+    let
+      r = InitializeResult(
+        capabilities: ServerCapabilities(
+          selectionRangeProvider: none(JsonNode)))
+
+      s = LspFeatureSettings(
+        selectionRange: LspSelectionRangeSettings(
+          enable: true))
+
+    client.setCapabilities(r, s)
+
+    check not client.capabilities.get.selectionRange
+
+  test "Disable Selection Range 2":
+    let
+      r = InitializeResult(
+        capabilities: ServerCapabilities(
+          selectionRangeProvider: some(%*true)))
+
+      s = LspFeatureSettings(
+        selectionRange: LspSelectionRangeSettings(
+          enable: false))
+
+    client.setCapabilities(r, s)
+
+    check not client.capabilities.get.selectionRange
+
 suite "lsp: Send requests":
   privateAccess(LspClient)
 

--- a/tests/tlspselectionrange.nim
+++ b/tests/tlspselectionrange.nim
@@ -1,0 +1,111 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, json, options]
+
+import pkg/results
+
+import moepkg/lsp/protocol/types
+import moepkg/lsp/selectionrange {.all.}
+
+suite "lsp: parseTextDocumentSelectionRangeResponse":
+  test "Not found":
+    check parseTextDocumentSelectionRangeResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": []
+    })
+    .get
+    .len == 0
+
+  test "Not found 2":
+    check parseTextDocumentSelectionRangeResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": nil
+    })
+    .get
+    .len == 0
+
+  test "Basic":
+    let selectionRanges = parseTextDocumentSelectionRangeResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": [
+        {
+          "range": {
+            "start": {
+              "line": 5,
+              "character": 0
+            },
+            "end": {
+              "line": 5,
+              "character": 0
+            }
+          },
+          "parent": {
+            "range": {
+              "start": {
+                "line": 5,
+                "character": 0
+              },
+              "end": {
+                "line": 6,
+                "character": 0
+              }
+            },
+            "parent": {
+              "range": {
+                "start": {
+                  "line": 4,
+                  "character": 10
+                },
+                "end": {
+                  "line": 7,
+                  "character": 1
+                }
+              }
+            }
+          }
+        }
+      ]
+    })
+    .get
+
+    check selectionRanges.len == 1
+
+    var r = selectionRanges[0]
+    check r.range.start.line == 5
+    check r.range.start.character == 0
+    check r.range.`end`.line == 5
+    check r.range.`end`.character == 0
+
+    r = r.parent.get
+    check r.range.start.line == 5
+    check r.range.start.character == 0
+    check r.range.`end`.line == 6
+    check r.range.`end`.character == 0
+
+    r = r.parent.get
+    check r.range.start.line == 4
+    check r.range.start.character == 10
+    check r.range.`end`.line == 7
+    check r.range.`end`.character == 1
+
+    check r.parent.isNone

--- a/tests/tlsputils.nim
+++ b/tests/tlsputils.nim
@@ -310,9 +310,17 @@ suite "lsp: lspMethod":
     }).get
 
   test "textDocument/foldingRange":
-    check LspMethod.textDocumentFoldingRange== lspMethod(%*{
+    check LspMethod.textDocumentFoldingRange == lspMethod(%*{
       "jsonrpc": "2.0",
       "id": 0,
       "method": "textDocument/foldingRange",
+      "params": nil
+    }).get
+
+  test "textDocument/selectionRange":
+    check LspMethod.textDocumentSelectionRange == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "textDocument/selectionRange",
       "params": nil
     }).get

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -181,6 +181,9 @@ enable = false
 [Lsp.FoldingRange]
 enable = false
 
+[Lsp.SelectionRange]
+enable = false
+
 [Lsp.Hover]
 enable = false
 
@@ -624,6 +627,8 @@ suite "settings: Parse configuration file":
     check not settings.lsp.features.diagnostics.enable
 
     check not settings.lsp.features.foldingRange.enable
+
+    check not settings.lsp.features.selectionRange.enable
 
     check not settings.lsp.features.hover.enable
 


### PR DESCRIPTION
Add LSP Selection Range support.

- Add `Ctrl-s` command to Normal and Visual Mode.

## TODO
- [x] tests
- [x] docs