### PR TITLE
ci: test with nightlies devel compiler

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,5 +71,13 @@ jobs:
         with:
           nim-version: ${{ matrix.nim-version }}
           repo-token: ${{ secrets.GITHUB_TOKEN }}
+        if: matrix.nim-version != 'devel'
+
+      - uses: jiro4989/setup-nim-action@v2
+        with:
+          nim-version: ${{ matrix.nim-version }}
+          use-nightlies: true
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+        if: matrix.nim-version == 'devel'
 
       - run: nimble build -y


### PR DESCRIPTION
## Overview

* use `use-nightlies` parameter in CI test with `devel` compiler
  * `use-nightlies` is available in [setup-nim-action `v2.2.0`](https://github.com/jiro4989/setup-nim-action/releases/tag/v2.2.0)
  * CI will complete faster because it will use [nightlies build](https://github.com/nim-lang/nightlies/releases) (latest-devel) compiler.