### PR TITLE
lsp: Add Document Formatting support

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,8 @@ This project's goals are easily customizable, high productivity, user friendly, 
 
   - Code Lens
 
+  - Document Formatting
+
   - Rename
 
   - Semantic Tokens

--- a/changelog.d/20240918_230642_github-actions[bot]_document-format.rst
+++ b/changelog.d/20240918_230642_github-actions[bot]_document-format.rst
@@ -1,0 +1,7 @@
+.. _#2187:  https://github.com/fox0430/moe/pull/2187
+
+Added
+.....
+
+- `#2187`_ lsp: Add Document Formatting support
+

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -346,6 +346,7 @@
 | `highlightCurrentLine on` or `highlightCurrentLine off` | Change the highlight setting of the current line |
 | `build` | Build the current buffer |
 | `lspFold` | LSP Folding Range |
+| `lspFormat` | LSP Document Formatting |
 | `log` | Open a log viewer for editor log |
 | `lspLog` | Open a log viewer for LSP log |
 | `lspRestart` | Result the current LSP server |

--- a/documents/lsp.md
+++ b/documents/lsp.md
@@ -49,6 +49,7 @@ Please feedback, bug reports and PRs.
 - `textDocument/selectionRange`
 - `textDocument/documentSymbol`
 - `textDocument/signatureHelp`
+- `textDocument/formatting`
 
 ## Configuration
 
@@ -106,6 +107,10 @@ Results will be received from the LPS server and displayed automatically.
 `Ctrl-r` in Normal mode. Show the signature help on the hover.
 
 ![moe-signature](https://github.com/user-attachments/assets/7c8f2487-7cd9-4bb5-8833-2e495fdd21b3)
+
+### Document Formatting
+
+`lspFormat` in Ex mode. Format the buffer.
 
 ### Folding Range
 

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -253,6 +253,9 @@ enable = true
 [Lsp.SignatureHelp]
 enable = true
 
+[Lsp.DocumentFormatting]
+enable = true
+
 [Lsp.FoldingRange]
 enable = true
 

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -23,7 +23,7 @@ import std/[strutils, os, times, options, strformat, logging, tables, sequtils,
 import pkg/results
 
 import syntax/highlite
-import lsp/client
+import lsp/[client, formatting]
 import editorstatus, ui, normalmode, gapbuffer, fileutils, editorview,
        unicodeext, independentutils, highlight, windownode, movement, build,
        bufferstatus, editor, settings, quickrunutils, messages, commandline,
@@ -1195,9 +1195,15 @@ proc lspDocumentFormatting(status: var EditorStatus) =
     status.commandLine.writeLspError("Client not found")
     return
 
-  let r = lspClient.textDocumentDocumentFormatting(
+  let options = FormattingOptions(
+    tabSize: status.settings.standard.tabStop,
+    insertSpaces: true,
+    insertFinalNewline: some(true))
+
+  let r = lspClient.textDocumentFormatting(
     currentBufStatus.id,
-    $currentBufStatus.absolutePath)
+    $currentBufStatus.absolutePath,
+    options)
   if r.isErr:
     status.commandLine.writeLspDocumentFormattingHelpError(r.error)
 

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -1188,6 +1188,19 @@ proc lspRestartClient(status: var EditorStatus) =
       if r.isErr:
         status.commandLine.writeLspError(r.error)
 
+proc lspDocumentFormatting(status: var EditorStatus) =
+  status.changeMode(currentBufStatus.prevMode)
+
+  if not status.lspClients.contains(currentBufStatus.langId):
+    status.commandLine.writeLspError("Client not found")
+    return
+
+  let r = lspClient.textDocumentDocumentFormatting(
+    currentBufStatus.id,
+    $currentBufStatus.absolutePath)
+  if r.isErr:
+    status.commandLine.writeLspDocumentFormattingHelpError(r.error)
+
 proc saveExCommandHistory(
   exCommandHistory: var seq[Runes],
   command: seq[Runes],
@@ -1385,6 +1398,8 @@ proc exModeCommand*(status: var EditorStatus, command: seq[Runes]) =
     status.lspFoldingRange
   elif isLspRestartCommand(command):
     status.lspRestartClient
+  elif isLspFormatCommand(command):
+    status.lspDocumentFormatting
   else:
     status.commandLine.writeNotEditorCommandError(command)
     status.changeMode(currentBufStatus.prevMode)

--- a/src/moepkg/exmodeutils.nim
+++ b/src/moepkg/exmodeutils.nim
@@ -183,6 +183,10 @@ const
       command: "lspFold",
       description: "LSP Folding Range",
       argsType: ArgsType.none),
+   ExCommandInfo(
+      command: "lspFormat",
+      description: "LSP Document Formatting",
+      argsType: ArgsType.none),
     ExCommandInfo(
       command: "lspLog",
       description: "Open the LSP log viewer",
@@ -763,6 +767,9 @@ proc isLspExeCommand*(command: seq[Runes]): bool {.inline.} =
 proc isLspFoldingCommand*(command: seq[Runes]): bool {.inline.} =
   command.len == 1 and cmpIgnoreCase($command[0], "lspfold") == 0
 
+proc isLspFormatCommand*(command: seq[Runes]): bool {.inline.} =
+  command.len == 1 and cmpIgnoreCase($command[0], "lspformat") == 0
+
 proc isLspRestartCommand*(command: seq[Runes]): bool {.inline.} =
   command.len == 1 and cmpIgnoreCase($command[0], "lsprestart") == 0
 
@@ -844,7 +851,8 @@ proc isValidExCommand*(commandSplit: seq[Runes]): bool =
     isBuildCommand(commandSplit) or
     isLspExeCommand(commandSplit) or
     isLspFoldingCommand(commandSplit) or
-    isLspRestartCommand(commandSplit)
+    isLspRestartCommand(commandSplit) or
+    isLspFormatCommand(commandSplit)
 
 proc getArgsType*(command: Runes): Result[ArgsType, string] =
   ## Return ArgsType if valid ex command.

--- a/src/moepkg/helputils.nim
+++ b/src/moepkg/helputils.nim
@@ -303,6 +303,7 @@ smartcase - Change setting to smartcase
 highlightCurrentLine on or highlightCurrentLine off - Change the highlight setting of the current line
 build - Build the current buffer
 lspFold - LSP Folding Range
+lspFormat - LSP Document Formatting
 
 log - Open a log viewer for editor log
 lspLog- Open a log viewer for LSP log

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -34,7 +34,7 @@ import jsonrpc, utils, completion, progress, hover, semantictoken, inlayhint,
        definition, references, rename, typedefinition, implementation,
        callhierarchy, documenthighlight, documentlink, codelens, foldingrange,
        executecommand, selectionrange, documentsymbol, inlinevalue,
-       signaturehelp
+       signaturehelp, documentformatting
 
 type
   LspError* = object
@@ -67,6 +67,7 @@ type
     selectionRange*: bool
     documentSymbol*: bool
     signatureHelp*: Option[SignatureHelpOptions]
+    formatting*: bool
 
   LspProgressTable* = Table[ProgressToken, ProgressReport]
 
@@ -525,6 +526,9 @@ proc initInitializeParams*(
           publishDiagnostics: some(PublishDiagnosticsClientCapabilities(
             dynamicRegistration: some(true)
           )),
+          formatting: some(DocumentFormattingClientCapabilities(
+            dynamicRegistration: some(true)
+          )),
           foldingRange: some(FoldingRangeClientCapabilities(
             dynamicRegistration: some(true),
             lineFoldingOnly: some(true)
@@ -616,6 +620,21 @@ proc setCapabilities(
     if settings.completion.enable and
        initResult.capabilities.completionProvider.isSome:
          capabilities.completion = initResult.capabilities.completionProvider
+
+    if settings.formatting.enable and
+       initResult.capabilities.documentFormattingProvider.isSome:
+         if initResult.capabilities.documentFormattingProvider.get.kind == JBool:
+           capabilities.formatting =
+             initResult.capabilities.documentFormattingProvider.get.getBool
+         else:
+           try:
+             discard initResult.capabilities.documentFormattingProvider.get.to(
+               DocumentFormattingOptions
+             )
+             capabilities.formatting = true
+           except CatchableError:
+             # Invalid documentFormattingProvider
+             discard
 
     if settings.declaration.enable and
        initResult.capabilities.declarationProvider.isSome:
@@ -1793,5 +1812,30 @@ proc textDocumentSignatureHelp*(
     let r = c.request(bufferId, LspMethod.textDocumentSignatureHelp, params)
     if r.isErr:
       return R[(), string].err fmt"textDocument/signatureHelp request failed: {r.error}"
+
+    return R[(), string].ok ()
+
+proc textDocumentDocumentFormatting*(
+  c: var LspClient,
+  bufferId: int,
+  path: string): LspSendRequestResult =
+    ## Send a textDocument/documentFormatting request to the server.
+    ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_formatting
+
+    if not c.serverProcess.running:
+      if not c.closed: c.closed = true
+      return R[(), string].err "server crashed"
+
+    if not c.isInitialized:
+      return R[(), string].err "lsp unavailable"
+
+    if not c.capabilities.get.formatting:
+      return R[(), string].err "textDocument/documentFormatting unavailable"
+
+    let params = %* initDocumentFormattingParams(path)
+
+    let r = c.request(bufferId, LspMethod.textDocumentDocumentFormatting, params)
+    if r.isErr:
+      return R[(), string].err fmt"textDocument/documentFormatting request failed: {r.error}"
 
     return R[(), string].ok ()

--- a/src/moepkg/lsp/documentformatting.nim
+++ b/src/moepkg/lsp/documentformatting.nim
@@ -27,6 +27,8 @@ import utils
 type
   DocumentFormattingResponseResult* = Result[seq[TextEdit], string]
 
+export TextEdit
+
 proc initDocumentFormattingParams*(path: string): DocumentFormattingParams =
   DocumentFormattingParams(
     textDocument: TextDocumentIdentifier(uri: path.pathToUri),

--- a/src/moepkg/lsp/documentformatting.nim
+++ b/src/moepkg/lsp/documentformatting.nim
@@ -1,0 +1,54 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[json, options, strformat]
+
+import pkg/results
+
+import protocol/types
+import utils
+
+type
+  DocumentFormattingResponseResult* = Result[seq[TextEdit], string]
+
+proc initDocumentFormattingParams*(path: string): DocumentFormattingParams =
+  DocumentFormattingParams(
+    textDocument: TextDocumentIdentifier(uri: path.pathToUri),
+    options: none(JsonNode) # FormattingOptions
+  )
+
+proc parseDocumentFormattingResponse*(
+  res: JsonNode): DocumentFormattingResponseResult =
+
+    if res["result"].kind == JNull:
+      # Not found
+      return DocumentFormattingResponseResult.ok @[]
+    elif res["result"].kind != JArray:
+      return DocumentFormattingResponseResult.err "Invalid response"
+    elif res["result"].len == 0:
+      # Not found
+      return DocumentFormattingResponseResult.ok @[]
+
+    let edits =
+      try:
+        res.to(seq[TextEdit])
+      except CatchableError as e:
+        return DocumentFormattingResponseResult.err fmt"Invalid response: {e.msg}"
+
+    return DocumentFormattingResponseResult.ok edits

--- a/src/moepkg/lsp/formatting.nim
+++ b/src/moepkg/lsp/formatting.nim
@@ -17,7 +17,7 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[json, options, strformat]
+import std/[json, strformat]
 
 import pkg/results
 
@@ -27,13 +27,16 @@ import utils
 type
   DocumentFormattingResponseResult* = Result[seq[TextEdit], string]
 
-export TextEdit
+export TextEdit, FormattingOptions
 
-proc initDocumentFormattingParams*(path: string): DocumentFormattingParams =
-  DocumentFormattingParams(
-    textDocument: TextDocumentIdentifier(uri: path.pathToUri),
-    options: none(JsonNode) # FormattingOptions
-  )
+proc initDocumentFormattingParams*(
+  path: string,
+  options: FormattingOptions): DocumentFormattingParams =
+
+    DocumentFormattingParams(
+      textDocument: TextDocumentIdentifier(uri: path.pathToUri),
+      options: options
+    )
 
 proc parseDocumentFormattingResponse*(
   res: JsonNode): DocumentFormattingResponseResult =
@@ -49,7 +52,7 @@ proc parseDocumentFormattingResponse*(
 
     let edits =
       try:
-        res.to(seq[TextEdit])
+        res["result"].to(seq[TextEdit])
       except CatchableError as e:
         return DocumentFormattingResponseResult.err fmt"Invalid response: {e.msg}"
 

--- a/src/moepkg/lsp/handler.nim
+++ b/src/moepkg/lsp/handler.nim
@@ -570,8 +570,6 @@ proc lspDocumentFormatting(
   res: JsonNode): Result[(), string] =
     ## textDocument/documentFormatting
 
-    exitUi()
-    echo res
     let requestId =
       try: res["id"].getInt
       except CatchableError as e: return Result[(), string].err e.msg

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -817,9 +817,17 @@ type
     textEdit*: Option[TextEdit]
     additionalTextEdits*: OptionalSeq[TextEdit]
 
+  FormattingOptions* = ref object of RootObj
+    tabSize*: int
+    insertSpaces*: bool
+    trimTrailingWhitespace*: Option[bool]
+    insertFinalNewline*: Option[bool]
+    trimFinalNewlines*: Option[bool]
+#   key
+
   DocumentFormattingParams* = ref object of RootObj
     textDocument*: TextDocumentIdentifier
-    options*: OptionalNode
+    options*: OptionalNode # FormattingOptions
 
   DocumentRangeFormattingParams* = ref object of RootObj
     textDocument*: TextDocumentIdentifier

--- a/src/moepkg/lsp/protocol/types.nim
+++ b/src/moepkg/lsp/protocol/types.nim
@@ -823,11 +823,10 @@ type
     trimTrailingWhitespace*: Option[bool]
     insertFinalNewline*: Option[bool]
     trimFinalNewlines*: Option[bool]
-#   key
 
   DocumentFormattingParams* = ref object of RootObj
     textDocument*: TextDocumentIdentifier
-    options*: OptionalNode # FormattingOptions
+    options*: FormattingOptions
 
   DocumentRangeFormattingParams* = ref object of RootObj
     textDocument*: TextDocumentIdentifier

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -80,7 +80,7 @@ type
     textDocumentDocumentSymbol
     textDocumentInlineValue
     textDocumentSignatureHelp
-    textDocumentDocumentFormatting
+    textDocumentFormatting
 
   CallHierarchyType* = enum
     prepare
@@ -194,7 +194,7 @@ proc toLspMethodStr*(m: LspMethod): string =
     of textDocumentDocumentSymbol: "textDocument/documentSymbol"
     of textDocumentInlineValue: "textDocument/inlineValue"
     of textDocumentSignatureHelp: "textDocument/signatureHelp"
-    of textDocumentDocumentFormatting: "textDocument/documentFormatting"
+    of textDocumentFormatting: "textDocument/formatting"
 
 proc parseTraceValue*(s: string): Result[TraceValue, string] =
   ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue
@@ -298,8 +298,8 @@ proc lspMethod*(j: JsonNode): LspMethodResult =
       LspMethodResult.ok textDocumentInlineValue
     of "textDocument/signatureHelp":
       LspMethodResult.ok textDocumentSignatureHelp
-    of "textDocument/documentFormatting":
-      LspMethodResult.ok textDocumentDocumentFormatting
+    of "textDocument/formatting":
+      LspMethodResult.ok textDocumentFormatting
     else:
       LspMethodResult.err "Not supported: " & j["method"].getStr
 
@@ -332,7 +332,7 @@ proc getWaitingType*(lspMethod: LspMethod): Option[WaitType] =
     of textDocumentFoldingRange: some(WaitType.foreground)
     of textDocumentSelectionRange: some(WaitType.foreground)
     of textDocumentDocumentSymbol: some(WaitType.foreground)
-    of textDocumentDocumentFormatting : some(WaitType.foreground)
+    of textDocumentFormatting : some(WaitType.foreground)
     else: none(WaitType)
 
 proc isForegroundWait*(lspMethod: LspMethod): bool {.inline.} =

--- a/src/moepkg/lsp/utils.nim
+++ b/src/moepkg/lsp/utils.nim
@@ -80,6 +80,7 @@ type
     textDocumentDocumentSymbol
     textDocumentInlineValue
     textDocumentSignatureHelp
+    textDocumentDocumentFormatting
 
   CallHierarchyType* = enum
     prepare
@@ -193,6 +194,7 @@ proc toLspMethodStr*(m: LspMethod): string =
     of textDocumentDocumentSymbol: "textDocument/documentSymbol"
     of textDocumentInlineValue: "textDocument/inlineValue"
     of textDocumentSignatureHelp: "textDocument/signatureHelp"
+    of textDocumentDocumentFormatting: "textDocument/documentFormatting"
 
 proc parseTraceValue*(s: string): Result[TraceValue, string] =
   ## https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#traceValue
@@ -296,6 +298,8 @@ proc lspMethod*(j: JsonNode): LspMethodResult =
       LspMethodResult.ok textDocumentInlineValue
     of "textDocument/signatureHelp":
       LspMethodResult.ok textDocumentSignatureHelp
+    of "textDocument/documentFormatting":
+      LspMethodResult.ok textDocumentDocumentFormatting
     else:
       LspMethodResult.err "Not supported: " & j["method"].getStr
 
@@ -328,6 +332,7 @@ proc getWaitingType*(lspMethod: LspMethod): Option[WaitType] =
     of textDocumentFoldingRange: some(WaitType.foreground)
     of textDocumentSelectionRange: some(WaitType.foreground)
     of textDocumentDocumentSymbol: some(WaitType.foreground)
+    of textDocumentDocumentFormatting : some(WaitType.foreground)
     else: none(WaitType)
 
 proc isForegroundWait*(lspMethod: LspMethod): bool {.inline.} =

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -406,6 +406,13 @@ proc writeLspSignatureHelpError*(commandLine: var CommandLine, message: string) 
   let mess = fmt"lsp: Error: signatureHelp failed: {message}"
   commandLine.writeError(mess)
 
+proc writeLspDocumentFormattingHelpError*(
+  commandLine: var CommandLine,
+  message: string) =
+
+    let mess = fmt"lsp: Error: document formatting failed: {message}"
+    commandLine.writeError(mess)
+
 proc writeLspDeclarationError*(commandLine: var CommandLine, message: string) =
   let mess = fmt"lsp: Error: declaration failed: {message}"
   commandLine.writeError(mess)

--- a/src/moepkg/settings.nim
+++ b/src/moepkg/settings.nim
@@ -240,6 +240,9 @@ type
   LspCompletionSettings* = object
     enable*: bool
 
+  LspDocumentFormattingSettings* = object
+    enable*: bool
+
   LspDeclarationSettings* = object
     enable*: bool
 
@@ -302,6 +305,7 @@ type
 
   LspFeatureSettings* = object
     completion*: LspCompletionSettings
+    formatting*: LspDocumentFormattingSettings
     declaration*: LspDeclarationSettings
     definition*: LspDefinitionSettings
     typeDefinition*: LspTypeDefinitionSettings
@@ -579,6 +583,9 @@ proc initThemeSettings(): ThemeSettings =
 proc initLspCompletionSettings(): LspCompletionSettings =
   result.enable = true
 
+proc initLspDocumentFormattingSettings(): LspDocumentFormattingSettings =
+  result.enable = true
+
 proc initLspDeclarationSettings(): LspDeclarationSettings =
   result.enable = true
 
@@ -641,6 +648,7 @@ proc initLspExecuteCommandSettings(): LspExecuteCommandSettings =
 
 proc initLspFeatureSettings(): LspFeatureSettings =
   result.completion = initLspCompletionSettings()
+  result.formatting = initLspDocumentFormattingSettings()
   result.declaration = initLspDeclarationSettings()
   result.definition = initLspDefinitionSettings()
   result.typeDefinition = initLspTypeDefinitionSettings()
@@ -1886,6 +1894,13 @@ proc parseLspTable(s: var EditorSettings, lspConfigs: TomlValueRef) =
               s.lsp.features.completion.enable = val.getBool
             else:
               discard
+      of "DocumentFormatting":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              s.lsp.features.formatting.enable = val.getBool
+            else:
+              discard
       of "Declaration":
         for key, val in val.getTable:
           case key:
@@ -2587,6 +2602,14 @@ proc validateLspTable(table: TomlValueRef): Option[InvalidItem] =
                 return some(InvalidItem(name: $key, val: $val))
             else:
               return some(InvalidItem(name: $key, val: $val))
+      of "DocumentFormatting":
+        for key, val in val.getTable:
+          case key:
+            of "enable":
+              if val.kind != TomlValueKind.Bool:
+                return some(InvalidItem(name: $key, val: $val))
+            else:
+              return some(InvalidItem(name: $key, val: $val))
       of "Declaration":
         for key, val in val.getTable:
           case key:
@@ -3134,6 +3157,9 @@ proc genTomlConfigStr*(settings: EditorSettings): string =
 
   result.addLine fmt "[Lsp.Completion]"
   result.addLine fmt "enable = {$settings.lsp.features.completion.enable}"
+
+  result.addLine fmt "[Lsp.DocumentFormatting]"
+  result.addLine fmt "enable = {$settings.lsp.features.formatting.enable}"
 
   result.addLine fmt "[Lsp.Declaration]"
   result.addLine fmt "enable = {$settings.lsp.features.declaration.enable}"

--- a/tests/texmode.nim
+++ b/tests/texmode.nim
@@ -1081,6 +1081,7 @@ suite "Ex mode: Quickrun command without file":
   test "Exec Quickrun without file":
     # Create a file for the test.
     var status = initEditorStatus()
+    status.settings.lsp.enable = false
     discard status.addNewBufferInCurrentWin.get
     status.bufStatus[0].language = SourceLanguage.langNim
     status.bufStatus[0].buffer = toGapBuffer(@[ru"echo 1"])
@@ -1121,6 +1122,7 @@ suite "Ex mode: Quickrun command without file":
 
   test "Exec Quickrun without file twice":
     var status = initEditorStatus()
+    status.settings.lsp.enable = false
     discard status.addNewBufferInCurrentWin.get
     status.bufStatus[0].language = SourceLanguage.langNim
     status.bufStatus[0].buffer = toGapBuffer(@[ru"echo 1"])
@@ -1209,6 +1211,7 @@ suite "Ex mode: Quickrun command with file":
   test "Exec Quickrun with file":
     # Create a file for the test.
     var status = initEditorStatus()
+    status.settings.lsp.enable = false
     discard status.addNewBufferInCurrentWin(TestfilePath, Mode.normal).get
 
     const Command = @[ru"run"]
@@ -1247,6 +1250,7 @@ suite "Ex mode: Quickrun command with file":
 
   test "Exec Quickrun with file twice":
     var status = initEditorStatus()
+    status.settings.lsp.enable = false
     discard status.addNewBufferInCurrentWin(TestfilePath, Mode.normal).get
 
     const Command = @[ru"run"]

--- a/tests/texmode.nim
+++ b/tests/texmode.nim
@@ -1203,6 +1203,7 @@ suite "Ex mode: Quickrun command with file":
     writeFile(TestfilePath, "echo 1")
 
   teardown:
+    removeFile(TestfilePath)
     removeDir(TestfileDir)
 
   test "Exec Quickrun with file":

--- a/tests/texmode.nim
+++ b/tests/texmode.nim
@@ -43,6 +43,18 @@ proc isValidWindowSize(n: WindowNode) =
   check n.view.originalLine.len > 1
   check n.view.length.len > 1
 
+template handleLspInitialize(status: var EditorStatus) =
+  const Timeout = 1000
+
+  for _ in 0 .. 20:
+    assert lspClient.readable(Timeout).isOk
+    let res = lspClient.read.get
+    if res.contains("id"):
+      assert res["id"].getInt == 1
+      assert status.lspInitialized(res).isOk
+      assert lspClient.isInitialized
+      break
+
 suite "Ex mode: isExCommandBuffer":
   ## Generate test code
   template isExCommandBufferTest(command: Runes, exceptInputState: InputState) =
@@ -178,12 +190,7 @@ suite "Ex mode: Write command":
 
         assert status.lspInitialize(workspaceRoot, LangId).isOk
 
-        const Timeout = 5000
-        assert lspClient.readable(Timeout).get
-
-        let resJson = lspClient.read.get
-        assert status.lspInitialized(resJson).isOk
-        assert lspClient.isInitialized
+        status.handleLspInitialize
 
       const Command = @[ru"w"]
       status.exModeCommand(Command)

--- a/tests/tlspclient.nim
+++ b/tests/tlspclient.nim
@@ -1229,27 +1229,27 @@ suite "lsp: Send requests":
 
           return Result[(), string].ok ()
 
-#  test "Send textDocument/didOpen":
-#    if not isNimlangserverAvailable():
-#      skip()
-#    else:
-#      const BufferId = 1
-#
-#      block:
-#        let
-#          rootPath = getCurrentDir()
-#          params = initInitializeParams(ServerName, rootPath, Trace)
-#        assert client.lspInitialize(BufferId, params).isOk
-#
-#        # workspace/didChangeConfiguration notification
-#        assert client.workspaceDidChangeConfiguration.isOk
-#
-#      const LanguageId = "nim"
-#      let
-#        path = getCurrentDir() / "src/moe.nim"
-#        text = readFile(path)
-#
-#      check client.textDocumentDidOpen(path, LanguageId, text).isOk
+  test "Send textDocument/didOpen":
+    if not isNimlangserverAvailable():
+      skip()
+    else:
+      const BufferId = 1
+
+      block:
+        let
+          rootPath = getCurrentDir()
+          params = initInitializeParams(ServerName, rootPath, Trace)
+        assert client.lspInitialize(BufferId, params).isOk
+
+        # workspace/didChangeConfiguration notification
+        assert client.workspaceDidChangeConfiguration.isOk
+
+      const LanguageId = "nim"
+      let
+        path = getCurrentDir() / "src/moe.nim"
+        text = readFile(path)
+
+      check client.textDocumentDidOpen(path, LanguageId, text).isOk
 
   template prepareLsp(bufferId: int, langId: LanguageId, rootDir, path, text: string) =
     block:
@@ -1785,7 +1785,7 @@ echo Ojb(n: 1)
 
       check not isTimeout
 
-  test "Send textDocument/documentFormatting":
+  test "Send textDocument/formatting":
     if not isNimlangserverAvailable():
       skip()
     else:
@@ -1801,10 +1801,11 @@ echo Ojb(n: 1)
 
       let requestId = client.lastId + 1
 
-      check client.textDocumentDocumentFormatting(
+      check client.textDocumentFormatting(
         BufferId,
-        path).isOk
+        path,
+        FormattingOptions()).isOk
       check client.waitingResponses[requestId].lspMethod ==
-        LspMethod.textDocumentDocumentFormatting
+        LspMethod.textDocumentFormatting
 
       # TODO: Add response check

--- a/tests/tlspclient.nim
+++ b/tests/tlspclient.nim
@@ -1799,13 +1799,17 @@ echo Ojb(n: 1)
 
       prepareLsp(BufferId, LanguageId, rootDir, path, Text)
 
-      let requestId = client.lastId + 1
+      if not client.capabilities.get.formatting:
+        # TODO: Enable textDocument/formatting on Actions
+        skip()
+      else:
+        let requestId = client.lastId + 1
 
-      check client.textDocumentFormatting(
-        BufferId,
-        path,
-        FormattingOptions()).isOk
-      check client.waitingResponses[requestId].lspMethod ==
-        LspMethod.textDocumentFormatting
+        check client.textDocumentFormatting(
+          BufferId,
+          path,
+          FormattingOptions()).isOk
+        check client.waitingResponses[requestId].lspMethod ==
+          LspMethod.textDocumentFormatting
 
-      # TODO: Add response check
+        # TODO: Add response check

--- a/tests/tlspformatting.nim
+++ b/tests/tlspformatting.nim
@@ -1,0 +1,81 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2024 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, json]
+
+import pkg/results
+
+import moepkg/lsp/formatting {.all.}
+
+suite "lsp: parseDocumentFormattingResponse":
+  test "Not found":
+    check parseDocumentFormattingResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": []
+    })
+    .get
+    .len == 0
+
+  test "Not found 2":
+    check parseDocumentFormattingResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": nil
+    })
+    .get
+    .len == 0
+
+  test "Basic":
+    let r = parseDocumentFormattingResponse(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "result": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 0
+            },
+            "end": {
+              "line": 1,
+              "character": 0
+            }
+          },
+          "newText": "a"
+        }
+      ]
+    })
+    .get
+
+    check r.len == 1
+
+    check %*r[0] == %*{
+      "range": {
+        "start": {
+          "line": 1,
+          "character": 0
+        },
+        "end": {
+          "line": 1,
+          "character": 0
+        }
+      },
+      "newText": "a"
+    }

--- a/tests/tlsphandler.nim
+++ b/tests/tlsphandler.nim
@@ -1868,8 +1868,14 @@ suite "lsp: handleLspResponse":
       const LangId = "nim"
       assert status.lspInitialize(workspaceRoot, LangId).isOk
 
-      status.handleLspInitialize
+      var isTimeout = true
+      for _ in 0 .. 30:
+        const Timeout = 1000
+        if lspClient.readable(Timeout).get:
+          status.handleLspResponse
 
-      status.handleLspResponse
+          if lspClient.isInitialized:
+            isTimeout = false
+            break
 
-      check lspClient.isInitialized
+      check not isTimeout

--- a/tests/tlsphandler.nim
+++ b/tests/tlsphandler.nim
@@ -1869,7 +1869,7 @@ suite "lsp: handleLspResponse":
       assert status.lspInitialize(workspaceRoot, LangId).isOk
 
       var isTimeout = true
-      for _ in 0 .. 30:
+      for _ in 0 .. 60:
         const Timeout = 1000
         if lspClient.readable(Timeout).get:
           status.handleLspResponse

--- a/tests/tlsputils.nim
+++ b/tests/tlsputils.nim
@@ -340,3 +340,11 @@ suite "lsp: lspMethod":
       "method": "textDocument/signatureHelp",
       "params": nil
     }).get
+
+  test "textDocument/documentFormatting":
+    check LspMethod.textDocumentDocumentFormatting == lspMethod(%*{
+      "jsonrpc": "2.0",
+      "id": 0,
+      "method": "textDocument/documentFormatting",
+      "params": nil
+    }).get

--- a/tests/tlsputils.nim
+++ b/tests/tlsputils.nim
@@ -341,10 +341,10 @@ suite "lsp: lspMethod":
       "params": nil
     }).get
 
-  test "textDocument/documentFormatting":
-    check LspMethod.textDocumentDocumentFormatting == lspMethod(%*{
+  test "textDocument/formatting":
+    check LspMethod.textDocumentFormatting == lspMethod(%*{
       "jsonrpc": "2.0",
       "id": 0,
-      "method": "textDocument/documentFormatting",
+      "method": "textDocument/formatting",
       "params": nil
     }).get

--- a/tests/tsettings.nim
+++ b/tests/tsettings.nim
@@ -181,6 +181,9 @@ enable = false
 [Lsp.SignatureHelp]
 enable = false
 
+[Lsp.DocumentFormatting]
+enable = false
+
 [Lsp.FoldingRange]
 enable = false
 
@@ -637,6 +640,8 @@ suite "settings: Parse configuration file":
     check not settings.lsp.features.diagnostics.enable
 
     check not settings.lsp.features.signatureHelp.enable
+
+    check not settings.lsp.features.formatting.enable
 
     check not settings.lsp.features.foldingRange.enable
 


### PR DESCRIPTION
Add LSP Document Formatting support.

- Add `LspFormat` command to Ex mode

# TODO
- [x] Set `FormattingOptions`
- [x] tests
- [x] docs