### PR TITLE
Fix typos

### DIFF
--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -121,7 +121,7 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 | Name | Type | Default Value | Description |
 |:-----------------------------|:-----------------------------|:---------------------------|:---------------------------|
 | multipleStatusLine | bool | true | Show multiple status lines |
-| merge | bool | fale | Enable merge the status line with the command line |
+| merge | bool | false | Enable merge the status line with the command line |
 | mode | bool | true | Display the current mode |
 | chanedMark | bool | true | Display the buffer changed mark |
 | directory | bool | true | Display the directory of the path |

--- a/documents/developer.md
+++ b/documents/developer.md
@@ -116,7 +116,7 @@ Implementation of Gap buffer.
 
 ### ```src/moepkg/movement.nim```
 Many editor movement procs (Ex. move right, move to the end of the line, move to the next word, etc...).
-theses procs are used in many modes.
+these procs are used in many modes.
 
 ### ```src/moepkg/editor.nim```
 Many procs for editing text (Ex. Insert/delete characters, undo/redo, delete a word, etc...).
@@ -189,8 +189,8 @@ Main module for the log mode (Log viewer).
 The log mode can be started with `:log` command.
 
 ### ```src/moepkg/backupmanager.nim```
-Main module for the backup mode (Backup manger).
-Backup manger is the manager of the auto-backup files.
+Main module for the backup mode (Backup manager).
+Backup manager is the manager of the auto-backup files.
 The backup mode can be started with `:backup` command.
 
 ### ```src/moepkg/diffviewer.nim```

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -140,7 +140,7 @@
 | <kbd>**Ctrl**</kbd> <kbd>**s**</kbd></br> | Selection Range (LSP) |
 | <kbd>**Space**</kbd> <kbd>**o**</kbd></br> | Document Symbol (LSP) |
 | <kbd>**Ctrl**</kbd> <kbd>**o**</kbd></br> | Jump Back (Jumplist) |
-| <kbd>**Ctrl**</kbd> <kbd>**i**</kbd></br> | Jump Foward (Jumplist) |
+| <kbd>**Ctrl**</kbd> <kbd>**i**</kbd></br> | Jump Forward (Jumplist) |
 
 </details>
 

--- a/src/moepkg/commandline.nim
+++ b/src/moepkg/commandline.nim
@@ -29,7 +29,7 @@ type
     cursor: CursorPosition
     color*: EditorColorPairIndex
     window*: Window ## Ncurses window
-    view*: EditorView ## Comand line view
+    view*: EditorView ## Command line view
     isUpdate*: bool ## Update flag
     y*, x*, h*, w*: int ## Window position and window size
 

--- a/src/moepkg/editorstatus.nim
+++ b/src/moepkg/editorstatus.nim
@@ -317,7 +317,7 @@ proc exitEditor*(status: EditorStatus) =
     saveLastCursorPosition(status.lastPosition)
 
   if dirExists(gitDiffTmpDir()):
-    # Cleanup temporary files fot git diff.
+    # Cleanup temporary files for git diff.
     removeDir(gitDiffTmpDir())
 
   exitUi()
@@ -896,7 +896,7 @@ proc updateCommandLine(status: var EditorStatus) =
     let message = currentBufStatus.syntaxCheckResults.formattedMessage(
       currentMainWindowNode.currentLine
     )
-    if message.isSome: # Write messages for syntax checker reuslts.
+    if message.isSome: # Write messages for syntax checker results.
       status.commandLine.write message.get
     elif status.commandLine.buffer.isSyntaxCheckFormattedMessage:
       # Clear if messages for other lines are still displayed.
@@ -1047,7 +1047,7 @@ proc update*(status: var EditorStatus) =
             node.view.updateSidebarBufferForChangedLine(b.changedLines)
 
           if status.settings.syntaxChecker.enable:
-            # Write syntax checker reuslts to the sidebar
+            # Write syntax checker results to the sidebar
             node.view.updateSidebarBufferForSyntaxChecker(b.syntaxCheckResults)
 
         node.view.updateEditorViewConfig(status.settings)

--- a/src/moepkg/editorview.nim
+++ b/src/moepkg/editorview.nim
@@ -811,7 +811,7 @@ proc updateSidebarBufferForChangedLine*(view: var EditorView, changedLines: seq[
 proc updateSidebarBufferForSyntaxChecker*(
     view: var EditorView, syntaxCheckResults: seq[SyntaxError]
 ) =
-  ## Update (Overwrite) a sidebar buffer for syntax checker reuslts.
+  ## Update (Overwrite) a sidebar buffer for syntax checker results.
   ## It's on left side of EditorView.
 
   template highlights(): var seq[seq[EditorColorPairIndex]] =

--- a/src/moepkg/exmode.nim
+++ b/src/moepkg/exmode.nim
@@ -887,7 +887,7 @@ proc writeCommand(status: var EditorStatus, path: Runes) =
     if status.settings.git.showChangedLine and currentBufStatus.isTrackingByGit:
       status.updateChangedLines
 
-    # Update syntax checker reuslts.
+    # Update syntax checker results.
     if status.settings.syntaxChecker.enable:
       let syntaxCheckProcess =
         startBackgroundSyntaxCheck($currentBufStatus.path, currentBufStatus.language)
@@ -1246,7 +1246,7 @@ proc lspExecuteCommand(status: var EditorStatus, command: seq[Runes]) =
   let lspCommand = $command[0]
 
   if lspCommand notin lspClient.capabilities.get.executeCommand.get:
-    status.commandLine.writeLspExecuteCommandError("unknow command")
+    status.commandLine.writeLspExecuteCommandError("unknown command")
     return
 
   let r = waitFor lspClient.workspaceExecuteCommand(

--- a/src/moepkg/globalsidebar.nim
+++ b/src/moepkg/globalsidebar.nim
@@ -157,7 +157,7 @@ proc write*(
     color: EditorColorPairIndex = EditorColorPairIndex.default,
 ) {.inline.} =
   ## Write a buffer to the terminalBuffer
-  ## Cut off the buffer if longer than the window sieze.
+  ## Cut off the buffer if longer than the window size.
 
   when not defined(release):
     assert startPosition.y >= 0 and startPosition.x >= 0

--- a/src/moepkg/helputils.nim
+++ b/src/moepkg/helputils.nim
@@ -143,7 +143,7 @@ zD         - Delete all folding lines
 Ctrl-s     - Selection Range (LSP)
 Space o    - Document Symbol (LSP)
 Ctrl-o     - Jump Back (Jumplist)
-Ctrl-i     - Jump Foward (Jumplist)
+Ctrl-i     - Jump Forward (Jumplist)
 
 # Register
 

--- a/src/moepkg/lsp/client.nim
+++ b/src/moepkg/lsp/client.nim
@@ -88,7 +88,7 @@ type
     state*: LspServerState # State of the Lsp server.
     serverProcess: AsyncProcessRef # LSP server process.
     serverStreams: Streams # Input/Output streams for the LSP server process.
-    outputStreamFuture: Future[JsonRpcResponseResult] # The feture of the output stream.
+    outputStreamFuture: Future[JsonRpcResponseResult] # The feature of the output stream.
     capabilities*: Option[LspCapabilities] # LSP server capabilities
     progress*: LspProgressTable # Use in window/workDoneProgress
     waitingResponses*: Table[RequestId, WaitLspResponse]

--- a/src/moepkg/messages.nim
+++ b/src/moepkg/messages.nim
@@ -68,7 +68,7 @@ proc writeWarn*(c: CommandLine, message: string) {.inline.} =
   c.writeMessageOnCommandLine(fmt"Warn: {message}", EditorColorPairIndex.warnMessage)
 
 proc writeNcursesColorError*(commandLine: CommandLine) {.inline.} =
-  commandLine.writeError("Ncurses: Cannot use extened colors")
+  commandLine.writeError("Ncurses: Cannot use extended colors")
 
 proc writeNoWriteError*(commandLine: CommandLine) {.inline.} =
   commandLine.writeError("No write since last change")

--- a/src/moepkg/normalmode.nim
+++ b/src/moepkg/normalmode.nim
@@ -620,7 +620,7 @@ proc jumpByJumpList(status: var EditorStatus, j: JumpInfo) =
   # Find destination buffer
   let b = status.bufStatus.getBufferStatusByBufferId(j.bufferId)
   if b.isSome:
-    # Alread opend
+    # Already opend
     if b.get.id != currentBufStatus.id:
       let err = status.changeCurrentBufferById(b.get.id)
       if err.isErr:

--- a/src/moepkg/viewhighlight.nim
+++ b/src/moepkg/viewhighlight.nim
@@ -398,7 +398,7 @@ proc updateViewHighlight*(
   let bufferInView = initBufferInView(bufStatus, windowNode)
 
   if bufStatus.isEditMode:
-    # LSP or build-in
+    # LSP or built-in
     if lspCapabilities.isSome and lspCapabilities.get.documentHighlight:
       h.highlightDocumentHighlights(
         windowNode.bufferPosition, bufStatus.documentHighlightInfo.ranges

--- a/tests/tconfigmode.nim
+++ b/tests/tconfigmode.nim
@@ -1306,8 +1306,8 @@ suite "Config mode: Get Git table setting values":
     const Name = "test"
     check s.getGitTableSettingsValues(Name).len == 0
 
-suite "Config mode: Chaging Standard table settings":
-  test "Chaging number":
+suite "Config mode: Changing Standard table settings":
+  test "Changing number":
     var settings = initEditorSettings()
 
     let val = not settings.view.lineNumber
@@ -1315,7 +1315,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.view.lineNumber
 
-  test "Chaging currentNumber":
+  test "Changing currentNumber":
     var settings = initEditorSettings()
 
     let val = not settings.view.currentLineNumber
@@ -1323,7 +1323,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.view.currentLineNumber
 
-  test "Chaging cursorLine":
+  test "Changing cursorLine":
     var settings = initEditorSettings()
 
     let val = not settings.view.cursorLine
@@ -1331,7 +1331,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.view.cursorLine
 
-  test "Chaging statusLine":
+  test "Changing statusLine":
     var settings = initEditorSettings()
 
     let val = not settings.statusLine.enable
@@ -1339,7 +1339,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.statusLine.enable
 
-  test "Chaging tabLine":
+  test "Changing tabLine":
     var settings = initEditorSettings()
 
     let val = not settings.tabLine.enable
@@ -1347,7 +1347,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.tabLine.enable
 
-  test "Chaging syntax":
+  test "Changing syntax":
     var settings = initEditorSettings()
 
     let val = not settings.standard.syntax
@@ -1355,7 +1355,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.syntax
 
-  test "Chaging indentationLines":
+  test "Changing indentationLines":
     var settings = initEditorSettings()
 
     let val = not settings.view.indentationLines
@@ -1363,7 +1363,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.view.indentationLines
 
-  test "Chaging autoCloseParen":
+  test "Changing autoCloseParen":
     var settings = initEditorSettings()
 
     let val = not settings.standard.autoCloseParen
@@ -1371,7 +1371,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.autoCloseParen
 
-  test "Chaging autoIndent":
+  test "Changing autoIndent":
     var settings = initEditorSettings()
 
     let val = not settings.standard.autoIndent
@@ -1379,7 +1379,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.autoIndent
 
-  test "Chaging ignorecase":
+  test "Changing ignorecase":
     var settings = initEditorSettings()
 
     let val = not settings.standard.ignorecase
@@ -1387,7 +1387,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.ignorecase
 
-  test "Chaging smartcase":
+  test "Changing smartcase":
     var settings = initEditorSettings()
 
     let val = not settings.standard.smartcase
@@ -1395,7 +1395,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.smartcase
 
-  test "Chaging disableChangeCursor":
+  test "Changing disableChangeCursor":
     var settings = initEditorSettings()
 
     let val = not settings.standard.disableChangeCursor
@@ -1403,7 +1403,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.disableChangeCursor
 
-  test "Chaging defaultCursor":
+  test "Changing defaultCursor":
     var settings = initEditorSettings()
 
     let val = "noneBlinkIbeam"
@@ -1411,7 +1411,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check CursorType.noneBlinkIbeam == settings.standard.defaultCursor
 
-  test "Chaging normalModeCursor":
+  test "Changing normalModeCursor":
     var settings = initEditorSettings()
 
     let val = "noneBlinkIbeam"
@@ -1419,7 +1419,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check CursorType.noneBlinkIbeam == settings.standard.normalModeCursor
 
-  test "Chaging insertModeCursor":
+  test "Changing insertModeCursor":
     var settings = initEditorSettings()
 
     let val = "noneBlinkIbeam"
@@ -1427,7 +1427,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check CursorType.noneBlinkIbeam == settings.standard.insertModeCursor
 
-  test "Chaging liveReloadOfConf":
+  test "Changing liveReloadOfConf":
     var settings = initEditorSettings()
 
     let val = not settings.standard.liveReloadOfConf
@@ -1435,7 +1435,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.liveReloadOfConf
 
-  test "Chaging incrementalSearch":
+  test "Changing incrementalSearch":
     var settings = initEditorSettings()
 
     let val = not settings.standard.incrementalSearch
@@ -1443,7 +1443,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.incrementalSearch
 
-  test "Chaging popupWindowInExmode":
+  test "Changing popupWindowInExmode":
     var settings = initEditorSettings()
 
     let val = not settings.standard.popupWindowInExmode
@@ -1451,7 +1451,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.popupWindowInExmode
 
-  test "Chaging autoDeleteParen":
+  test "Changing autoDeleteParen":
     var settings = initEditorSettings()
 
     let val = not settings.standard.autoDeleteParen
@@ -1459,7 +1459,7 @@ suite "Config mode: Chaging Standard table settings":
 
     check val == settings.standard.autoDeleteParen
 
-  test "Chaging colorMode":
+  test "Changing colorMode":
     var settings = initEditorSettings()
 
     settings.standard.colorMode = ColorMode.c24bit
@@ -1490,8 +1490,8 @@ suite "Config mode: Chaging Standard table settings":
 
     check beforeSettings == settings
 
-suite "Config mode: Chaging ClipBoard table settings":
-  test "Chaging enable":
+suite "Config mode: Changing ClipBoard table settings":
+  test "Changing enable":
     var
       settings = initEditorSettings()
       clipboardSettings = settings.clipboard
@@ -1521,8 +1521,8 @@ suite "Config mode: Chaging ClipBoard table settings":
 
     check beforeSettings == clipboardSettings
 
-suite "Config mode: Chaging BuildOnSave table settings":
-  test "Chaging enable":
+suite "Config mode: Changing BuildOnSave table settings":
+  test "Changing enable":
     var
       settings = initEditorSettings()
       buildOnSaveSettings = settings.buildOnSave
@@ -1542,8 +1542,8 @@ suite "Config mode: Chaging BuildOnSave table settings":
 
     check beforeSettings == buildOnSaveSettings
 
-suite "Config mode: Chaging TabLine table settings":
-  test "Chaging allBuffer":
+suite "Config mode: Changing TabLine table settings":
+  test "Changing allBuffer":
     var
       settings = initEditorSettings()
       tablineSettings = settings.tabline
@@ -1563,8 +1563,8 @@ suite "Config mode: Chaging TabLine table settings":
 
     check beforeSettings == tablineSettings
 
-suite "Config mode: Chaging StatusLine table settings":
-  test "Chaging ":
+suite "Config mode: Changing StatusLine table settings":
+  test "Changing ":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1574,7 +1574,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.multipleStatusLine
 
-  test "Chaging merge":
+  test "Changing merge":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1584,7 +1584,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.merge
 
-  test "Chaging mode":
+  test "Changing mode":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1594,7 +1594,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.mode
 
-  test "Chaging fileName":
+  test "Changing fileName":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1604,7 +1604,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.fileName
 
-  test "Chaging chanedMark":
+  test "Changing chanedMark":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1614,7 +1614,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.chanedMark
 
-  test "Chaging directory":
+  test "Changing directory":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1624,7 +1624,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.directory
 
-  test "Chaging gitChangedLines":
+  test "Changing gitChangedLines":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1634,7 +1634,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.gitChangedLines
 
-  test "Chaging gitBranchName":
+  test "Changing gitBranchName":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1644,7 +1644,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.gitBranchName
 
-  test "Chaging showGitInactive":
+  test "Changing showGitInactive":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1654,7 +1654,7 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check val == statusLineSettings.showGitInactive
 
-  test "Chaging showModeInactive":
+  test "Changing showModeInactive":
     var
       settings = initEditorSettings()
       statusLineSettings = settings.statusLine
@@ -1674,8 +1674,8 @@ suite "Config mode: Chaging StatusLine table settings":
 
     check beforeSettings == statusLineSettings
 
-suite "Config mode: Chaging Highlight table settings":
-  test "Chaging currentLine":
+suite "Config mode: Changing Highlight table settings":
+  test "Changing currentLine":
     var settings = initEditorSettings()
 
     let val = not settings.view.highlightCurrentLine
@@ -1683,7 +1683,7 @@ suite "Config mode: Chaging Highlight table settings":
 
     check val == settings.view.highlightCurrentLine
 
-  test "Chaging fullWidthSpace":
+  test "Changing fullWidthSpace":
     var settings = initEditorSettings()
 
     let val = not settings.highlight.fullWidthSpace
@@ -1691,7 +1691,7 @@ suite "Config mode: Chaging Highlight table settings":
 
     check val == settings.highlight.fullWidthSpace
 
-  test "Chaging trailingSpaces":
+  test "Changing trailingSpaces":
     var settings = initEditorSettings()
 
     let val = not settings.highlight.trailingSpaces
@@ -1699,7 +1699,7 @@ suite "Config mode: Chaging Highlight table settings":
 
     check val == settings.highlight.trailingSpaces
 
-  test "Chaging replaceText":
+  test "Changing replaceText":
     var settings = initEditorSettings()
 
     let val = not settings.highlight.replaceText
@@ -1707,7 +1707,7 @@ suite "Config mode: Chaging Highlight table settings":
 
     check val == settings.highlight.replaceText
 
-  test "Chaging pairOfParen":
+  test "Changing pairOfParen":
     var settings = initEditorSettings()
 
     let val = not settings.highlight.pairOfParen
@@ -1715,7 +1715,7 @@ suite "Config mode: Chaging Highlight table settings":
 
     check val == settings.highlight.pairOfParen
 
-  test "Chaging currentWord":
+  test "Changing currentWord":
     var settings = initEditorSettings()
 
     let val = not settings.highlight.currentWord
@@ -1731,8 +1731,8 @@ suite "Config mode: Chaging Highlight table settings":
 
     check beforeSettings == settings
 
-suite "Config mode: Chaging AutoBackup table settings":
-  test "Chaging enable":
+suite "Config mode: Changing AutoBackup table settings":
+  test "Changing enable":
     var
       settings = initEditorSettings()
       autoBackupSettings = settings.autoBackup
@@ -1752,8 +1752,8 @@ suite "Config mode: Chaging AutoBackup table settings":
 
     check beforeSettings == autoBackupSettings
 
-suite "Config mode: Chaging QuickRun table settings":
-  test "Chaging saveBufferWhenQuickRun":
+suite "Config mode: Changing QuickRun table settings":
+  test "Changing saveBufferWhenQuickRun":
     var
       settings = initEditorSettings()
       quickRunSettings = settings.quickRun
@@ -1773,8 +1773,8 @@ suite "Config mode: Chaging QuickRun table settings":
 
     check beforeSettings == quickRunSettings
 
-suite "Config mode: Chaging Notification table settings":
-  test "Chaging screenNotifications":
+suite "Config mode: Changing Notification table settings":
+  test "Changing screenNotifications":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1784,7 +1784,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.screenNotifications
 
-  test "Chaging logNotifications":
+  test "Changing logNotifications":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1794,7 +1794,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.logNotifications
 
-  test "Chaging autoBackupScreenNotify":
+  test "Changing autoBackupScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1804,7 +1804,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.autoBackupScreenNotify
 
-  test "Chaging autoBackupLogNotify":
+  test "Changing autoBackupLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1814,7 +1814,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.autoBackupLogNotify
 
-  test "Chaging autoSaveScreenNotify":
+  test "Changing autoSaveScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1824,7 +1824,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.autoSaveScreenNotify
 
-  test "Chaging autoSaveLogNotify":
+  test "Changing autoSaveLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1834,7 +1834,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.autoSaveLogNotify
 
-  test "Chaging yankScreenNotify":
+  test "Changing yankScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1844,7 +1844,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.yankScreenNotify
 
-  test "Chaging yankLogNotify":
+  test "Changing yankLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1854,7 +1854,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.yankLogNotify
 
-  test "Chaging deleteScreenNotify":
+  test "Changing deleteScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1864,7 +1864,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.deleteScreenNotify
 
-  test "Chaging deleteLogNotify":
+  test "Changing deleteLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1874,7 +1874,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.deleteLogNotify
 
-  test "Chaging saveScreenNotify":
+  test "Changing saveScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1884,7 +1884,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.saveScreenNotify
 
-  test "Chaging saveLogNotify":
+  test "Changing saveLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1894,7 +1894,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.saveLogNotify
 
-  test "Chaging quickRunScreenNotify":
+  test "Changing quickRunScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1904,7 +1904,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.quickRunScreenNotify
 
-  test "Chaging quickRunLogNotify":
+  test "Changing quickRunLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1914,7 +1914,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.quickRunLogNotify
 
-  test "Chaging buildOnSaveScreenNotify":
+  test "Changing buildOnSaveScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1924,7 +1924,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.buildOnSaveScreenNotify
 
-  test "Chaging buildOnSaveLogNotify":
+  test "Changing buildOnSaveLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1934,7 +1934,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.buildOnSaveLogNotify
 
-  test "Chaging filerScreenNotify":
+  test "Changing filerScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1944,7 +1944,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.filerScreenNotify
 
-  test "Chaging filerLogNotify":
+  test "Changing filerLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1954,7 +1954,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.filerLogNotify
 
-  test "Chaging restoreScreenNotify":
+  test "Changing restoreScreenNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1964,7 +1964,7 @@ suite "Config mode: Chaging Notification table settings":
 
     check val == notificationSettings.restoreScreenNotify
 
-  test "Chaging restoreLogNotify":
+  test "Changing restoreLogNotify":
     var
       settings = initEditorSettings()
       notificationSettings = settings.notification
@@ -1984,8 +1984,8 @@ suite "Config mode: Chaging Notification table settings":
 
     check beforeSettings == notificationSettings
 
-suite "Config mode: Chaging Filer table settings":
-  test "Chaging showIcons":
+suite "Config mode: Changing Filer table settings":
+  test "Changing showIcons":
     var
       settings = initEditorSettings()
       filerSettings = settings.filer
@@ -2005,8 +2005,8 @@ suite "Config mode: Chaging Filer table settings":
 
     check beforeSettings == filerSettings
 
-suite "Config mode: Chaging Autocomplete table settings":
-  test "Chaging enable":
+suite "Config mode: Changing Autocomplete table settings":
+  test "Changing enable":
     var
       settings = initEditorSettings()
       autocompleteSettings = settings.autocomplete
@@ -2026,8 +2026,8 @@ suite "Config mode: Chaging Autocomplete table settings":
 
     check beforeSettings == autocompleteSettings
 
-suite "Config mode: Chaging Persist table settings":
-  test "Chaging exCommand":
+suite "Config mode: Changing Persist table settings":
+  test "Changing exCommand":
     var
       settings = initEditorSettings()
       persistSettings = settings.persist
@@ -2037,7 +2037,7 @@ suite "Config mode: Chaging Persist table settings":
 
     check val == persistSettings.exCommand
 
-  test "Chaging exCommandHistoryLimit":
+  test "Changing exCommandHistoryLimit":
     var
       settings = initEditorSettings()
       persistSettings = settings.persist
@@ -2047,7 +2047,7 @@ suite "Config mode: Chaging Persist table settings":
 
     check val == persistSettings.exCommandHistoryLimit
 
-  test "Chaging search":
+  test "Changing search":
     var
       settings = initEditorSettings()
       persistSettings = settings.persist
@@ -2057,7 +2057,7 @@ suite "Config mode: Chaging Persist table settings":
 
     check val == persistSettings.search
 
-  test "Chaging searchHistoryLimit":
+  test "Changing searchHistoryLimit":
     var
       settings = initEditorSettings()
       persistSettings = settings.persist
@@ -2067,7 +2067,7 @@ suite "Config mode: Chaging Persist table settings":
 
     check val == persistSettings.searchHistoryLimit
 
-  test "Chaging cursorPosition":
+  test "Changing cursorPosition":
     var
       settings = initEditorSettings()
       persistSettings = settings.persist
@@ -2077,7 +2077,7 @@ suite "Config mode: Chaging Persist table settings":
 
     check val == persistSettings.search
 
-suite "Config mode: Change Git table sttings":
+suite "Config mode: Change Git table settings":
   test "showChangedLine":
     var s = initGitSettings()
 

--- a/tests/tnormalmode.nim
+++ b/tests/tnormalmode.nim
@@ -974,7 +974,7 @@ suite "Normal mode: Repeat last command":
 
       check isNormalModeCommand(Command, none(Rune)) == InputState.Valid
 
-      # Dont' save "j"
+      # Don't save "j"
       check status.normalCommand(Command).isNone
       status.update
 

--- a/tests/tworddictionary.nim
+++ b/tests/tworddictionary.nim
@@ -151,7 +151,7 @@ suite "worddictionary: update":
         (key: "nop", val: 0),
       ]
 
-  test "With build-in":
+  test "With built-in":
     var d: WordDictionary
 
     const Buffer = @["a"].toSeqRunes


### PR DESCRIPTION
Found via `codespell -L
compiletime,qeue,deques,absolutey,notin,te,splited -S changelog.d`