### PR TITLE
feat: Add terminal support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This project's goals are easily customizable, high productivity, user friendly, 
 
 - Macros
 
-- Terminal
+- Terminal ( >= 0.5.0 )
 
 - Language Server Protocol (WIP)
 
@@ -164,7 +164,7 @@ We recommend Linux environments.
 
 - [wl-clipboard](https://github.com/bugaevc/wl-clipboard) (Option on GNU/Linux)
 
-Version <= 0.3.0 (Ncurses base)
+Version <= 0.4.0 (Ncurses base)
 
 - [Ncurses](https://invisible-island.net/ncurses) 6.1 or higher
 
@@ -174,7 +174,7 @@ nimble install moe
 
 Check [detail](https://github.com/fox0430/moe/blob/v0.4.0/documents/overview.md)
 
-Version >= 0.4.0 ([Celina](https://github.com/fox0430/celina) base)
+Version >= 0.5.0 ([Celina](https://github.com/fox0430/celina) base)
 
 ```sh
 # Latest developmental state inside Github repository

--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ This project's goals are easily customizable, high productivity, user friendly, 
 
 - Macros
 
+- Terminal
+
 - Language Server Protocol (WIP)
 
   - Completion
@@ -135,8 +137,6 @@ This project's goals are easily customizable, high productivity, user friendly, 
 - Snippets
 
 - Spell checker
-
-- Terminal
 
 - Select data structures
 

--- a/documents/features.md
+++ b/documents/features.md
@@ -84,6 +84,6 @@ moe has a built-in terminal emulator. You can run a shell or any command inside 
 Terminal mode has two sub-modes:
 
 - **Terminal-Input**: All keystrokes are forwarded to the running shell/command. Press `Ctrl-\ Ctrl-n` to switch to Terminal-Normal sub-mode.
-- **Terminal-Normal**: Browse the terminal output with Vim-like navigation (`j`/`k`/`gg`/`G`). Press `i` or `a` to return to Terminal-Input sub-mode. Press `:` to enter command mode.
+- **Terminal-Normal**: Browse the terminal output. Press `i` or `a` to return to Terminal-Input sub-mode. Press `:` to enter command mode.
 
 When a command finishes (e.g. `:terminal ls`), the output is displayed in a read-only scrollback view (Terminal-Normal sub-mode). When an interactive shell exits, the terminal window is automatically closed.

--- a/documents/features.md
+++ b/documents/features.md
@@ -73,3 +73,17 @@ moe can use Vim-like registers.
 ### No name register
 
 Stores the value of the last used register.
+
+## Terminal mode
+
+moe has a built-in terminal emulator. You can run a shell or any command inside the editor window.
+
+- `:terminal` - Open an interactive shell (default shell)
+- `:terminal command` - Run a specific command (e.g. `:terminal ls -la`)
+
+Terminal mode has two sub-modes:
+
+- **Terminal-Input**: All keystrokes are forwarded to the running shell/command. Press `Ctrl-\ Ctrl-n` to switch to Terminal-Normal sub-mode.
+- **Terminal-Normal**: Browse the terminal output with Vim-like navigation (`j`/`k`/`gg`/`G`). Press `i` or `a` to return to Terminal-Input sub-mode. Press `:` to enter command mode.
+
+When a command finishes (e.g. `:terminal ls`), the output is displayed in a read-only scrollback view (Terminal-Normal sub-mode). When an interactive shell exits, the terminal window is automatically closed.

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -305,10 +305,6 @@ All keystrokes are forwarded to the running shell/command.
 
 | Keys | Description |
 |:-----------------------------|:---------------------------|
-| <kbd>**j**</kbd><br> | Go Down |
-| <kbd>**k**</kbd><br> | Go Up |
-| <kbd>**g**</kbd> <kbd>**g**</kbd><br> | Go to the first line |
-| <kbd>**G**</kbd><br> | Go to the last line |
 | <kbd>**i**</kbd><br> | Return to Terminal-Input sub-mode |
 | <kbd>**a**</kbd><br> | Return to Terminal-Input sub-mode |
 | <kbd>**:**</kbd><br> | Enter command mode |

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -12,6 +12,7 @@
 - [References Mode](#references-mode)
 - [Call Hierarchy Mode](#call-hierarchy-mode)
 - [Filer Mode](#filer-mode)
+- [Terminal Mode](#terminal-mode)
 - [Configuration Mode](#configuration-mode)
 - [Command Mode](#command-mode)
 
@@ -287,6 +288,33 @@
 </details>
 
 
+## Terminal mode
+
+<details open>
+  <summary>Built-in Terminal Emulator</summary>
+
+### Terminal-Input sub-mode (default)
+
+All keystrokes are forwarded to the running shell/command.
+
+| Keys | Description |
+|:-----------------------------|:---------------------------|
+| <kbd>**Ctrl**</kbd> <kbd>**\\**</kbd> <kbd>**Ctrl**</kbd> <kbd>**n**</kbd><br> | Switch to Terminal-Normal sub-mode |
+
+### Terminal-Normal sub-mode
+
+| Keys | Description |
+|:-----------------------------|:---------------------------|
+| <kbd>**j**</kbd><br> | Go Down |
+| <kbd>**k**</kbd><br> | Go Up |
+| <kbd>**g**</kbd> <kbd>**g**</kbd><br> | Go to the first line |
+| <kbd>**G**</kbd><br> | Go to the last line |
+| <kbd>**i**</kbd><br> | Return to Terminal-Input sub-mode |
+| <kbd>**a**</kbd><br> | Return to Terminal-Input sub-mode |
+| <kbd>**:**</kbd><br> | Enter command mode |
+
+</details>
+
 ## Configuration mode
 <details open>
   <summary>Configuration mode</summary>
@@ -362,6 +390,8 @@
 | `config` | Open configuration mode |
 | `debug` | Open debug mode |
 | `jump` | Open Jump list viewer |
+| `terminal` | Open terminal emulator (default shell) |
+| `terminal command` | Run command in terminal emulator |
 
 </details>
 

--- a/documents/overview.md
+++ b/documents/overview.md
@@ -2,7 +2,7 @@
 
 moe adopts the mode and keybinding like vi/vim.
 You can easily adapt if you have used vi/vim.
-Currently you can use normal mode, visual mode, replace mode, insert mode, ex mode, filer mode.
+Currently you can use normal mode, visual mode, replace mode, insert mode, ex mode, filer mode, terminal mode.
 
 # Install and compile
 

--- a/src/moe.nim
+++ b/src/moe.nim
@@ -36,6 +36,34 @@ proc toCursorStyle(ct: CursorType): CursorStyle =
   of ctNonBlinkBlock: CursorStyle.SteadyBlock
   of ctNonBlinkIbeam: CursorStyle.SteadyBar
 
+proc pollTerminalWindows*(e: Editor) =
+  ## Poll PTY output for all windows in Terminal mode.
+  ## Called on every render frame to ensure terminal output is up-to-date.
+  ## Also handles automatic cleanup when the shell process exits.
+  for i, window in e.windowManager.windows:
+    if window.mode == EditorMode.Terminal and window.terminalState.isSome:
+      let termState = window.terminalState.get
+      if termState.subMode == tsmInput:
+        let updated = termState.pollOutput()
+        if updated:
+          e.state.needsFullRedraw = true
+
+        if termState.exitCode.isSome:
+          if termState.command.len > 0:
+            # Command mode (e.g. `:terminal ls`): show output in scrollback view
+            let snapshot = termState.enterNormalSubMode()
+            window.buffer = snapshot
+            window.cursor = BufferPosition(line: max(0, snapshot.len - 1), column: 0)
+            window.viewport.topLine = max(0, snapshot.len - window.viewport.height)
+          else:
+            # Interactive shell (`:terminal`): close and return to Normal mode
+            window.clearModeState(EditorMode.Terminal)
+            window.mode = EditorMode.Normal
+            if i == e.windowManager.activeWindowIndex:
+              e.setMode(EditorMode.Normal)
+          e.state.needsFullRedraw = true
+          return
+
 proc handleResize(e: Editor) =
   ## Debounce resize events to prevent terminal buffer overflow
   ## Only process if at least 50ms have passed since last resize
@@ -103,6 +131,9 @@ proc runEditor(
     app.onRenderAsync proc(buffer: var Buffer) =
       {.cast(gcsafe).}:
         {.cast(raises: []).}:
+          # Poll terminal output for all windows in Terminal mode
+          editor.pollTerminalWindows()
+
           editor.render(buffer)
 
           # Set cursor style based on editor mode (unless disabled)

--- a/src/moe.nim
+++ b/src/moe.nim
@@ -44,6 +44,13 @@ proc pollTerminalWindows*(e: Editor) =
     if window.mode == EditorMode.Terminal and window.terminalState.isSome:
       let termState = window.terminalState.get
       if termState.subMode == tsmInput:
+        # Resize terminal if window dimensions changed
+        let (expectedCols, expectedRows) = e.calculateTerminalAreaDimensions(window)
+        if expectedCols != termState.grid.cols or expectedRows != termState.grid.rows:
+          if expectedCols > 0 and expectedRows > 0:
+            termState.resize(expectedCols, expectedRows)
+            e.state.needsFullRedraw = true
+
         let updated = termState.pollOutput()
         if updated:
           e.state.needsFullRedraw = true
@@ -56,10 +63,24 @@ proc pollTerminalWindows*(e: Editor) =
             window.cursor = BufferPosition(line: max(0, snapshot.len - 1), column: 0)
             window.viewport.topLine = max(0, snapshot.len - window.viewport.height)
           else:
-            # Interactive shell (`:terminal`): close and return to Normal mode
+            # Interactive shell (`:terminal`): close terminal window
             window.clearModeState(EditorMode.Terminal)
-            window.mode = EditorMode.Normal
-            if i == e.windowManager.activeWindowIndex:
+            if e.windowManager.windows.len > 1:
+              # Multiple windows: close the terminal window
+              let origActive = e.windowManager.activeWindowIndex
+              e.windowManager.activeWindowIndex = i
+              discard e.windowManager.closeWindow(e.state.display.multiStatusLine)
+              if origActive != i:
+                e.windowManager.activeWindowIndex =
+                  if origActive > i:
+                    origActive - 1
+                  else:
+                    origActive
+              e.syncActiveWindow()
+              e.setMode(e.activeWindow.mode)
+            else:
+              # Last window: return to Normal mode
+              window.mode = EditorMode.Normal
               e.setMode(EditorMode.Normal)
           e.state.needsFullRedraw = true
           return

--- a/src/moepkg/command_completion.nim
+++ b/src/moepkg/command_completion.nim
@@ -170,6 +170,8 @@ const CommandDescriptions = {
   "lspexecommand": "Execute LSP command",
   "lspcallhierarchyincoming": "Show incoming calls",
   "lspcallhierarchyoutgoing": "Show outgoing calls",
+  # Terminal
+  "terminal": "Open terminal emulator",
 }.toTable
 
 # Commands that take file path arguments

--- a/src/moepkg/command_config.nim
+++ b/src/moepkg/command_config.nim
@@ -192,6 +192,9 @@ proc loadDefaultConfig*(config: CommandConfig) =
   config.addAlias("lspcallhierarchyincoming", claLspCallHierarchyIncoming)
   config.addAlias("lspcallhierarchyoutgoing", claLspCallHierarchyOutgoing)
 
+  # Terminal
+  config.addAlias("terminal", claTerminal)
+
 proc applyToParser*(config: CommandConfig, parser: CommandLineParser) =
   ## Apply configuration to a command line parser
   # Clear existing aliases

--- a/src/moepkg/command_handlers/command_handler.nim
+++ b/src/moepkg/command_handlers/command_handler.nim
@@ -117,6 +117,7 @@ type
     cmrLspCallHierarchyIncoming # LSP incoming calls (:lspCallHierarchyIncoming)
     cmrLspCallHierarchyOutgoing # LSP outgoing calls (:lspCallHierarchyOutgoing)
     cmrSubstitute # Search and replace (:s)
+    cmrTerminal # Open terminal emulator (:terminal)
     cmrError # Command error
 
   CommandModeHandler* = ref object ## Handler for Command mode specific commands
@@ -225,6 +226,8 @@ type
       substituteReplacement*: string
       substituteGlobal*: bool # true for /g flag
       substituteCount*: int # number of replacements made
+    of cmrTerminal:
+      terminalCommand*: string # Optional command (empty = default shell)
     of cmrError:
       errorMessage*: string
 
@@ -916,6 +919,9 @@ proc handleCommandModeInput*(
     return CommandModeResult(kind: cmrLspCallHierarchyIncoming)
   of claLspCallHierarchyOutgoing:
     return CommandModeResult(kind: cmrLspCallHierarchyOutgoing)
+  of claTerminal:
+    return
+      CommandModeResult(kind: cmrTerminal, terminalCommand: cmdResult.terminalCommand)
   of claSubstitute:
     return handler.executeSubstitute(
       buffer, cmdResult.pattern, cmdResult.replacement, cmdResult.substituteFlags,

--- a/src/moepkg/command_handlers/handler_manager.nim
+++ b/src/moepkg/command_handlers/handler_manager.nim
@@ -36,13 +36,15 @@ import
   normal_handler, insert_handler, command_handler, visual_handler, replace_handler,
   filer_handler, log_viewer_handler, help_handler, buffer_manager_handler,
   backup_manager_handler, diff_viewer_handler, recent_file_mode_handler, debug_handler,
-  config_handler, references_handler, documentsymbol_handler, callhierarchy_handler
+  config_handler, references_handler, documentsymbol_handler, callhierarchy_handler,
+  terminal_handler
 
 export
   normal_handler, insert_handler, command_handler, visual_handler, replace_handler,
   filer_handler, log_viewer_handler, help_handler, buffer_manager_handler,
   backup_manager_handler, diff_viewer_handler, recent_file_mode_handler, debug_handler,
-  config_handler, references_handler, documentsymbol_handler, callhierarchy_handler
+  config_handler, references_handler, documentsymbol_handler, callhierarchy_handler,
+  terminal_handler
 
 type
   HandlerResultKind* = enum
@@ -141,6 +143,8 @@ type
     hrCallHierarchyRequestIncoming # Request incoming calls for selected item
     hrCallHierarchyRequestOutgoing # Request outgoing calls for selected item
     hrEnterCallHierarchy # Enter call hierarchy viewer mode
+    hrEnterTerminal # Enter terminal mode
+    hrTerminalQuit # Close terminal and return to previous mode
     hrUnhandled # Command was not handled
     hrError # Error occurred
 
@@ -161,6 +165,7 @@ type
     referencesHandler*: ReferencesHandler
     documentSymbolHandler*: DocumentSymbolHandler
     callHierarchyHandler*: CallHierarchyHandler
+    terminalHandler*: TerminalHandler
     motionController*: MotionController
     keyBindingRegistry*: KeyBindingRegistry
     commandLineParser*: CommandLineParser
@@ -363,6 +368,10 @@ type
       callHierarchyOutgoingItem*: lspTypes.CallHierarchyItem
     of hrEnterCallHierarchy:
       discard
+    of hrEnterTerminal:
+      enterTerminalCommand*: string # Optional command (empty = default shell)
+    of hrTerminalQuit:
+      discard
     of hrUnhandled:
       discard
     of hrError:
@@ -409,6 +418,7 @@ proc newHandlerManager*(
   let referencesHandler = newReferencesHandler()
   let documentSymbolHandler = newDocumentSymbolHandler()
   let callHierarchyHandler = newCallHierarchyHandler()
+  let terminalHandler = newTerminalHandler()
 
   HandlerManager(
     normalHandler: normalHandler,
@@ -427,6 +437,7 @@ proc newHandlerManager*(
     referencesHandler: referencesHandler,
     documentSymbolHandler: documentSymbolHandler,
     callHierarchyHandler: callHierarchyHandler,
+    terminalHandler: terminalHandler,
     motionController: motionController,
     keyBindingRegistry: keyBindingRegistry,
     commandLineParser: commandLineParser,
@@ -806,6 +817,8 @@ proc handleCommandMode*(
     return HandlerResult(kind: hrLspCallHierarchyOutgoing)
   of cmrSubstitute:
     return HandlerResult(kind: hrSubstitute, hrSubstituteCount: r.substituteCount)
+  of cmrTerminal:
+    return HandlerResult(kind: hrEnterTerminal, enterTerminalCommand: r.terminalCommand)
   of cmrError:
     return HandlerResult(kind: hrError, errorMessage: r.errorMessage)
 
@@ -1419,6 +1432,52 @@ proc handleRecentFileMode*(
   of rfmrError:
     return HandlerResult(kind: hrError, errorMessage: r.errorMessage)
 
+proc handleTerminalMode*(
+    manager: HandlerManager,
+    termState: TerminalState,
+    state: EditorState,
+    keyCombo: KeyCombo,
+    window: EditorWindow,
+): HandlerResult =
+  ## Handle Terminal mode input
+  let r = manager.terminalHandler.handleTerminalModeKey(termState, keyCombo)
+  case r.kind
+  of trHandled:
+    return HandlerResult(
+      kind: hrHandled, modeTransition: none(EditorMode), statusMessage: ""
+    )
+  of trSwitchToNormal:
+    # Switch to Terminal-Normal sub-mode: snapshot grid to TextBuffer
+    let snapshotBuffer = termState.enterNormalSubMode()
+    window.buffer = snapshotBuffer
+    window.cursor = BufferPosition(line: max(0, snapshotBuffer.len - 1), column: 0)
+    window.viewport.topLine = max(0, snapshotBuffer.len - window.viewport.height)
+    return HandlerResult(
+      kind: hrHandled,
+      modeTransition: none(EditorMode),
+      statusMessage: "-- TERMINAL NORMAL --",
+    )
+  of trReturnToInput:
+    # Return to Terminal-Input sub-mode: restore placeholder buffer
+    termState.exitNormalSubMode()
+    window.buffer = newTextBuffer("")
+    window.cursor = BufferPosition(line: 0, column: 0)
+    return HandlerResult(
+      kind: hrHandled, modeTransition: none(EditorMode), statusMessage: ""
+    )
+  of trEnterCommand:
+    state.commandText = ":"
+    state.commandCursor = 0
+    return HandlerResult(
+      kind: hrHandled, overlayTransition: some(okCommand), statusMessage: ""
+    )
+  of trQuit:
+    return HandlerResult(kind: hrTerminalQuit)
+  of trUnhandled:
+    return HandlerResult(kind: hrUnhandled)
+  of trError:
+    return HandlerResult(kind: hrError, errorMessage: r.errorMessage)
+
 const MaxMacroRecursionDepth = 100
   ## Maximum macro recursion depth to prevent infinite loops
 
@@ -1529,6 +1588,14 @@ proc handleKeyCombo*(
       return HandlerResult(
         kind: hrError, errorMessage: "Call hierarchy viewer state not initialized"
       )
+  of EditorMode.Terminal:
+    if window.isSome and window.get.terminalState.isSome:
+      return manager.handleTerminalMode(
+        window.get.terminalState.get, state, keyCombo, window.get
+      )
+    else:
+      return
+        HandlerResult(kind: hrError, errorMessage: "Terminal state not initialized")
   of EditorMode.RecentFile:
     # Recent File mode requires its own state, not EditorState
     # This should be handled at a higher level with RecentFileModeState

--- a/src/moepkg/command_handlers/normal_handler.nim
+++ b/src/moepkg/command_handlers/normal_handler.nim
@@ -302,6 +302,8 @@ proc handleModeSwitch*(
   of EditorMode.CallHierarchy:
     return
       NormalModeResult(kind: nmrHandled, modeTransition: some(EditorMode.CallHierarchy))
+  of EditorMode.Terminal:
+    return NormalModeResult(kind: nmrHandled, modeTransition: some(EditorMode.Terminal))
   of EditorMode.Normal:
     # Already in Normal mode
     return NormalModeResult(kind: nmrHandled, modeTransition: none(EditorMode))

--- a/src/moepkg/command_handlers/terminal_handler.nim
+++ b/src/moepkg/command_handlers/terminal_handler.nim
@@ -1,0 +1,185 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2026 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+## Terminal mode command handler
+##
+## Handles input in Terminal mode. Has two sub-modes:
+## - Terminal-Input: forwards keystrokes to PTY
+## - Terminal-Normal: Vim-like scrollback navigation
+
+import std/options
+
+import ../[terminal_mode, key_bindings]
+
+type
+  TerminalResultKind* = enum
+    trHandled # Key was forwarded to PTY or processed
+    trSwitchToNormal # Switch to Terminal-Normal sub-mode
+    trReturnToInput # Return to Terminal-Input sub-mode
+    trEnterCommand # Enter command mode (:)
+    trQuit # Close terminal
+    trUnhandled # Key not handled (delegate to normal mode in tsmNormal)
+    trError # Error occurred
+
+  TerminalResult* = object
+    case kind*: TerminalResultKind
+    of trError:
+      errorMessage*: string
+    else:
+      discard
+
+  TerminalHandler* = ref object ## Handler for Terminal mode specific commands
+    discard
+
+proc newTerminalHandler*(): TerminalHandler =
+  TerminalHandler()
+
+proc keyComboToBytes*(keyCombo: KeyCombo): string =
+  ## Convert a KeyCombo to raw terminal bytes for PTY forwarding.
+  if keyCombo.isSpecial:
+    case keyCombo.special
+    of skEnter:
+      return "\r"
+    of skEscape:
+      return "\x1b"
+    of skBackspace:
+      return "\x7f"
+    of skTab:
+      return "\t"
+    of skBackTab:
+      return "\x1b[Z"
+    of skUp:
+      return "\x1b[A"
+    of skDown:
+      return "\x1b[B"
+    of skRight:
+      return "\x1b[C"
+    of skLeft:
+      return "\x1b[D"
+    of skHome:
+      return "\x1b[H"
+    of skEnd:
+      return "\x1b[F"
+    of skDelete:
+      return "\x1b[3~"
+    of skPageUp:
+      return "\x1b[5~"
+    of skPageDown:
+      return "\x1b[6~"
+    of skFunction:
+      # Function keys F1-F12
+      case keyCombo.fnNum
+      of 1:
+        return "\x1bOP"
+      of 2:
+        return "\x1bOQ"
+      of 3:
+        return "\x1bOR"
+      of 4:
+        return "\x1bOS"
+      of 5:
+        return "\x1b[15~"
+      of 6:
+        return "\x1b[17~"
+      of 7:
+        return "\x1b[18~"
+      of 8:
+        return "\x1b[19~"
+      of 9:
+        return "\x1b[20~"
+      of 10:
+        return "\x1b[21~"
+      of 11:
+        return "\x1b[23~"
+      of 12:
+        return "\x1b[24~"
+      else:
+        return ""
+    of skNone:
+      return ""
+  else:
+    if kmCtrl in keyCombo.modifiers:
+      # Ctrl+letter -> ASCII control character
+      if keyCombo.char.len == 1:
+        let ch = keyCombo.char[0]
+        if ch >= 'a' and ch <= 'z':
+          return $chr(ch.ord - 'a'.ord + 1)
+        elif ch >= 'A' and ch <= 'Z':
+          return $chr(ch.ord - 'A'.ord + 1)
+      return ""
+    elif kmAlt in keyCombo.modifiers:
+      # Alt+key -> ESC + key
+      return "\x1b" & keyCombo.char
+    else:
+      return keyCombo.char
+
+proc handleTerminalModeKey*(
+    handler: TerminalHandler, termState: TerminalState, keyCombo: KeyCombo
+): TerminalResult =
+  ## Handle a key press in Terminal mode.
+
+  case termState.subMode
+  of tsmInput:
+    # Terminal-Input sub-mode: forward almost everything to PTY
+
+    # Check for Ctrl-\ (escape sequence to enter Normal sub-mode)
+    if not keyCombo.isSpecial and kmCtrl in keyCombo.modifiers and
+        keyCombo.char in ["\\", "\x1c"]:
+      termState.waitingForCtrlN = true
+      return TerminalResult(kind: trHandled)
+
+    # If waiting for Ctrl-N after Ctrl-\
+    if termState.waitingForCtrlN:
+      termState.waitingForCtrlN = false
+      if not keyCombo.isSpecial and kmCtrl in keyCombo.modifiers and
+          keyCombo.char in ["n", "N"]:
+        return TerminalResult(kind: trSwitchToNormal)
+      # Not Ctrl-N, forward the original Ctrl-\ and this key
+      termState.feedInput("\x1c")
+      let bytes = keyComboToBytes(keyCombo)
+      if bytes.len > 0:
+        termState.feedInput(bytes)
+      return TerminalResult(kind: trHandled)
+
+    # Forward key to PTY
+    let bytes = keyComboToBytes(keyCombo)
+    if bytes.len > 0:
+      termState.feedInput(bytes)
+    return TerminalResult(kind: trHandled)
+  of tsmNormal:
+    # Terminal-Normal sub-mode: Vim-like scrollback navigation
+
+    # 'i' or 'a' returns to Terminal-Input sub-mode
+    if not keyCombo.isSpecial and keyCombo.modifiers == {}:
+      case keyCombo.char
+      of "i", "a":
+        return TerminalResult(kind: trReturnToInput)
+      of ":":
+        return TerminalResult(kind: trEnterCommand)
+      of "q":
+        # Close terminal if process has exited
+        if termState.exitCode.isSome:
+          return TerminalResult(kind: trQuit)
+        # Otherwise ignore (process still running)
+        return TerminalResult(kind: trHandled)
+      else:
+        discard
+
+    # Delegate unhandled keys to normal mode navigation (j/k/gg/G/search etc.)
+    return TerminalResult(kind: trUnhandled)

--- a/src/moepkg/command_handlers/terminal_handler.nim
+++ b/src/moepkg/command_handlers/terminal_handler.nim
@@ -122,6 +122,18 @@ proc keyComboToBytes*(keyCombo: KeyCombo): string =
           return $chr(ch.ord - 'a'.ord + 1)
         elif ch >= 'A' and ch <= 'Z':
           return $chr(ch.ord - 'A'.ord + 1)
+        elif ch == '\\':
+          return "\x1c" # FS
+        elif ch == ']':
+          return "\x1d" # GS
+        elif ch == '^':
+          return "\x1e" # RS
+        elif ch == '_':
+          return "\x1f" # US
+        elif ch == '@':
+          return "\x00" # NUL
+        elif ch == '[':
+          return "\x1b" # ESC
       return ""
     elif kmAlt in keyCombo.modifiers:
       # Alt+key -> ESC + key

--- a/src/moepkg/command_line.nim
+++ b/src/moepkg/command_line.nim
@@ -74,6 +74,7 @@ type
     claLspExecuteCommand # :lspexecommand (LSP execute command)
     claLspCallHierarchyIncoming # :lspcallhierarchyincoming (LSP incoming calls)
     claLspCallHierarchyOutgoing # :lspcallhierarchyoutgoing (LSP outgoing calls)
+    claTerminal # :terminal (open terminal emulator)
     claUnknown # Unknown command
 
   ParsedCommand* = object
@@ -184,6 +185,8 @@ type
       discard
     of claLspCallHierarchyOutgoing:
       discard
+    of claTerminal:
+      terminalCommand*: string # Optional command (empty = default shell)
     of claUnknown:
       errorMessage*: string
 
@@ -202,6 +205,7 @@ const ArgumentRequiredActions* = {
   claVSplit, # optional but user may want to specify file
   claHSplit, # optional but user may want to specify file
   claFiler, # optional but user may want to specify path
+  claTerminal, # optional but user may want to specify command
   claUnknown, # invalid command
 }
 
@@ -763,6 +767,13 @@ proc execute*(parser: CommandLineParser, cmd: ParsedCommand): CommandLineResult 
     return CommandLineResult(kind: claLspCallHierarchyIncoming)
   of claLspCallHierarchyOutgoing:
     return CommandLineResult(kind: claLspCallHierarchyOutgoing)
+  of claTerminal:
+    let termCmd =
+      if cmd.args.len > 0:
+        cmd.args.join(" ")
+      else:
+        ""
+    return CommandLineResult(kind: claTerminal, terminalCommand: termCmd)
   of claUnknown:
     return CommandLineResult(
       kind: claUnknown, errorMessage: "Not an editor command: " & cmd.rawText

--- a/src/moepkg/editor.nim
+++ b/src/moepkg/editor.nim
@@ -604,6 +604,7 @@ proc newEditor*(editorConfig: EditorConfig, vr: ValidationResult): Editor =
       ),
     ),
     viewport: ViewPort(topLine: 0, leftColumn: 0, width: 80, height: 20, x: 0, y: 0),
+    screenSize: ScreenSize(width: 80, height: 20),
     commandRegistry: cmdRegistry,
     keyBindingRegistry: keyRegistry,
     commandLineParser: cmdLineParser,

--- a/src/moepkg/editor_render_modes.nim
+++ b/src/moepkg/editor_render_modes.nim
@@ -254,6 +254,8 @@ proc renderTerminal*(
     for row in 0 ..< min(grid.rows, maxRows):
       for col in 0 ..< min(grid.cols, maxCols):
         let cell = grid.cells[row][col]
+        if cell.widePadding:
+          continue # celina's setString handles wide char's second column
         let style = terminalCellToStyle(cell)
         let ch = if cell.ch.len > 0: cell.ch else: " "
         buffer.setString(startX + col, startY + row, ch, style)

--- a/src/moepkg/editor_render_modes.nim
+++ b/src/moepkg/editor_render_modes.nim
@@ -17,13 +17,14 @@
 #                                                                              #
 #[############################################################################]#
 
-## Special mode rendering procedures (config mode)
+## Special mode rendering procedures (config mode, terminal mode)
 
 import std/[options, strutils]
 
 import pkg/celina
 
 import editor_types, color, render_utils, config_mode
+import terminal/ansi_parser
 
 proc renderConfig*(
     e: Editor,
@@ -186,4 +187,95 @@ proc renderConfig*(
       e.state.cursorVisible = true
   else:
     # Hide cursor when not in edit mode
+    e.state.cursorVisible = false
+
+proc terminalColorToColorValue(tc: TerminalColor): ColorValue =
+  ## Convert ansi_parser TerminalColor to celina ColorValue.
+  case tc.kind
+  of ckDefault:
+    ColorValue(kind: Default)
+  of ckIndexed:
+    ColorValue(kind: Indexed256, indexed256: tc.index)
+  of ckRgb:
+    ColorValue(kind: celina.Rgb, rgb: RgbColor(r: tc.r, g: tc.g, b: tc.b))
+
+proc terminalCellToStyle(cell: TerminalCell): Style =
+  ## Convert a TerminalCell's colors and attributes to a celina Style.
+  var modifiers: set[StyleModifier] = {}
+  if taBold in cell.attrs:
+    modifiers.incl(StyleModifier.Bold)
+  if taDim in cell.attrs:
+    modifiers.incl(StyleModifier.Dim)
+  if taItalic in cell.attrs:
+    modifiers.incl(StyleModifier.Italic)
+  if taUnderline in cell.attrs:
+    modifiers.incl(StyleModifier.Underline)
+  if taReverse in cell.attrs:
+    modifiers.incl(StyleModifier.Reversed)
+  if taStrikethrough in cell.attrs:
+    modifiers.incl(StyleModifier.Crossed)
+
+  Style(
+    fg: terminalColorToColorValue(cell.fg),
+    bg: terminalColorToColorValue(cell.bg),
+    modifiers: modifiers,
+  )
+
+proc renderTerminal*(
+    e: Editor,
+    buffer: var Buffer,
+    window: EditorWindow,
+    isBottomWindow: bool,
+    tabLineOffset: int,
+) =
+  ## Render the terminal emulator grid within a window's viewport.
+  if window.terminalState.isNone:
+    return
+
+  let reservedBottom =
+    if isBottomWindow and e.state.display.showStatusLine:
+      StatusAndCommandReserve
+    elif isBottomWindow:
+      CommandLineReserve
+    else:
+      0
+
+  let
+    termState = window.terminalState.get
+    grid = termState.grid
+    startX = window.viewport.x
+    startY = window.viewport.y + tabLineOffset
+    maxRows = window.viewport.height - reservedBottom - tabLineOffset
+    maxCols = window.viewport.width
+
+  case termState.subMode
+  of tsmInput:
+    # Render live terminal grid directly to celina buffer
+    for row in 0 ..< min(grid.rows, maxRows):
+      for col in 0 ..< min(grid.cols, maxCols):
+        let cell = grid.cells[row][col]
+        let style = terminalCellToStyle(cell)
+        let ch = if cell.ch.len > 0: cell.ch else: " "
+        buffer.setString(startX + col, startY + row, ch, style)
+      # Clear remaining columns if grid is narrower than viewport
+      if grid.cols < maxCols:
+        let emptyStr = " ".repeat(maxCols - grid.cols)
+        buffer.setString(startX + grid.cols, startY + row, emptyStr, normalStyle())
+
+    # Clear remaining rows
+    if grid.rows < maxRows:
+      let emptyLine = " ".repeat(maxCols)
+      for row in grid.rows ..< maxRows:
+        buffer.setString(startX, startY + row, emptyLine, normalStyle())
+
+    # Position cursor at terminal cursor location
+    if grid.cursorVisible and grid.cursorRow < maxRows and grid.cursorCol < maxCols:
+      e.state.screenCursor.x = startX + grid.cursorCol
+      e.state.screenCursor.y = startY + grid.cursorRow
+      e.state.cursorVisible = true
+    else:
+      e.state.cursorVisible = false
+  of tsmNormal:
+    # In Normal sub-mode, rendering is handled by editor_render_views.nim
+    # via renderWindow (the snapshot buffer is already set as window.buffer).
     e.state.cursorVisible = false

--- a/src/moepkg/editor_render_views.nim
+++ b/src/moepkg/editor_render_views.nim
@@ -28,15 +28,18 @@ import
   status_line, tab_line, buffer
 
 proc updateViewportSize*(e: Editor, buffer: Buffer): bool =
-  ## Update viewport size from buffer area and return true if resized
-  let
-    oldWidth = e.viewport.width
-    oldHeight = e.viewport.height
+  ## Update screen size from buffer area and return true if resized.
+  ## Uses e.screenSize (not e.viewport) to avoid overwriting the active
+  ## window's viewport dimensions in split mode.
+  ## Stores previous dimensions in prevWidth/prevHeight for resize calculations.
+  e.screenSize.prevWidth = e.screenSize.width
+  e.screenSize.prevHeight = e.screenSize.height
 
-  e.viewport.width = buffer.area.width
-  e.viewport.height = buffer.area.height
+  e.screenSize.width = buffer.area.width
+  e.screenSize.height = buffer.area.height
 
-  (oldWidth != e.viewport.width) or (oldHeight != e.viewport.height)
+  (e.screenSize.prevWidth != e.screenSize.width) or
+    (e.screenSize.prevHeight != e.screenSize.height)
 
 proc adjustViewportForCursor(
     viewport: ViewPort,
@@ -84,18 +87,14 @@ proc adjustViewportForCursor(
 proc renderSplitView*(e: Editor, buffer: var Buffer, wasResized: bool) =
   ## Render split window view
 
-  let
-    oldWidth = e.viewport.width
-    oldHeight = e.viewport.height
-
   # If terminal was resized, rebuild window layout
-  if wasResized and oldWidth > 0 and oldHeight > 0 and e.viewport.width > 0 and
-      e.viewport.height > 0:
+  if wasResized and e.screenSize.prevWidth > 0 and e.screenSize.prevHeight > 0 and
+      e.screenSize.width > 0 and e.screenSize.height > 0:
     # Note: cursor is now stored directly in EditorWindow (single source of truth)
 
     e.windowManager.resizeWindows(
-      e.viewport.width, e.viewport.height, oldWidth, oldHeight,
-      e.state.display.multiStatusLine,
+      e.screenSize.width, e.screenSize.height, e.screenSize.prevWidth,
+      e.screenSize.prevHeight, e.state.display.multiStatusLine,
     )
 
   # Find the maximum bottom Y coordinate (to determine bottom windows)

--- a/src/moepkg/editor_render_views.nim
+++ b/src/moepkg/editor_render_views.nim
@@ -235,6 +235,15 @@ proc renderSplitView*(e: Editor, buffer: var Buffer, wasResized: bool) =
       e.renderWindow(
         buffer, window, lineNumOffset, isBottomWindow, isActiveWindow, tabLineOffset
       )
+    of EditorMode.Terminal:
+      # Terminal mode renders grid directly in Input sub-mode,
+      # or uses standard window rendering in Normal sub-mode
+      if window.terminalState.isSome and window.terminalState.get.subMode == tsmInput:
+        e.renderTerminal(buffer, window, isBottomWindow, tabLineOffset)
+      else:
+        e.renderWindow(
+          buffer, window, lineNumOffset, isBottomWindow, isActiveWindow, tabLineOffset
+        )
     else:
       # Normal buffer rendering (Normal, Insert, Visual, Command, Search, etc.)
       e.renderWindow(
@@ -258,7 +267,14 @@ proc renderSplitView*(e: Editor, buffer: var Buffer, wasResized: bool) =
 
   # Set cursor to active window position
   if e.windowManager.activeWindowIndex < e.windowManager.windows.len:
-    e.setActiveWindowScreenCursor(e.activeWindow)
+    # Terminal-Input mode manages its own screen cursor from the grid,
+    # so skip the standard cursor calculation that would overwrite it.
+    let isTerminalInput =
+      e.activeWindow.mode == EditorMode.Terminal and e.activeWindow.terminalState.isSome and
+      e.activeWindow.terminalState.get.subMode == tsmInput
+
+    if not isTerminalInput:
+      e.setActiveWindowScreenCursor(e.activeWindow)
 
     # Set cursor visibility based on mode
     # Special modes (Filer, Config, etc.) set cursorVisible in their render functions
@@ -273,6 +289,9 @@ proc renderSplitView*(e: Editor, buffer: var Buffer, wasResized: bool) =
         EditorMode.DiffViewer, EditorMode.Debug, EditorMode.References,
         EditorMode.DocumentSymbol, EditorMode.CallHierarchy, EditorMode.RecentFile:
       e.state.cursorVisible = false
+    of EditorMode.Terminal:
+      # Terminal mode sets cursorVisible in renderTerminal
+      discard
     else:
       # Normal, Insert, Visual, etc. - cursor should be visible
       e.state.cursorVisible = true

--- a/src/moepkg/editor_types.nim
+++ b/src/moepkg/editor_types.nim
@@ -36,10 +36,15 @@ export
   background_process
 
 type
+  ScreenSize* = object
+    width*, height*: int
+    prevWidth*, prevHeight*: int
+
   Editor* = ref object
     textBuffer*: TextBuffer
     state*: EditorState
     viewport*: ViewPort
+    screenSize*: ScreenSize
     executer*: CommandExecutor
     commandRegistry*: CommandRegistry
     keyBindingRegistry*: KeyBindingRegistry

--- a/src/moepkg/editor_window.nim
+++ b/src/moepkg/editor_window.nim
@@ -170,6 +170,9 @@ proc restoreOriginalBuffer*(win: EditorWindow, mode: EditorMode) =
     if win.callHierarchyViewerState.isSome and
         win.callHierarchyViewerState.get.originalBuffer != nil:
       win.buffer = win.callHierarchyViewerState.get.originalBuffer
+  of EditorMode.Terminal:
+    if win.terminalState.isSome and win.terminalState.get.originalBuffer != nil:
+      win.buffer = win.terminalState.get.originalBuffer
   else:
     discard
 
@@ -202,6 +205,10 @@ proc clearModeState*(win: EditorWindow, mode: EditorMode) =
     win.callHierarchyViewerState = none(CallHierarchyViewerState)
   of EditorMode.RecentFile:
     win.recentFileModeState = none(RecentFileModeState)
+  of EditorMode.Terminal:
+    if win.terminalState.isSome:
+      win.terminalState.get.cleanup()
+    win.terminalState = none(TerminalState)
   else:
     discard
 

--- a/src/moepkg/editor_window.nim
+++ b/src/moepkg/editor_window.nim
@@ -74,6 +74,28 @@ proc calculateReservedLines*(e: Editor, isBottomWindow: bool = true): int =
   if isBottomWindow:
     result += e.state.statusMessageExtraLines()
 
+proc calculateTerminalAreaDimensions*(
+    e: Editor, window: EditorWindow
+): tuple[cols, rows: int] =
+  ## Compute the correct PTY cols/rows for a terminal in the given window,
+  ## matching the formula used by renderTerminal.
+  let
+    maxBottomY = findMaxBottomY(e.windowManager.windows)
+    windowBottomY = window.viewport.y + window.viewport.height
+    isBottomWindow = (windowBottomY == maxBottomY)
+    tabLineOffset = if e.state.display.showTabLine: TabLineHeight else: 0
+    reservedBottom =
+      if isBottomWindow and e.state.display.showStatusLine:
+        StatusAndCommandReserve
+      elif isBottomWindow:
+        CommandLineReserve
+      else:
+        0
+  result = (
+    cols: window.viewport.width,
+    rows: max(1, window.viewport.height - reservedBottom - tabLineOffset),
+  )
+
 proc calculateWindowCursor*(
     e: Editor,
     buffer: TextBuffer,

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -26,7 +26,8 @@ import
   editor, key_bindings, modes, buffer, logger, types, motion, search_utils, filer,
   quick_run_utils, help_viewer, buffer_manager, backup_manager, backup, diff_viewer,
   command_completion, build, render_utils, debug_viewer, config_loader,
-  documentsymbol_viewer, message_log, command_line, color, theme, tab_line
+  documentsymbol_viewer, message_log, command_line, color, theme, tab_line,
+  terminal_mode
 import command_handlers/handler_manager
 
 proc addRunningProcess*(e: Editor, p: BackgroundProcess) =
@@ -323,6 +324,28 @@ proc enterFilerInActiveWindow(e: Editor, path: string) =
   activeWin.cursor = BufferPosition(line: 0, column: 0)
   activeWin.viewport.topLine = 0
   activeWin.viewport.leftColumn = 0
+
+proc enterTerminalInActiveWindow(e: Editor, command: string) =
+  ## Switch the active window to Terminal mode.
+  let activeWin = e.activeWindow
+  let
+    cols = activeWin.viewport.width
+    rows = max(1, activeWin.viewport.height - e.calculateReservedLines(true))
+  let termResult = newTerminalState(command, cols, rows)
+  if termResult.isErr:
+    e.state.setStatusMessage("Terminal error: " & termResult.error)
+    return
+
+  let termState = termResult.get
+  termState.originalBuffer = activeWin.buffer
+  activeWin.terminalState = some(termState)
+  # Create a placeholder buffer (grid will be rendered directly)
+  activeWin.buffer = newTextBuffer("")
+  activeWin.cursor = BufferPosition(line: 0, column: 0)
+  activeWin.viewport.topLine = 0
+  activeWin.viewport.leftColumn = 0
+  e.setMode(EditorMode.Terminal)
+  activeWin.mode = EditorMode.Terminal
 
 proc handleCommandModeEvent(e: Editor, event: Event): bool =
   ## Handle Command mode events (special handling for text input)
@@ -855,6 +878,12 @@ proc handleCommandModeEvent(e: Editor, event: Event): bool =
           else:
             getCurrentDir()
         e.enterFilerInActiveWindow(startPath)
+      of hrEnterTerminal:
+        overlayHandled = true
+        let baseModeBeforeOverlay = e.state.baseMode
+        e.state.exitOverlay()
+        e.state.previousMode = baseModeBeforeOverlay
+        e.enterTerminalInActiveWindow(r.enterTerminalCommand)
       of hrEnterLogViewer:
         overlayHandled = true
         # Open LogViewer in a new split window for editor messages - exit overlay first
@@ -1227,7 +1256,7 @@ proc handleCommandModeEvent(e: Editor, event: Event): bool =
           hrPrevWindow, hrLspGotoDefinition, hrLspGotoDeclaration, hrLspFindReferences,
           hrLspCodeLensExecute, hrLspTypeDefinition, hrLspImplementation, hrLspHover,
           hrLspRename, hrLspSelectionRange, hrLspDocumentLink, hrConfigQuit,
-          hrConfigSaveConfig, hrDebugViewerQuit, hrLogViewerQuit:
+          hrConfigSaveConfig, hrDebugViewerQuit, hrLogViewerQuit, hrTerminalQuit:
         discard # Not returned from command mode handler
 
       if not overlayHandled:
@@ -1585,7 +1614,7 @@ proc handleRecentFileModeEvent(e: Editor, event: Event): bool =
       hrEnterReferences, hrDocumentSymbolQuit, hrDocumentSymbolJumpTo,
       hrEnterDocumentSymbol, hrCallHierarchyQuit, hrCallHierarchyJumpTo,
       hrCallHierarchyRequestIncoming, hrCallHierarchyRequestOutgoing,
-      hrEnterCallHierarchy:
+      hrEnterCallHierarchy, hrEnterTerminal, hrTerminalQuit:
     discard # Not expected from RecentFile mode handler
 
   # Handle overlay transitions (e.g., entering Command mode with :)
@@ -2036,8 +2065,17 @@ proc handleEvent*(e: Editor, event: Event): bool =
   if event.kind == EventKind.Key and e.state.scrollAnimation.active:
     cancelScrollAnimation(e.state.scrollAnimation)
 
-  # Handle Ctrl-C (Quit event from celina) - Vim-like behavior
+  # Handle Ctrl-C (Quit event from celina)
   if event.kind == EventKind.Quit:
+    # Terminal-Input mode: forward Ctrl-C to PTY as \x03
+    if e.state.mode == EditorMode.Terminal:
+      let activeWin = e.activeWindow
+      if activeWin.terminalState.isSome:
+        let termState = activeWin.terminalState.get
+        if termState.subMode == tsmInput:
+          termState.feedInput("\x03")
+          return true
+
     if e.state.mode == EditorMode.Normal:
       # Normal mode: show exit message like Vim
       e.state.statusMessage = "Type :qa and press <Enter> to exit"
@@ -2453,6 +2491,12 @@ proc handleEvent*(e: Editor, event: Event): bool =
   of hrFilerQuit:
     # Close filer and return to Normal mode
     e.activeWindow.clearModeState(EditorMode.Filer)
+    e.activeWindow.mode = EditorMode.Normal
+    e.setMode(EditorMode.Normal)
+    return true
+  of hrTerminalQuit:
+    # Close terminal and return to Normal mode
+    e.activeWindow.clearModeState(EditorMode.Terminal)
     e.activeWindow.mode = EditorMode.Normal
     e.setMode(EditorMode.Normal)
     return true
@@ -2904,7 +2948,7 @@ proc handleEvent*(e: Editor, event: Event): bool =
       hrRecentFile, hrRecentFileOpenFile, hrRecentFileQuit, hrNextWindow, hrPrevWindow,
       hrEnterFiler, hrEnterLogViewer, hrEnterHelpViewer, hrEnterBufferManager,
       hrEnterBackupManager, hrEnterDiffViewer, hrEnterReferences, hrEnterDocumentSymbol,
-      hrEnterCallHierarchy:
+      hrEnterCallHierarchy, hrEnterTerminal:
     discard # Handled by handleCommandModeEvent or other code paths
 
   # Handle overlay transitions

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -328,9 +328,7 @@ proc enterFilerInActiveWindow(e: Editor, path: string) =
 proc enterTerminalInActiveWindow(e: Editor, command: string) =
   ## Switch the active window to Terminal mode.
   let activeWin = e.activeWindow
-  let
-    cols = activeWin.viewport.width
-    rows = max(1, activeWin.viewport.height - e.calculateReservedLines(true))
+  let (cols, rows) = e.calculateTerminalAreaDimensions(activeWin)
   let termResult = newTerminalState(command, cols, rows)
   if termResult.isErr:
     e.state.setStatusMessage("Terminal error: " & termResult.error)

--- a/src/moepkg/help_viewer.nim
+++ b/src/moepkg/help_viewer.nim
@@ -348,10 +348,6 @@ Ctrl-\ Ctrl-n - Switch to Terminal-Normal sub-mode
 
 ## Terminal-Normal sub-mode
 
-j  - Go down
-k  - Go up
-gg - Go to the first line
-G  - Go to the last line
 i  - Return to Terminal-Input sub-mode
 a  - Return to Terminal-Input sub-mode
 :  - Enter command mode

--- a/src/moepkg/help_viewer.nim
+++ b/src/moepkg/help_viewer.nim
@@ -334,6 +334,27 @@ config - Open configuration mode
 debug - Open debug mode
 
 jump - Open Jump list viewer
+
+terminal         - Open terminal emulator (default shell)
+terminal command - Run command in terminal emulator
+
+# Terminal mode
+
+## Terminal-Input sub-mode (default)
+
+All keystrokes are forwarded to the running shell/command.
+
+Ctrl-\ Ctrl-n - Switch to Terminal-Normal sub-mode
+
+## Terminal-Normal sub-mode
+
+j  - Go down
+k  - Go up
+gg - Go to the first line
+G  - Go to the last line
+i  - Return to Terminal-Input sub-mode
+a  - Return to Terminal-Input sub-mode
+:  - Enter command mode
 """
 
 import std/[strutils, options]

--- a/src/moepkg/modes.nim
+++ b/src/moepkg/modes.nim
@@ -47,6 +47,7 @@ type
     References
     DocumentSymbol
     CallHierarchy
+    Terminal
 
   ModeTransition* = object
     newMode*: Option[EditorMode]
@@ -82,6 +83,7 @@ proc modeLabel*(m: EditorMode): string =
   of EditorMode.References: "REFERENCES"
   of EditorMode.DocumentSymbol: "SYMBOLS"
   of EditorMode.CallHierarchy: "CALL HIERARCHY"
+  of EditorMode.Terminal: "TERMINAL"
 
 proc overlayLabel*(o: OverlayKind): string =
   case o

--- a/src/moepkg/terminal/ansi_parser.nim
+++ b/src/moepkg/terminal/ansi_parser.nim
@@ -21,7 +21,9 @@
 ## Implements a VT100/xterm state machine to process PTY output and
 ## maintain a 2D grid of styled cells.
 
-import std/strutils
+import std/[strutils, deques, unicode]
+
+import ../unicode_utils
 
 type
   ColorKind* = enum
@@ -52,6 +54,7 @@ type
     fg*: TerminalColor # Foreground color
     bg*: TerminalColor # Background color
     attrs*: set[TerminalAttr]
+    widePadding*: bool # Second cell of a wide (CJK) character
 
   AnsiParserState* = enum
     apsNormal # Normal text processing
@@ -68,7 +71,7 @@ type
     cursorCol*: int
     cursorVisible*: bool
     # Scrollback
-    scrollbackBuffer*: seq[seq[TerminalCell]]
+    scrollbackBuffer*: Deque[seq[TerminalCell]]
     maxScrollback*: int
     # Current SGR state
     currentFg*: TerminalColor
@@ -77,6 +80,7 @@ type
     # Parser state
     parserState*: AnsiParserState
     escapeBuffer*: string
+    utf8Buffer*: string # Incomplete UTF-8 bytes from previous read
     # Flags
     needsRedraw*: bool
     title*: string
@@ -91,6 +95,12 @@ proc indexedColor*(idx: uint8): TerminalColor =
 
 proc rgbColor*(r, g, b: uint8): TerminalColor =
   TerminalColor(kind: ckRgb, r: r, g: g, b: b)
+
+proc charDisplayWidth(ch: string): int =
+  ## Return the display width of a UTF-8 character (1 for narrow, 2 for wide/CJK).
+  if ch.len == 0:
+    return 1
+  runeWidth(ch.runeAt(0))
 
 proc defaultCell*(): TerminalCell =
   TerminalCell(ch: "", fg: defaultColor(), bg: defaultColor(), attrs: {})
@@ -107,7 +117,7 @@ proc newTerminalGrid*(cols, rows: int): TerminalGrid =
     cursorRow: 0,
     cursorCol: 0,
     cursorVisible: true,
-    scrollbackBuffer: @[],
+    scrollbackBuffer: initDeque[seq[TerminalCell]](),
     maxScrollback: DefaultMaxScrollback,
     currentFg: defaultColor(),
     currentBg: defaultColor(),
@@ -134,6 +144,11 @@ proc resize*(grid: TerminalGrid, cols, rows: int) =
     if r < oldRows:
       for c in 0 ..< min(cols, oldCols):
         newCells[r][c] = grid.cells[r][c]
+      # Clean up wide char split at the new right edge:
+      # If the cell just past the boundary (old col `cols`) was a padding cell,
+      # its main cell at cols-1 has lost its padding — clear it.
+      if cols < oldCols and cols > 0 and grid.cells[r][cols].widePadding:
+        newCells[r][cols - 1] = defaultCell()
 
   grid.cells = newCells
   grid.cols = cols
@@ -151,9 +166,9 @@ proc scrollUp(grid: TerminalGrid) =
     return
 
   # Push top line to scrollback
-  grid.scrollbackBuffer.add(grid.cells[0])
+  grid.scrollbackBuffer.addLast(grid.cells[0])
   if grid.scrollbackBuffer.len > grid.maxScrollback:
-    grid.scrollbackBuffer.delete(0)
+    grid.scrollbackBuffer.shrink(fromFirst = 1)
 
   # Shift rows up
   for r in 0 ..< grid.rows - 1:
@@ -164,8 +179,11 @@ proc scrollUp(grid: TerminalGrid) =
 
 proc putChar(grid: TerminalGrid, ch: string) =
   ## Place a character at the current cursor position, advancing the cursor.
+  ## Wide (CJK) characters occupy two cells: the character cell + a padding cell.
   if grid.cursorRow < 0 or grid.cursorRow >= grid.rows:
     return
+
+  let width = charDisplayWidth(ch)
 
   # Wrap if at right edge
   if grid.cursorCol >= grid.cols:
@@ -175,10 +193,60 @@ proc putChar(grid: TerminalGrid, ch: string) =
       grid.scrollUp()
       grid.cursorRow = grid.rows - 1
 
-  grid.cells[grid.cursorRow][grid.cursorCol] = TerminalCell(
+  # Wide character that doesn't fit on this line — pad the remaining cell and wrap
+  if width == 2 and grid.cursorCol + 1 >= grid.cols:
+    # Fill the last cell with a space and wrap
+    grid.cells[grid.cursorRow][grid.cursorCol] = defaultCell()
+    grid.cursorCol = 0
+    grid.cursorRow += 1
+    if grid.cursorRow >= grid.rows:
+      grid.scrollUp()
+      grid.cursorRow = grid.rows - 1
+
+  let col = grid.cursorCol
+  let row = grid.cursorRow
+
+  # If overwriting onto a padding cell, clear the wide char's main cell
+  if grid.cells[row][col].widePadding and col > 0:
+    grid.cells[row][col - 1] = defaultCell()
+
+  # If overwriting a wide char's main cell, clear its padding cell
+  if not grid.cells[row][col].widePadding and col + 1 < grid.cols and
+      grid.cells[row][col + 1].widePadding:
+    grid.cells[row][col + 1] = defaultCell()
+
+  grid.cells[row][col] = TerminalCell(
     ch: ch, fg: grid.currentFg, bg: grid.currentBg, attrs: grid.currentAttrs
   )
-  grid.cursorCol += 1
+
+  if width == 2 and col + 1 < grid.cols:
+    # If the padding cell is a wide char's main cell, clear its padding too
+    if col + 2 < grid.cols and grid.cells[row][col + 2].widePadding:
+      grid.cells[row][col + 2] = defaultCell()
+    grid.cells[row][col + 1] = TerminalCell(
+      ch: "",
+      fg: grid.currentFg,
+      bg: grid.currentBg,
+      attrs: grid.currentAttrs,
+      widePadding: true,
+    )
+
+  grid.cursorCol += width
+
+proc cleanWideCharBoundary(grid: TerminalGrid, row, col: int) =
+  ## Clean up wide character boundaries at an erase edge.
+  ## If the cell at (row, col) is a padding cell, clear both it and its main cell.
+  ## This handles both start and end boundaries of erase operations:
+  ##   - Start boundary: padding at cursorCol → clear the main cell before the range
+  ##   - End boundary: padding just past the range → clear the orphaned padding
+  ## Note: wide char main cells at the erase start don't need explicit cleanup
+  ## because the erase loop or end-boundary check will handle the padding.
+  if row < 0 or row >= grid.rows or col < 0 or col >= grid.cols:
+    return
+  if grid.cells[row][col].widePadding:
+    if col > 0:
+      grid.cells[row][col - 1] = defaultCell()
+    grid.cells[row][col] = defaultCell()
 
 proc parseCsiParams(s: string): seq[int] =
   ## Parse CSI parameter string "1;2;3" into sequence of ints.
@@ -369,6 +437,7 @@ proc processCsi(grid: TerminalGrid, buf: string) =
     case mode
     of 0:
       # Erase from cursor to end of screen
+      grid.cleanWideCharBoundary(grid.cursorRow, grid.cursorCol)
       for c in grid.cursorCol ..< grid.cols:
         grid.cells[grid.cursorRow][c] = defaultCell()
       for r in grid.cursorRow + 1 ..< grid.rows:
@@ -377,9 +446,11 @@ proc processCsi(grid: TerminalGrid, buf: string) =
       # Erase from beginning of screen to cursor
       for r in 0 ..< grid.cursorRow:
         grid.cells[r] = newRow(grid.cols)
-      for c in 0 .. grid.cursorCol:
-        if c < grid.cols:
-          grid.cells[grid.cursorRow][c] = defaultCell()
+      let endCol = min(grid.cursorCol, grid.cols - 1)
+      if endCol + 1 < grid.cols:
+        grid.cleanWideCharBoundary(grid.cursorRow, endCol + 1)
+      for c in 0 .. endCol:
+        grid.cells[grid.cursorRow][c] = defaultCell()
     of 2, 3:
       # Erase entire screen
       for r in 0 ..< grid.rows:
@@ -396,11 +467,15 @@ proc processCsi(grid: TerminalGrid, buf: string) =
     case mode
     of 0:
       # Erase from cursor to end of line
+      grid.cleanWideCharBoundary(grid.cursorRow, grid.cursorCol)
       for c in grid.cursorCol ..< grid.cols:
         grid.cells[grid.cursorRow][c] = defaultCell()
     of 1:
       # Erase from beginning of line to cursor
-      for c in 0 .. min(grid.cursorCol, grid.cols - 1):
+      let endCol = min(grid.cursorCol, grid.cols - 1)
+      if endCol + 1 < grid.cols:
+        grid.cleanWideCharBoundary(grid.cursorRow, endCol + 1)
+      for c in 0 .. endCol:
         grid.cells[grid.cursorRow][c] = defaultCell()
     of 2:
       # Erase entire line
@@ -470,7 +545,11 @@ proc processCsi(grid: TerminalGrid, buf: string) =
         params[0]
       else:
         1
-    for c in grid.cursorCol ..< min(grid.cursorCol + n, grid.cols):
+    grid.cleanWideCharBoundary(grid.cursorRow, grid.cursorCol)
+    let endCol = min(grid.cursorCol + n, grid.cols)
+    if endCol < grid.cols:
+      grid.cleanWideCharBoundary(grid.cursorRow, endCol)
+    for c in grid.cursorCol ..< endCol:
       grid.cells[grid.cursorRow][c] = defaultCell()
   of 'P':
     # Delete Character
@@ -480,6 +559,10 @@ proc processCsi(grid: TerminalGrid, buf: string) =
       else:
         1
     let row = grid.cursorRow
+    grid.cleanWideCharBoundary(row, grid.cursorCol)
+    let srcStart = grid.cursorCol + n
+    if srcStart < grid.cols:
+      grid.cleanWideCharBoundary(row, srcStart)
     for c in grid.cursorCol ..< grid.cols - n:
       if c + n < grid.cols:
         grid.cells[row][c] = grid.cells[row][c + n]
@@ -493,6 +576,12 @@ proc processCsi(grid: TerminalGrid, buf: string) =
       else:
         1
     let row = grid.cursorRow
+    # Clean wide char boundary at insertion point
+    grid.cleanWideCharBoundary(row, grid.cursorCol)
+    # Clean wide char boundary at the right edge that will be pushed off
+    let pushEdge = grid.cols - n
+    if pushEdge >= 0 and pushEdge < grid.cols:
+      grid.cleanWideCharBoundary(row, pushEdge)
     for c in countdown(grid.cols - 1, grid.cursorCol + n):
       grid.cells[row][c] = grid.cells[row][c - n]
     for c in grid.cursorCol ..< min(grid.cursorCol + n, grid.cols):
@@ -531,9 +620,13 @@ proc processCsi(grid: TerminalGrid, buf: string) =
 proc processOutput*(grid: TerminalGrid, data: string) =
   ## Process raw PTY output through the ANSI parser state machine.
   ## Updates the grid cells, cursor position, and colors.
+  var actualData = data
+  if grid.utf8Buffer.len > 0:
+    actualData = grid.utf8Buffer & data
+    grid.utf8Buffer = ""
   var i = 0
-  while i < data.len:
-    let ch = data[i]
+  while i < actualData.len:
+    let ch = actualData[i]
 
     case grid.parserState
     of apsNormal:
@@ -579,11 +672,14 @@ proc processOutput*(grid: TerminalGrid, data: string) =
               4
             else:
               1
-          if i + byteLen <= data.len:
-            runeStr = data[i ..< i + byteLen]
+          if i + byteLen <= actualData.len:
+            runeStr = actualData[i ..< i + byteLen]
             i += byteLen - 1 # -1 because the main loop increments
           else:
-            runeStr = "?"
+            # Incomplete UTF-8 sequence at end of buffer — save for next read
+            grid.utf8Buffer = actualData[i ..< actualData.len]
+            grid.needsRedraw = true
+            return
         grid.putChar(runeStr)
     of apsEscape:
       case ch
@@ -629,7 +725,7 @@ proc processOutput*(grid: TerminalGrid, data: string) =
         grid.parserState = apsNormal
       of '#':
         # DEC line attribute sequences (e.g., ESC # 8) - skip next byte
-        if i + 1 < data.len:
+        if i + 1 < actualData.len:
           i += 1
         grid.parserState = apsNormal
       of 'P', '_', '^', 'X':
@@ -666,7 +762,7 @@ proc processOutput*(grid: TerminalGrid, data: string) =
             grid.title = oscStr[2 .. ^1]
         if ch == '\x1b':
           # OSC terminated by ESC \ (ST), skip the backslash
-          if i + 1 < data.len and data[i + 1] == '\\':
+          if i + 1 < actualData.len and actualData[i + 1] == '\\':
             i += 1
         grid.parserState = apsNormal
       else:
@@ -675,7 +771,7 @@ proc processOutput*(grid: TerminalGrid, data: string) =
       # Consuming DCS/APC/PM/SOS string until ST (ESC \) or BEL
       if ch == '\x1b':
         # Possible start of ST (ESC \)
-        if i + 1 < data.len and data[i + 1] == '\\':
+        if i + 1 < actualData.len and actualData[i + 1] == '\\':
           i += 1 # Skip the backslash
         grid.parserState = apsNormal
       elif ch == '\x07':
@@ -703,6 +799,8 @@ proc toPlainText*(grid: TerminalGrid): string =
   for row in grid.scrollbackBuffer:
     var line = ""
     for cell in row:
+      if cell.widePadding:
+        continue
       if cell.ch.len > 0:
         line.add(cell.ch)
       else:
@@ -713,7 +811,7 @@ proc toPlainText*(grid: TerminalGrid): string =
   var lastNonEmptyRow = -1
   for r in 0 ..< grid.rows:
     for c in 0 ..< grid.cols:
-      if grid.cells[r][c].ch.len > 0:
+      if grid.cells[r][c].ch.len > 0 and not grid.cells[r][c].widePadding:
         lastNonEmptyRow = r
         break
 
@@ -722,6 +820,8 @@ proc toPlainText*(grid: TerminalGrid): string =
       var line = ""
       for c in 0 ..< grid.cols:
         let cell = grid.cells[r][c]
+        if cell.widePadding:
+          continue
         if cell.ch.len > 0:
           line.add(cell.ch)
         else:

--- a/src/moepkg/terminal/ansi_parser.nim
+++ b/src/moepkg/terminal/ansi_parser.nim
@@ -1,0 +1,733 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2026 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+## ANSI escape sequence parser and terminal grid for terminal emulation.
+## Implements a VT100/xterm state machine to process PTY output and
+## maintain a 2D grid of styled cells.
+
+import std/strutils
+
+type
+  ColorKind* = enum
+    ckDefault
+    ckIndexed # SGR 30-37, 90-97, 38;5;N (0-255)
+    ckRgb # SGR 38;2;r;g;b
+
+  TerminalColor* = object
+    case kind*: ColorKind
+    of ckDefault:
+      discard
+    of ckIndexed:
+      index*: uint8
+    of ckRgb:
+      r*, g*, b*: uint8
+
+  TerminalAttr* = enum
+    taBold
+    taDim
+    taItalic
+    taUnderline
+    taBlink
+    taReverse
+    taStrikethrough
+
+  TerminalCell* = object
+    ch*: string # UTF-8 character (empty = space)
+    fg*: TerminalColor # Foreground color
+    bg*: TerminalColor # Background color
+    attrs*: set[TerminalAttr]
+
+  AnsiParserState* = enum
+    apsNormal # Normal text processing
+    apsEscape # Got ESC (\x1b)
+    apsCsi # Got ESC [ (Control Sequence Introducer)
+    apsOsc # Got ESC ] (Operating System Command)
+    apsStringSeq # Consuming DCS/APC/PM/SOS string until ST
+
+  TerminalGrid* = ref object
+    cells*: seq[seq[TerminalCell]] # [row][col]
+    cols*: int
+    rows*: int
+    cursorRow*: int
+    cursorCol*: int
+    cursorVisible*: bool
+    # Scrollback
+    scrollbackBuffer*: seq[seq[TerminalCell]]
+    maxScrollback*: int
+    # Current SGR state
+    currentFg*: TerminalColor
+    currentBg*: TerminalColor
+    currentAttrs*: set[TerminalAttr]
+    # Parser state
+    parserState*: AnsiParserState
+    escapeBuffer*: string
+    # Flags
+    needsRedraw*: bool
+    title*: string
+
+const DefaultMaxScrollback* = 10000
+
+proc defaultColor*(): TerminalColor =
+  TerminalColor(kind: ckDefault)
+
+proc indexedColor*(idx: uint8): TerminalColor =
+  TerminalColor(kind: ckIndexed, index: idx)
+
+proc rgbColor*(r, g, b: uint8): TerminalColor =
+  TerminalColor(kind: ckRgb, r: r, g: g, b: b)
+
+proc defaultCell*(): TerminalCell =
+  TerminalCell(ch: "", fg: defaultColor(), bg: defaultColor(), attrs: {})
+
+proc newRow(cols: int): seq[TerminalCell] =
+  result = newSeq[TerminalCell](cols)
+  for i in 0 ..< cols:
+    result[i] = defaultCell()
+
+proc newTerminalGrid*(cols, rows: int): TerminalGrid =
+  result = TerminalGrid(
+    cols: cols,
+    rows: rows,
+    cursorRow: 0,
+    cursorCol: 0,
+    cursorVisible: true,
+    scrollbackBuffer: @[],
+    maxScrollback: DefaultMaxScrollback,
+    currentFg: defaultColor(),
+    currentBg: defaultColor(),
+    currentAttrs: {},
+    parserState: apsNormal,
+    escapeBuffer: "",
+    needsRedraw: false,
+    title: "",
+  )
+  result.cells = newSeq[seq[TerminalCell]](rows)
+  for i in 0 ..< rows:
+    result.cells[i] = newRow(cols)
+
+proc resize*(grid: TerminalGrid, cols, rows: int) =
+  ## Resize the grid, preserving content where possible.
+  let
+    oldRows = grid.rows
+    oldCols = grid.cols
+
+  # Create new cells grid
+  var newCells = newSeq[seq[TerminalCell]](rows)
+  for r in 0 ..< rows:
+    newCells[r] = newRow(cols)
+    if r < oldRows:
+      for c in 0 ..< min(cols, oldCols):
+        newCells[r][c] = grid.cells[r][c]
+
+  grid.cells = newCells
+  grid.cols = cols
+  grid.rows = rows
+
+  # Clamp cursor
+  grid.cursorRow = min(grid.cursorRow, rows - 1)
+  grid.cursorCol = min(grid.cursorCol, cols - 1)
+  grid.needsRedraw = true
+
+proc scrollUp(grid: TerminalGrid) =
+  ## Scroll the grid up by one line: top line goes to scrollback,
+  ## new blank line at bottom.
+  if grid.rows == 0:
+    return
+
+  # Push top line to scrollback
+  grid.scrollbackBuffer.add(grid.cells[0])
+  if grid.scrollbackBuffer.len > grid.maxScrollback:
+    grid.scrollbackBuffer.delete(0)
+
+  # Shift rows up
+  for r in 0 ..< grid.rows - 1:
+    grid.cells[r] = grid.cells[r + 1]
+
+  # New blank line at bottom
+  grid.cells[grid.rows - 1] = newRow(grid.cols)
+
+proc putChar(grid: TerminalGrid, ch: string) =
+  ## Place a character at the current cursor position, advancing the cursor.
+  if grid.cursorRow < 0 or grid.cursorRow >= grid.rows:
+    return
+
+  # Wrap if at right edge
+  if grid.cursorCol >= grid.cols:
+    grid.cursorCol = 0
+    grid.cursorRow += 1
+    if grid.cursorRow >= grid.rows:
+      grid.scrollUp()
+      grid.cursorRow = grid.rows - 1
+
+  grid.cells[grid.cursorRow][grid.cursorCol] = TerminalCell(
+    ch: ch, fg: grid.currentFg, bg: grid.currentBg, attrs: grid.currentAttrs
+  )
+  grid.cursorCol += 1
+
+proc parseCsiParams(s: string): seq[int] =
+  ## Parse CSI parameter string "1;2;3" into sequence of ints.
+  ## Empty or missing params default to 0.
+  result = @[]
+  if s.len == 0:
+    return
+  for part in s.split(';'):
+    if part.len == 0:
+      result.add(0)
+    else:
+      try:
+        result.add(parseInt(part))
+      except ValueError:
+        result.add(0)
+
+proc applySgr(grid: TerminalGrid, params: seq[int]) =
+  ## Apply SGR (Select Graphic Rendition) parameters.
+  var i = 0
+  let p =
+    if params.len == 0:
+      @[0]
+    else:
+      params
+
+  while i < p.len:
+    let code = p[i]
+    case code
+    of 0:
+      # Reset
+      grid.currentFg = defaultColor()
+      grid.currentBg = defaultColor()
+      grid.currentAttrs = {}
+    of 1:
+      grid.currentAttrs.incl(taBold)
+    of 2:
+      grid.currentAttrs.incl(taDim)
+    of 3:
+      grid.currentAttrs.incl(taItalic)
+    of 4:
+      grid.currentAttrs.incl(taUnderline)
+    of 5:
+      grid.currentAttrs.incl(taBlink)
+    of 7:
+      grid.currentAttrs.incl(taReverse)
+    of 9:
+      grid.currentAttrs.incl(taStrikethrough)
+    of 22:
+      grid.currentAttrs.excl(taBold)
+      grid.currentAttrs.excl(taDim)
+    of 23:
+      grid.currentAttrs.excl(taItalic)
+    of 24:
+      grid.currentAttrs.excl(taUnderline)
+    of 25:
+      grid.currentAttrs.excl(taBlink)
+    of 27:
+      grid.currentAttrs.excl(taReverse)
+    of 29:
+      grid.currentAttrs.excl(taStrikethrough)
+    of 30 .. 37:
+      grid.currentFg = indexedColor(uint8(code - 30))
+    of 38:
+      # Extended foreground: 38;5;N or 38;2;r;g;b
+      if i + 1 < p.len:
+        if p[i + 1] == 5 and i + 2 < p.len:
+          grid.currentFg = indexedColor(uint8(p[i + 2]))
+          i += 2
+        elif p[i + 1] == 2 and i + 4 < p.len:
+          grid.currentFg = rgbColor(uint8(p[i + 2]), uint8(p[i + 3]), uint8(p[i + 4]))
+          i += 4
+    of 39:
+      grid.currentFg = defaultColor()
+    of 40 .. 47:
+      grid.currentBg = indexedColor(uint8(code - 40))
+    of 48:
+      # Extended background: 48;5;N or 48;2;r;g;b
+      if i + 1 < p.len:
+        if p[i + 1] == 5 and i + 2 < p.len:
+          grid.currentBg = indexedColor(uint8(p[i + 2]))
+          i += 2
+        elif p[i + 1] == 2 and i + 4 < p.len:
+          grid.currentBg = rgbColor(uint8(p[i + 2]), uint8(p[i + 3]), uint8(p[i + 4]))
+          i += 4
+    of 49:
+      grid.currentBg = defaultColor()
+    of 90 .. 97:
+      grid.currentFg = indexedColor(uint8(code - 90 + 8))
+    of 100 .. 107:
+      grid.currentBg = indexedColor(uint8(code - 100 + 8))
+    else:
+      discard
+    i += 1
+
+proc processCsi(grid: TerminalGrid, buf: string) =
+  ## Process a CSI sequence: ESC [ <params> <final byte>
+  ## buf contains everything after "ESC [" including the final byte.
+  if buf.len == 0:
+    return
+
+  let finalByte = buf[^1]
+  let paramStr = buf[0 ..< buf.len - 1]
+
+  # Handle private mode sequences (ESC [ ? ...)
+  if paramStr.len > 0 and paramStr[0] == '?':
+    let privParams = parseCsiParams(paramStr[1 .. ^1])
+    case finalByte
+    of 'h':
+      # Set mode
+      for p in privParams:
+        case p
+        of 25:
+          grid.cursorVisible = true
+        else:
+          discard
+    of 'l':
+      # Reset mode
+      for p in privParams:
+        case p
+        of 25:
+          grid.cursorVisible = false
+        else:
+          discard
+    else:
+      discard
+    return
+
+  let params = parseCsiParams(paramStr)
+
+  case finalByte
+  of 'm':
+    # SGR - Select Graphic Rendition
+    grid.applySgr(params)
+  of 'A':
+    # Cursor Up
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    grid.cursorRow = max(0, grid.cursorRow - n)
+  of 'B':
+    # Cursor Down
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    grid.cursorRow = min(grid.rows - 1, grid.cursorRow + n)
+  of 'C':
+    # Cursor Forward
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    grid.cursorCol = min(grid.cols - 1, grid.cursorCol + n)
+  of 'D':
+    # Cursor Back
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    grid.cursorCol = max(0, grid.cursorCol - n)
+  of 'H', 'f':
+    # Cursor Position
+    let
+      row =
+        if params.len > 0 and params[0] > 0:
+          params[0] - 1
+        else:
+          0
+      col =
+        if params.len > 1 and params[1] > 0:
+          params[1] - 1
+        else:
+          0
+    grid.cursorRow = clamp(row, 0, grid.rows - 1)
+    grid.cursorCol = clamp(col, 0, grid.cols - 1)
+  of 'J':
+    # Erase in Display
+    let mode =
+      if params.len > 0:
+        params[0]
+      else:
+        0
+    case mode
+    of 0:
+      # Erase from cursor to end of screen
+      for c in grid.cursorCol ..< grid.cols:
+        grid.cells[grid.cursorRow][c] = defaultCell()
+      for r in grid.cursorRow + 1 ..< grid.rows:
+        grid.cells[r] = newRow(grid.cols)
+    of 1:
+      # Erase from beginning of screen to cursor
+      for r in 0 ..< grid.cursorRow:
+        grid.cells[r] = newRow(grid.cols)
+      for c in 0 .. grid.cursorCol:
+        if c < grid.cols:
+          grid.cells[grid.cursorRow][c] = defaultCell()
+    of 2, 3:
+      # Erase entire screen
+      for r in 0 ..< grid.rows:
+        grid.cells[r] = newRow(grid.cols)
+    else:
+      discard
+  of 'K':
+    # Erase in Line
+    let mode =
+      if params.len > 0:
+        params[0]
+      else:
+        0
+    case mode
+    of 0:
+      # Erase from cursor to end of line
+      for c in grid.cursorCol ..< grid.cols:
+        grid.cells[grid.cursorRow][c] = defaultCell()
+    of 1:
+      # Erase from beginning of line to cursor
+      for c in 0 .. min(grid.cursorCol, grid.cols - 1):
+        grid.cells[grid.cursorRow][c] = defaultCell()
+    of 2:
+      # Erase entire line
+      grid.cells[grid.cursorRow] = newRow(grid.cols)
+    else:
+      discard
+  of 'S':
+    # Scroll Up
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    for _ in 0 ..< n:
+      grid.scrollUp()
+  of 'T':
+    # Scroll Down
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    for _ in 0 ..< n:
+      if grid.rows > 0:
+        # Shift rows down, insert blank at top
+        for r in countdown(grid.rows - 1, 1):
+          grid.cells[r] = grid.cells[r - 1]
+        grid.cells[0] = newRow(grid.cols)
+  of 'd':
+    # Vertical Position Absolute
+    let row =
+      if params.len > 0 and params[0] > 0:
+        params[0] - 1
+      else:
+        0
+    grid.cursorRow = clamp(row, 0, grid.rows - 1)
+  of 'G':
+    # Cursor Character Absolute
+    let col =
+      if params.len > 0 and params[0] > 0:
+        params[0] - 1
+      else:
+        0
+    grid.cursorCol = clamp(col, 0, grid.cols - 1)
+  of 'E':
+    # Cursor Next Line
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    grid.cursorRow = min(grid.rows - 1, grid.cursorRow + n)
+    grid.cursorCol = 0
+  of 'F':
+    # Cursor Previous Line
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    grid.cursorRow = max(0, grid.cursorRow - n)
+    grid.cursorCol = 0
+  of 'X':
+    # Erase Character
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    for c in grid.cursorCol ..< min(grid.cursorCol + n, grid.cols):
+      grid.cells[grid.cursorRow][c] = defaultCell()
+  of 'P':
+    # Delete Character
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    let row = grid.cursorRow
+    for c in grid.cursorCol ..< grid.cols - n:
+      if c + n < grid.cols:
+        grid.cells[row][c] = grid.cells[row][c + n]
+    for c in max(grid.cursorCol, grid.cols - n) ..< grid.cols:
+      grid.cells[row][c] = defaultCell()
+  of '@':
+    # Insert Character (shift right)
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    let row = grid.cursorRow
+    for c in countdown(grid.cols - 1, grid.cursorCol + n):
+      grid.cells[row][c] = grid.cells[row][c - n]
+    for c in grid.cursorCol ..< min(grid.cursorCol + n, grid.cols):
+      grid.cells[row][c] = defaultCell()
+  of 'L':
+    # Insert Line
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    for _ in 0 ..< n:
+      if grid.cursorRow < grid.rows:
+        for r in countdown(grid.rows - 1, grid.cursorRow + 1):
+          grid.cells[r] = grid.cells[r - 1]
+        grid.cells[grid.cursorRow] = newRow(grid.cols)
+  of 'M':
+    # Delete Line
+    let n =
+      if params.len > 0 and params[0] > 0:
+        params[0]
+      else:
+        1
+    for _ in 0 ..< n:
+      if grid.cursorRow < grid.rows:
+        for r in grid.cursorRow ..< grid.rows - 1:
+          grid.cells[r] = grid.cells[r + 1]
+        grid.cells[grid.rows - 1] = newRow(grid.cols)
+  of 'r':
+    # Set Scrolling Region (DECSTSR) - simplified: just reset cursor
+    grid.cursorRow = 0
+    grid.cursorCol = 0
+  else:
+    discard
+
+proc processOutput*(grid: TerminalGrid, data: string) =
+  ## Process raw PTY output through the ANSI parser state machine.
+  ## Updates the grid cells, cursor position, and colors.
+  var i = 0
+  while i < data.len:
+    let ch = data[i]
+
+    case grid.parserState
+    of apsNormal:
+      case ch
+      of '\x1b':
+        grid.parserState = apsEscape
+        grid.escapeBuffer = ""
+      of '\r':
+        grid.cursorCol = 0
+      of '\n':
+        grid.cursorRow += 1
+        if grid.cursorRow >= grid.rows:
+          grid.scrollUp()
+          grid.cursorRow = grid.rows - 1
+      of '\t':
+        # Tab: move to next tab stop (every 8 columns)
+        let nextTab = ((grid.cursorCol div 8) + 1) * 8
+        grid.cursorCol = min(nextTab, grid.cols - 1)
+      of '\b':
+        # Backspace
+        if grid.cursorCol > 0:
+          grid.cursorCol -= 1
+      of '\x07':
+        # Bell - ignore
+        discard
+      of '\x00' .. '\x06', '\x0e' .. '\x1a', '\x1c' .. '\x1f':
+        # Other control characters - ignore
+        discard
+      else:
+        # Regular character (including multi-byte UTF-8)
+        var runeStr: string
+        if (ch.ord and 0x80) == 0:
+          # ASCII
+          runeStr = $ch
+        else:
+          # Multi-byte UTF-8: determine length and extract
+          let byteLen =
+            if (ch.ord and 0xE0) == 0xC0:
+              2
+            elif (ch.ord and 0xF0) == 0xE0:
+              3
+            elif (ch.ord and 0xF8) == 0xF0:
+              4
+            else:
+              1
+          if i + byteLen <= data.len:
+            runeStr = data[i ..< i + byteLen]
+            i += byteLen - 1 # -1 because the main loop increments
+          else:
+            runeStr = "?"
+        grid.putChar(runeStr)
+    of apsEscape:
+      case ch
+      of '[':
+        grid.parserState = apsCsi
+        grid.escapeBuffer = ""
+      of ']':
+        grid.parserState = apsOsc
+        grid.escapeBuffer = ""
+      of '(':
+        # Designate character set - skip next byte
+        i += 1
+        grid.parserState = apsNormal
+      of ')', '*', '+':
+        # Designate character set - skip next byte
+        i += 1
+        grid.parserState = apsNormal
+      of 'M':
+        # Reverse Index (scroll down)
+        if grid.cursorRow == 0:
+          # Insert line at top
+          for r in countdown(grid.rows - 1, 1):
+            grid.cells[r] = grid.cells[r - 1]
+          grid.cells[0] = newRow(grid.cols)
+        else:
+          grid.cursorRow -= 1
+        grid.parserState = apsNormal
+      of '7':
+        # Save cursor - simplified (no-op for now)
+        grid.parserState = apsNormal
+      of '8':
+        # Restore cursor - simplified (no-op for now)
+        grid.parserState = apsNormal
+      of 'c':
+        # Reset terminal
+        grid.currentFg = defaultColor()
+        grid.currentBg = defaultColor()
+        grid.currentAttrs = {}
+        grid.cursorRow = 0
+        grid.cursorCol = 0
+        for r in 0 ..< grid.rows:
+          grid.cells[r] = newRow(grid.cols)
+        grid.parserState = apsNormal
+      of '#':
+        # DEC line attribute sequences (e.g., ESC # 8) - skip next byte
+        if i + 1 < data.len:
+          i += 1
+        grid.parserState = apsNormal
+      of 'P', '_', '^', 'X':
+        # String-type sequences: DCS (P), APC (_), PM (^), SOS (X)
+        # Consume everything until ST (ESC \) or BEL
+        grid.parserState = apsStringSeq
+        grid.escapeBuffer = ""
+      of '=', '>':
+        # Application / Normal keypad mode - ignore
+        grid.parserState = apsNormal
+      else:
+        # Unknown escape sequence, return to normal
+        grid.parserState = apsNormal
+    of apsCsi:
+      if ch >= '\x40' and ch <= '\x7e':
+        # Final byte of CSI sequence
+        grid.escapeBuffer.add(ch)
+        grid.processCsi(grid.escapeBuffer)
+        grid.parserState = apsNormal
+      elif ch >= '\x20' and ch <= '\x3f':
+        # Parameter or intermediate byte
+        grid.escapeBuffer.add(ch)
+      else:
+        # Invalid CSI sequence, abort
+        grid.parserState = apsNormal
+    of apsOsc:
+      if ch == '\x07' or ch == '\x1b':
+        # End of OSC sequence (BEL or ESC)
+        # Parse title: "0;title" or "2;title"
+        let oscStr = grid.escapeBuffer
+        if oscStr.len > 2 and oscStr[1] == ';':
+          let oscType = oscStr[0]
+          if oscType in {'0', '2'}:
+            grid.title = oscStr[2 .. ^1]
+        if ch == '\x1b':
+          # OSC terminated by ESC \ (ST), skip the backslash
+          if i + 1 < data.len and data[i + 1] == '\\':
+            i += 1
+        grid.parserState = apsNormal
+      else:
+        grid.escapeBuffer.add(ch)
+    of apsStringSeq:
+      # Consuming DCS/APC/PM/SOS string until ST (ESC \) or BEL
+      if ch == '\x1b':
+        # Possible start of ST (ESC \)
+        if i + 1 < data.len and data[i + 1] == '\\':
+          i += 1 # Skip the backslash
+        grid.parserState = apsNormal
+      elif ch == '\x07':
+        # BEL also terminates string sequences
+        grid.parserState = apsNormal
+      else:
+        # Consume and discard the string content
+        discard
+
+    i += 1
+  grid.needsRedraw = true
+
+proc toPlainText*(grid: TerminalGrid): string =
+  ## Convert the current grid to plain text (no colors).
+  ## Useful for creating a TextBuffer snapshot for Terminal-Normal mode.
+  var lines: seq[string] = @[]
+
+  proc stripTrailingSpaces(line: string): string =
+    var endIdx = line.len
+    while endIdx > 0 and line[endIdx - 1] == ' ':
+      dec endIdx
+    line[0 ..< endIdx]
+
+  # Include scrollback first
+  for row in grid.scrollbackBuffer:
+    var line = ""
+    for cell in row:
+      if cell.ch.len > 0:
+        line.add(cell.ch)
+      else:
+        line.add(' ')
+    lines.add(stripTrailingSpaces(line))
+
+  # Then current grid (only up to the last row with content)
+  var lastNonEmptyRow = -1
+  for r in 0 ..< grid.rows:
+    for c in 0 ..< grid.cols:
+      if grid.cells[r][c].ch.len > 0:
+        lastNonEmptyRow = r
+        break
+
+  if lastNonEmptyRow >= 0:
+    for r in 0 .. lastNonEmptyRow:
+      var line = ""
+      for c in 0 ..< grid.cols:
+        let cell = grid.cells[r][c]
+        if cell.ch.len > 0:
+          line.add(cell.ch)
+        else:
+          line.add(' ')
+      lines.add(stripTrailingSpaces(line))
+
+  if lines.len == 0:
+    return ""
+  lines.join("\n")

--- a/src/moepkg/terminal/pty.nim
+++ b/src/moepkg/terminal/pty.nim
@@ -22,6 +22,10 @@
 
 import std/[os, posix, options]
 
+proc poll(
+  fds: ptr TPollfd, nfds: Tnfds, timeout: cint
+): cint {.importc, header: "<poll.h>".}
+
 import pkg/results
 
 type PtyHandle* = ref object
@@ -106,8 +110,13 @@ proc writeToPty*(pty: PtyHandle, data: string): Result[void, string] =
   while written < data.len:
     let n = write(pty.masterFd, unsafeAddr data[written], data.len - written)
     if n < 0:
+      if errno == EINTR:
+        continue
       if errno == EAGAIN or errno == EWOULDBLOCK:
-        # Would block, try again
+        var pfd: TPollfd
+        pfd.fd = pty.masterFd
+        pfd.events = POLLOUT
+        discard poll(addr pfd, 1, 100)
         continue
       return err("write to PTY failed: " & $strerror(errno))
     written += n.int
@@ -122,7 +131,15 @@ proc readFromPty*(pty: PtyHandle, maxBytes: int = 4096): string =
 
   var buf = newString(maxBytes)
   let n = read(pty.masterFd, addr buf[0], maxBytes)
-  if n <= 0:
+  if n < 0:
+    if errno == EINTR:
+      let n2 = read(pty.masterFd, addr buf[0], maxBytes)
+      if n2 <= 0:
+        return ""
+      buf.setLen(n2)
+      return buf
+    return ""
+  if n == 0:
     return ""
   buf.setLen(n)
   buf
@@ -186,8 +203,10 @@ proc closePty*(pty: PtyHandle) =
 
   discard close(pty.masterFd)
 
-  # Kill child if still alive
-  if pty.isAlive:
+  # Check if child is still running and kill if needed
+  var status: cint
+  let r = waitpid(pty.childPid, status, WNOHANG)
+  if r == 0:
+    # Still running — send SIGTERM and wait
     discard kill(pty.childPid, SIGTERM)
-    var status: cint
     discard waitpid(pty.childPid, status, 0)

--- a/src/moepkg/terminal/pty.nim
+++ b/src/moepkg/terminal/pty.nim
@@ -30,9 +30,15 @@ type PtyHandle* = ref object
   closed*: bool
 
 # POSIX PTY bindings
-proc forkpty(
-  amaster: var cint, name: cstring, termp: pointer, winp: pointer
-): Pid {.importc, header: "<pty.h>".}
+when defined(macosx):
+  proc forkpty(
+    amaster: var cint, name: cstring, termp: pointer, winp: pointer
+  ): Pid {.importc, header: "<util.h>".}
+
+else:
+  proc forkpty(
+    amaster: var cint, name: cstring, termp: pointer, winp: pointer
+  ): Pid {.importc, header: "<pty.h>".}
 
 type Winsize {.importc: "struct winsize", header: "<sys/ioctl.h>".} = object
   ws_row: cushort
@@ -40,7 +46,10 @@ type Winsize {.importc: "struct winsize", header: "<sys/ioctl.h>".} = object
   ws_xpixel: cushort
   ws_ypixel: cushort
 
-const TIOCSWINSZ = 0x5414.culong
+when defined(macosx):
+  const TIOCSWINSZ = 0x80087467.culong
+else:
+  const TIOCSWINSZ = 0x5414.culong
 
 proc ioctl(
   fd: cint, request: culong

--- a/src/moepkg/terminal/pty.nim
+++ b/src/moepkg/terminal/pty.nim
@@ -1,0 +1,184 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2026 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+## POSIX pseudo-terminal (PTY) wrapper for terminal emulation.
+## Provides PTY creation, non-blocking I/O, resize, and process lifecycle.
+
+import std/[os, posix, options]
+
+import pkg/results
+
+type PtyHandle* = ref object
+  masterFd*: cint
+  childPid*: Pid
+  closed*: bool
+
+# POSIX PTY bindings
+proc forkpty(
+  amaster: var cint, name: cstring, termp: pointer, winp: pointer
+): Pid {.importc, header: "<pty.h>".}
+
+type Winsize {.importc: "struct winsize", header: "<sys/ioctl.h>".} = object
+  ws_row: cushort
+  ws_col: cushort
+  ws_xpixel: cushort
+  ws_ypixel: cushort
+
+const TIOCSWINSZ = 0x5414.culong
+
+proc ioctl(
+  fd: cint, request: culong
+): cint {.importc, header: "<sys/ioctl.h>", varargs.}
+
+proc openPtyAndSpawn*(
+    command: string = "", cols: int = 80, rows: int = 24
+): Result[PtyHandle, string] =
+  ## Create a PTY pair via forkpty() and spawn a shell (or command) in the child.
+  ## Returns the master fd and child pid on success.
+
+  var masterFd: cint
+  var ws: Winsize
+  ws.ws_col = cols.cushort
+  ws.ws_row = rows.cushort
+
+  let pid = forkpty(masterFd, nil, nil, addr ws)
+  if pid < 0:
+    return err("forkpty failed: " & $strerror(errno))
+
+  if pid == 0:
+    # Child process
+    putEnv("TERM", "xterm-256color")
+
+    if command.len > 0:
+      let shell = getEnv("SHELL", "/bin/sh")
+      discard execl(shell.cstring, shell.cstring, "-c".cstring, command.cstring, nil)
+    else:
+      let shell = getEnv("SHELL", "/bin/sh")
+      discard execl(shell.cstring, shell.cstring, nil)
+
+    # execl only returns on error
+    quit(1)
+
+  # Parent process: set master fd to non-blocking
+  let flags = fcntl(masterFd, F_GETFL)
+  if flags == -1:
+    discard close(masterFd)
+    return err("fcntl F_GETFL failed")
+  if fcntl(masterFd, F_SETFL, flags or O_NONBLOCK) == -1:
+    discard close(masterFd)
+    return err("fcntl F_SETFL O_NONBLOCK failed")
+
+  ok(PtyHandle(masterFd: masterFd, childPid: pid, closed: false))
+
+proc writeToPty*(pty: PtyHandle, data: string): Result[void, string] =
+  ## Write raw bytes to the PTY master fd (forwards keystrokes to the shell).
+  if pty.closed:
+    return err("PTY is closed")
+  if data.len == 0:
+    return ok()
+
+  var written = 0
+  while written < data.len:
+    let n = write(pty.masterFd, unsafeAddr data[written], data.len - written)
+    if n < 0:
+      if errno == EAGAIN or errno == EWOULDBLOCK:
+        # Would block, try again
+        continue
+      return err("write to PTY failed: " & $strerror(errno))
+    written += n.int
+
+  ok()
+
+proc readFromPty*(pty: PtyHandle, maxBytes: int = 4096): string =
+  ## Non-blocking read from PTY master fd.
+  ## Returns empty string if no data is available.
+  if pty.closed:
+    return ""
+
+  var buf = newString(maxBytes)
+  let n = read(pty.masterFd, addr buf[0], maxBytes)
+  if n <= 0:
+    return ""
+  buf.setLen(n)
+  buf
+
+proc resizePty*(pty: PtyHandle, cols, rows: int) =
+  ## Send TIOCSWINSZ ioctl to update the terminal size.
+  ## The kernel sends SIGWINCH to the child process group.
+  if pty.closed:
+    return
+
+  var ws: Winsize
+  ws.ws_col = cols.cushort
+  ws.ws_row = rows.cushort
+  discard ioctl(pty.masterFd, TIOCSWINSZ, addr ws)
+
+proc isAlive*(pty: PtyHandle): bool =
+  ## Check if the child process is still running.
+  if pty.closed:
+    return false
+
+  var status: cint
+  let r = waitpid(pty.childPid, status, WNOHANG)
+  # waitpid returns 0 if child is still running
+  return r == 0
+
+proc waitForExit*(pty: PtyHandle): int =
+  ## Wait for the child process to exit and return the exit code.
+  var status: cint
+  discard waitpid(pty.childPid, status, 0)
+  if WIFEXITED(status):
+    WEXITSTATUS(status)
+  else:
+    -1
+
+proc checkExitStatus*(pty: PtyHandle): Option[int] =
+  ## Non-blocking check for process exit. Reaps the zombie and returns the exit
+  ## code in a single waitpid call. Returns none if the process is still running.
+  if pty.closed:
+    return some(-1)
+
+  var status: cint
+  let r = waitpid(pty.childPid, status, WNOHANG)
+  if r > 0:
+    # Process exited and was reaped
+    if WIFEXITED(status):
+      return some(WEXITSTATUS(status).int)
+    else:
+      return some(-1)
+  elif r == 0:
+    # Still running
+    return none(int)
+  else:
+    # waitpid error (e.g. already reaped) — treat as exited
+    return some(-1)
+
+proc closePty*(pty: PtyHandle) =
+  ## Close the master fd and clean up.
+  if pty.closed:
+    return
+  pty.closed = true
+
+  discard close(pty.masterFd)
+
+  # Kill child if still alive
+  if pty.isAlive:
+    discard kill(pty.childPid, SIGTERM)
+    var status: cint
+    discard waitpid(pty.childPid, status, 0)

--- a/src/moepkg/terminal_mode.nim
+++ b/src/moepkg/terminal_mode.nim
@@ -1,0 +1,123 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2026 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+## Terminal mode state management.
+## Integrates PTY handle with ANSI parser grid and manages sub-modes.
+
+import std/options
+
+import pkg/results
+
+import terminal/[pty, ansi_parser]
+import buffer
+
+type
+  TerminalSubMode* = enum
+    tsmInput # All keystrokes forwarded to PTY (default)
+    tsmNormal # Vim-like scrollback navigation
+
+  TerminalState* = ref object
+    pty*: PtyHandle
+    grid*: TerminalGrid
+    subMode*: TerminalSubMode
+    originalBuffer*: TextBuffer
+    scrollbackSnapshot*: TextBuffer # Snapshot for Terminal-Normal mode
+    command*: string
+    exitCode*: Option[int]
+    waitingForCtrlN*: bool # Waiting for Ctrl-N after Ctrl-\
+    needsBufferRefresh*: bool
+
+proc newTerminalState*(
+    command: string = "", cols: int = 80, rows: int = 24
+): Result[TerminalState, string] =
+  ## Create a new terminal state: open PTY, spawn shell, initialize grid.
+  let ptyResult = openPtyAndSpawn(command, cols, rows)
+  if ptyResult.isErr:
+    return err(ptyResult.error)
+
+  let state = TerminalState(
+    pty: ptyResult.get,
+    grid: newTerminalGrid(cols, rows),
+    subMode: tsmInput,
+    originalBuffer: nil,
+    scrollbackSnapshot: nil,
+    command: command,
+    exitCode: none(int),
+    waitingForCtrlN: false,
+    needsBufferRefresh: false,
+  )
+
+  ok(state)
+
+proc pollOutput*(state: TerminalState): bool =
+  ## Non-blocking read from PTY and process through ANSI parser.
+  ## Returns true if the grid was updated.
+  if state.pty.closed:
+    return false
+
+  let data = state.pty.readFromPty()
+  if data.len > 0:
+    state.grid.processOutput(data)
+    state.needsBufferRefresh = true
+    return true
+
+  # Check if process exited (use checkExitStatus which reaps and stores in one call)
+  if state.exitCode.isNone:
+    let code = state.pty.checkExitStatus()
+    if code.isSome:
+      # Drain remaining output
+      var remaining = state.pty.readFromPty()
+      while remaining.len > 0:
+        state.grid.processOutput(remaining)
+        remaining = state.pty.readFromPty()
+
+      state.exitCode = code
+      state.needsBufferRefresh = true
+      return true
+
+  false
+
+proc feedInput*(state: TerminalState, data: string) =
+  ## Forward raw bytes to the PTY (keystrokes).
+  if not state.pty.closed:
+    discard state.pty.writeToPty(data)
+
+proc enterNormalSubMode*(state: TerminalState): TextBuffer =
+  ## Switch to Terminal-Normal sub-mode.
+  ## Creates a snapshot of the grid as a TextBuffer for scrollback browsing.
+  state.subMode = tsmNormal
+  let plainText = state.grid.toPlainText()
+  state.scrollbackSnapshot = newTextBuffer(plainText)
+  state.scrollbackSnapshot.readOnly = true
+  state.scrollbackSnapshot
+
+proc exitNormalSubMode*(state: TerminalState) =
+  ## Return to Terminal-Input sub-mode.
+  state.subMode = tsmInput
+  state.scrollbackSnapshot = nil
+
+proc resize*(state: TerminalState, cols, rows: int) =
+  ## Resize the terminal grid and notify the PTY.
+  state.grid.resize(cols, rows)
+  state.pty.resizePty(cols, rows)
+
+proc cleanup*(state: TerminalState) =
+  ## Close PTY and release resources.
+  if not state.pty.closed:
+    state.pty.closePty()

--- a/src/moepkg/types.nim
+++ b/src/moepkg/types.nim
@@ -25,13 +25,13 @@ import
   modes, buffer, registers, filer, log_viewer, help_viewer, command_completion,
   message_log, buffer_manager, backup_manager, diff_viewer, debug_viewer, config_mode,
   references_viewer, documentsymbol_viewer, callhierarchy_viewer, hover_popup,
-  primitives, syntax_checker, recent_file_mode
+  primitives, syntax_checker, recent_file_mode, terminal_mode
 
 export
   buffer.SidebarItemKind, registers, command_completion, filer, log_viewer, help_viewer,
   buffer_manager, backup_manager, diff_viewer, debug_viewer, config_mode,
   references_viewer, documentsymbol_viewer, callhierarchy_viewer, hover_popup,
-  primitives, syntax_checker, recent_file_mode
+  primitives, syntax_checker, recent_file_mode, terminal_mode
 
 type
   SidebarItem* = object ## Single cell in the sidebar
@@ -88,6 +88,7 @@ type
     callHierarchyViewerState*: Option[CallHierarchyViewerState]
       # Call hierarchy viewer state
     recentFileModeState*: Option[RecentFileModeState] # Recent file mode state
+    terminalState*: Option[TerminalState] # Terminal mode state
 
   SearchDirection* = enum
     Forward # Search forward (/)

--- a/tests/test_ansi_parser.nim
+++ b/tests/test_ansi_parser.nim
@@ -1,0 +1,404 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2026 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, strutils]
+import ../src/moepkg/terminal/ansi_parser
+
+suite "TerminalGrid - Creation":
+  test "newTerminalGrid creates grid with correct dimensions":
+    let grid = newTerminalGrid(80, 24)
+    check grid.cols == 80
+    check grid.rows == 24
+    check grid.cells.len == 24
+    check grid.cells[0].len == 80
+    check grid.cursorRow == 0
+    check grid.cursorCol == 0
+    check grid.cursorVisible == true
+
+  test "newTerminalGrid initializes cells with spaces":
+    let grid = newTerminalGrid(10, 5)
+    for row in 0 ..< 5:
+      for col in 0 ..< 10:
+        check grid.cells[row][col].ch == ""
+        check grid.cells[row][col].fg.kind == ckDefault
+        check grid.cells[row][col].bg.kind == ckDefault
+
+suite "TerminalGrid - Plain text processing":
+  test "Process simple ASCII text":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("Hello")
+    check grid.cells[0][0].ch == "H"
+    check grid.cells[0][1].ch == "e"
+    check grid.cells[0][2].ch == "l"
+    check grid.cells[0][3].ch == "l"
+    check grid.cells[0][4].ch == "o"
+    check grid.cursorCol == 5
+    check grid.cursorRow == 0
+
+  test "Process text with newline":
+    let grid = newTerminalGrid(80, 24)
+    # LF only moves cursor down (does not return to column 0)
+    grid.processOutput("Hello\nWorld")
+    check grid.cells[0][0].ch == "H"
+    check grid.cells[1][5].ch == "W" # Column stays at 5 after LF
+    check grid.cursorRow == 1
+    check grid.cursorCol == 10
+
+  test "Process carriage return moves cursor to column 0":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("Hello\rWorld")
+    # "World" should overwrite "Hello"
+    check grid.cells[0][0].ch == "W"
+    check grid.cells[0][1].ch == "o"
+    check grid.cells[0][2].ch == "r"
+    check grid.cells[0][3].ch == "l"
+    check grid.cells[0][4].ch == "d"
+    check grid.cursorRow == 0
+
+  test "Text wrapping at end of line":
+    let grid = newTerminalGrid(5, 3)
+    grid.processOutput("ABCDEFGH")
+    check grid.cells[0][0].ch == "A"
+    check grid.cells[0][4].ch == "E"
+    check grid.cells[1][0].ch == "F"
+    check grid.cells[1][2].ch == "H"
+
+  test "Scrolling when reaching bottom":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("Line1\r\nLine2\r\nLine3\r\nLine4")
+    # After scrolling, Line1 should be gone, Line2/3/4 visible
+    check grid.cells[0][0].ch == "L"
+    check grid.cells[2][0].ch == "L"
+    check grid.cursorRow == 2
+
+suite "TerminalGrid - CSI cursor movement":
+  test "Cursor Up (CSI A)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("Line1\nLine2")
+    check grid.cursorRow == 1
+    grid.processOutput("\x1b[1A")
+    check grid.cursorRow == 0
+
+  test "Cursor Down (CSI B)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[3B")
+    check grid.cursorRow == 3
+
+  test "Cursor Forward (CSI C)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[5C")
+    check grid.cursorCol == 5
+
+  test "Cursor Backward (CSI D)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("Hello\x1b[3D")
+    check grid.cursorCol == 2
+
+  test "Cursor position set (CSI H)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[5;10H")
+    check grid.cursorRow == 4 # 1-based to 0-based
+    check grid.cursorCol == 9
+
+  test "Cursor home (CSI H with no params)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("Hello\n\x1b[H")
+    check grid.cursorRow == 0
+    check grid.cursorCol == 0
+
+suite "TerminalGrid - CSI erase operations":
+  test "Erase from cursor to end of line (CSI 0K)":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("ABCDEFGHIJ")
+    grid.processOutput("\x1b[1;4H") # Move to column 4 (0-based: col 3)
+    grid.processOutput("\x1b[0K")
+    check grid.cells[0][0].ch == "A"
+    check grid.cells[0][1].ch == "B"
+    check grid.cells[0][2].ch == "C"
+    check grid.cells[0][3].ch == "" # Erased
+    check grid.cells[0][9].ch == "" # Erased
+
+  test "Erase from start of line to cursor (CSI 1K)":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("ABCDEFGHIJ")
+    grid.processOutput("\x1b[1;4H") # Move to column 4 (0-based: col 3)
+    grid.processOutput("\x1b[1K")
+    check grid.cells[0][0].ch == "" # Erased
+    check grid.cells[0][1].ch == "" # Erased
+    check grid.cells[0][2].ch == "" # Erased
+    check grid.cells[0][3].ch == "" # Erased
+    check grid.cells[0][4].ch == "E" # Not erased
+
+  test "Erase entire line (CSI 2K)":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("ABCDEFGHIJ")
+    grid.processOutput("\x1b[1;4H")
+    grid.processOutput("\x1b[2K")
+    for col in 0 ..< 10:
+      check grid.cells[0][col].ch == ""
+
+  test "Erase screen from cursor to end (CSI 0J)":
+    let grid = newTerminalGrid(5, 3)
+    grid.processOutput("AAAAA\r\nBBBBB\r\nCCCCC")
+    grid.processOutput("\x1b[2;1H") # Row 2, Col 1 (0-based: row 1, col 0)
+    grid.processOutput("\x1b[0J")
+    # First row should be untouched
+    check grid.cells[0][0].ch == "A"
+    # Second and third rows erased
+    check grid.cells[1][0].ch == ""
+    check grid.cells[2][0].ch == ""
+
+  test "Erase entire screen (CSI 2J)":
+    let grid = newTerminalGrid(5, 3)
+    grid.processOutput("AAAAA\nBBBBB\nCCCCC")
+    grid.processOutput("\x1b[2J")
+    for row in 0 ..< 3:
+      for col in 0 ..< 5:
+        check grid.cells[row][col].ch == ""
+
+suite "TerminalGrid - SGR colors":
+  test "Basic foreground color (CSI 31m - red)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[31mR")
+    check grid.cells[0][0].ch == "R"
+    check grid.cells[0][0].fg.kind == ckIndexed
+    check grid.cells[0][0].fg.index == 1 # Red = index 1
+
+  test "Basic background color (CSI 42m - green bg)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[42mG")
+    check grid.cells[0][0].ch == "G"
+    check grid.cells[0][0].bg.kind == ckIndexed
+    check grid.cells[0][0].bg.index == 2 # Green = index 2
+
+  test "Reset attributes (CSI 0m)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[31mR\x1b[0mN")
+    check grid.cells[0][0].fg.kind == ckIndexed # Red
+    check grid.cells[0][1].fg.kind == ckDefault # Reset
+
+  test "Bold attribute (CSI 1m)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[1mB")
+    check taBold in grid.cells[0][0].attrs
+
+  test "256-color foreground (CSI 38;5;Nm)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[38;5;200mX")
+    check grid.cells[0][0].fg.kind == ckIndexed
+    check grid.cells[0][0].fg.index == 200
+
+  test "256-color background (CSI 48;5;Nm)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[48;5;100mX")
+    check grid.cells[0][0].bg.kind == ckIndexed
+    check grid.cells[0][0].bg.index == 100
+
+  test "RGB foreground (CSI 38;2;R;G;Bm)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[38;2;255;128;0mX")
+    check grid.cells[0][0].fg.kind == ckRgb
+    check grid.cells[0][0].fg.r == 255
+    check grid.cells[0][0].fg.g == 128
+    check grid.cells[0][0].fg.b == 0
+
+  test "RGB background (CSI 48;2;R;G;Bm)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[48;2;0;128;255mX")
+    check grid.cells[0][0].bg.kind == ckRgb
+    check grid.cells[0][0].bg.r == 0
+    check grid.cells[0][0].bg.g == 128
+    check grid.cells[0][0].bg.b == 255
+
+suite "TerminalGrid - Cursor visibility":
+  test "Hide cursor (CSI ?25l)":
+    let grid = newTerminalGrid(80, 24)
+    check grid.cursorVisible == true
+    grid.processOutput("\x1b[?25l")
+    check grid.cursorVisible == false
+
+  test "Show cursor (CSI ?25h)":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[?25l")
+    check grid.cursorVisible == false
+    grid.processOutput("\x1b[?25h")
+    check grid.cursorVisible == true
+
+suite "TerminalGrid - Resize":
+  test "Resize grid preserves existing content":
+    let grid = newTerminalGrid(10, 5)
+    grid.processOutput("Hello")
+    grid.resize(20, 10)
+    check grid.cols == 20
+    check grid.rows == 10
+    check grid.cells[0][0].ch == "H"
+    check grid.cells[0][4].ch == "o"
+
+  test "Resize grid shrinks content":
+    let grid = newTerminalGrid(10, 5)
+    grid.processOutput("Hello")
+    grid.resize(3, 2)
+    check grid.cols == 3
+    check grid.rows == 2
+    check grid.cells[0][0].ch == "H"
+    check grid.cells[0][2].ch == "l"
+
+suite "TerminalGrid - toPlainText":
+  test "Convert grid to plain text":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("Hello\nWorld")
+    let text = grid.toPlainText()
+    check "Hello" in text
+    check "World" in text
+
+  test "Trailing empty rows are excluded":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("OnlyOneLine")
+    let text = grid.toPlainText()
+    # Should contain only the one line, no trailing empty lines
+    check text.count('\n') == 0
+    check text == "OnlyOneLine"
+
+  test "Trailing spaces on lines are stripped":
+    let grid = newTerminalGrid(20, 3)
+    grid.processOutput("Hi")
+    let text = grid.toPlainText()
+    # "Hi" should not have trailing spaces padded to column width
+    check text == "Hi"
+
+  test "Intermediate empty rows are preserved":
+    let grid = newTerminalGrid(10, 5)
+    grid.processOutput("AAA")
+    grid.processOutput("\r\n") # Row 1: empty
+    grid.processOutput("\r\nBBB") # Row 2: BBB
+    let text = grid.toPlainText()
+    let lines = text.split('\n')
+    check lines.len == 3
+    check lines[0] == "AAA"
+    check lines[1] == ""
+    check lines[2] == "BBB"
+
+  test "Empty grid returns empty string":
+    let grid = newTerminalGrid(10, 5)
+    let text = grid.toPlainText()
+    check text == ""
+
+  test "Scrollback lines are included":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("Line1\r\nLine2\r\nLine3\r\nLine4")
+    # Line1 should have scrolled into scrollback
+    let text = grid.toPlainText()
+    check "Line1" in text
+    check "Line4" in text
+
+  test "Scrollback-only grid (visible grid empty after clear)":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("AAA\r\nBBB\r\nCCC\r\nDDD")
+    # Now clear the screen
+    grid.processOutput("\x1b[2J")
+    let text = grid.toPlainText()
+    # Scrollback should still have the scrolled-off line
+    check grid.scrollbackBuffer.len >= 1
+    # Visible grid is cleared, so only scrollback content
+    check "DDD" notin text or text.count('\n') < 3
+
+suite "TerminalGrid - Tab character":
+  test "Tab advances cursor to next tab stop":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("A\tB")
+    check grid.cells[0][0].ch == "A"
+    # Tab should advance to column 8 (default tab stop)
+    check grid.cells[0][8].ch == "B"
+
+suite "TerminalGrid - Incomplete sequences":
+  test "Incomplete escape sequence buffered across calls":
+    let grid = newTerminalGrid(80, 24)
+    # Send partial escape sequence
+    grid.processOutput("A\x1b")
+    check grid.cells[0][0].ch == "A"
+    # Complete the sequence
+    grid.processOutput("[31mR")
+    check grid.cells[0][1].ch == "R"
+    check grid.cells[0][1].fg.kind == ckIndexed
+
+suite "TerminalGrid - Scrollback buffer":
+  test "Lines scroll into scrollback buffer":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("Line1\r\nLine2\r\nLine3\r\nLine4\r\nLine5")
+    # Scrollback should contain the lines that scrolled off screen
+    check grid.scrollbackBuffer.len >= 1
+
+suite "TerminalGrid - Cursor position tracking (regression)":
+  ## Regression tests for cursor position. The grid cursor must track
+  ## the terminal cursor position independently — it is used directly for
+  ## screen cursor placement in Terminal-Input mode (not window.cursor).
+
+  test "Cursor tracks after simple output":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("Hello")
+    check grid.cursorRow == 0
+    check grid.cursorCol == 5
+
+  test "Cursor tracks across lines":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("ABC\r\nDEF\r\nGHI")
+    check grid.cursorRow == 2
+    check grid.cursorCol == 3
+
+  test "Cursor position after CSI H":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("ignored text")
+    grid.processOutput("\x1b[10;20H")
+    check grid.cursorRow == 9 # 1-based → 0-based
+    check grid.cursorCol == 19
+
+  test "Cursor position after CSI movement sequence":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("\x1b[5;5H") # Move to (4,4)
+    check grid.cursorRow == 4
+    check grid.cursorCol == 4
+    grid.processOutput("\x1b[2B") # Down 2
+    check grid.cursorRow == 6
+    grid.processOutput("\x1b[3C") # Right 3
+    check grid.cursorCol == 7
+    grid.processOutput("\x1b[1A") # Up 1
+    check grid.cursorRow == 5
+    grid.processOutput("\x1b[2D") # Left 2
+    check grid.cursorCol == 5
+
+  test "Cursor wraps at right edge on next character":
+    let grid = newTerminalGrid(5, 3)
+    grid.processOutput("ABCDE")
+    # After filling exactly 5 cols, cursor is at col 5 (deferred wrap)
+    check grid.cursorRow == 0
+    check grid.cursorCol == 5
+    # Next character triggers the wrap
+    grid.processOutput("F")
+    check grid.cursorRow == 1
+    check grid.cursorCol == 1 # After writing 'F' at (1,0), col advances to 1
+
+  test "Cursor visibility flag preserved":
+    let grid = newTerminalGrid(80, 24)
+    check grid.cursorVisible == true
+    grid.processOutput("\x1b[?25l") # Hide
+    check grid.cursorVisible == false
+    grid.processOutput("some output")
+    check grid.cursorVisible == false # Must stay hidden
+    grid.processOutput("\x1b[?25h") # Show
+    check grid.cursorVisible == true

--- a/tests/test_ansi_parser.nim
+++ b/tests/test_ansi_parser.nim
@@ -17,8 +17,8 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[unittest, strutils]
-import ../src/moepkg/terminal/ansi_parser
+import std/[unittest, strutils, deques]
+import ../src/moepkg/terminal/ansi_parser {.all.}
 
 suite "TerminalGrid - Creation":
   test "newTerminalGrid creates grid with correct dimensions":
@@ -259,6 +259,34 @@ suite "TerminalGrid - Resize":
     check grid.cells[0][0].ch == "H"
     check grid.cells[0][2].ch == "l"
 
+  test "Resize clears wide char main cell when padding is truncated":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("AB日DE")
+    # cells: [0]="A" [1]="B" [2]="日" [3]=padding [4]="D" [5]="E"
+    grid.resize(3, 3)
+    # col 3 (padding) is truncated, so col 2 (main) must be cleared
+    check grid.cells[0][0].ch == "A"
+    check grid.cells[0][1].ch == "B"
+    check grid.cells[0][2].ch == "" # cleared, not orphaned "日"
+
+  test "Resize preserves intact wide char at right edge":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("A日")
+    # cells: [0]="A" [1]="日" [2]=padding
+    grid.resize(3, 3)
+    # Both main (col 1) and padding (col 2) are in the new grid — must stay intact
+    check grid.cells[0][0].ch == "A"
+    check grid.cells[0][1].ch == "日"
+    check grid.cells[0][2].widePadding == true
+
+  test "Resize clears main cell when padding is truncated (cols=1)":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("日B")
+    # cells: [0]="日" [1]=padding [2]="B"
+    grid.resize(1, 3)
+    # col 0 is "日" main cell, its padding at col 1 is truncated
+    check grid.cells[0][0].ch == "" # cleared
+
 suite "TerminalGrid - toPlainText":
   test "Convert grid to plain text":
     let grid = newTerminalGrid(10, 3)
@@ -337,6 +365,35 @@ suite "TerminalGrid - Incomplete sequences":
     check grid.cells[0][1].ch == "R"
     check grid.cells[0][1].fg.kind == ckIndexed
 
+  test "Incomplete UTF-8 sequence buffered across calls":
+    let grid = newTerminalGrid(80, 24)
+    # "日" = E6 97 A5 (3-byte UTF-8). Send first 2 bytes then the last.
+    grid.processOutput("A" & "\xe6\x97")
+    check grid.cells[0][0].ch == "A"
+    # Incomplete bytes should not produce output
+    check grid.cells[0][1].ch == ""
+    # Complete the sequence
+    grid.processOutput("\xa5B")
+    check grid.cells[0][1].ch == "日"
+    check grid.cells[0][2].widePadding == true # wide char padding
+    check grid.cells[0][3].ch == "B"
+
+  test "Incomplete 4-byte UTF-8 sequence buffered across calls":
+    let grid = newTerminalGrid(80, 24)
+    # U+1F600 (😀) = F0 9F 98 80 (4-byte UTF-8). Split after 1 byte.
+    grid.processOutput("\xf0")
+    check grid.cells[0][0].ch == ""
+    grid.processOutput("\x9f\x98\x80")
+    check grid.cells[0][0].ch == "\xf0\x9f\x98\x80"
+
+  test "Incomplete 2-byte UTF-8 sequence buffered across calls":
+    let grid = newTerminalGrid(80, 24)
+    # "é" = C3 A9 (2-byte UTF-8). Split after 1 byte.
+    grid.processOutput("\xc3")
+    check grid.cells[0][0].ch == ""
+    grid.processOutput("\xa9")
+    check grid.cells[0][0].ch == "é"
+
 suite "TerminalGrid - Scrollback buffer":
   test "Lines scroll into scrollback buffer":
     let grid = newTerminalGrid(10, 3)
@@ -402,3 +459,161 @@ suite "TerminalGrid - Cursor position tracking (regression)":
     check grid.cursorVisible == false # Must stay hidden
     grid.processOutput("\x1b[?25h") # Show
     check grid.cursorVisible == true
+
+suite "TerminalGrid - Wide (CJK) character support":
+  test "Wide character advances cursor by 2 columns":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("日")
+    check grid.cursorCol == 2
+    check grid.cursorRow == 0
+    check grid.cells[0][0].ch == "日"
+    check grid.cells[0][0].widePadding == false
+    check grid.cells[0][1].widePadding == true
+
+  test "Multiple wide characters":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("日本語")
+    check grid.cursorCol == 6
+    check grid.cells[0][0].ch == "日"
+    check grid.cells[0][1].widePadding == true
+    check grid.cells[0][2].ch == "本"
+    check grid.cells[0][3].widePadding == true
+    check grid.cells[0][4].ch == "語"
+    check grid.cells[0][5].widePadding == true
+
+  test "Wide character wraps when it doesn't fit at end of line":
+    # Grid is 5 cols wide. After 4 narrow chars, only 1 col remains.
+    # A wide char (2 cols) should wrap to next line.
+    let grid = newTerminalGrid(5, 3)
+    grid.processOutput("ABCD日")
+    # "ABCD" fills cols 0-3, col 4 is blank (padded), "日" wraps to row 1
+    check grid.cells[0][0].ch == "A"
+    check grid.cells[0][3].ch == "D"
+    check grid.cells[0][4].ch == "" # padding space before wrap
+    check grid.cells[1][0].ch == "日"
+    check grid.cells[1][1].widePadding == true
+    check grid.cursorRow == 1
+    check grid.cursorCol == 2
+
+  test "Overwrite narrow char onto wide char clears padding":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("日")
+    # Overwrite the wide char at col 0 with 'A'
+    grid.processOutput("\x1b[1;1H") # Move to row 1, col 1 (0-based: 0,0)
+    grid.processOutput("A")
+    check grid.cells[0][0].ch == "A"
+    check grid.cells[0][0].widePadding == false
+    check grid.cells[0][1].widePadding == false # padding cleared
+    check grid.cells[0][1].ch == "" # default empty
+
+  test "Overwrite onto padding cell clears the wide char main cell":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("日")
+    # Move to col 1 (the padding cell) and write 'X'
+    grid.processOutput("\x1b[1;2H") # row 1, col 2 (0-based: 0,1)
+    grid.processOutput("X")
+    check grid.cells[0][0].ch == "" # main cell cleared
+    check grid.cells[0][0].widePadding == false
+    check grid.cells[0][1].ch == "X"
+    check grid.cells[0][1].widePadding == false
+
+  test "toPlainText does not duplicate wide characters":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("日本")
+    let text = grid.toPlainText()
+    check text == "日本"
+
+  test "toPlainText with mixed narrow and wide chars":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("A日B本C")
+    let text = grid.toPlainText()
+    check text == "A日B本C"
+
+  test "Erase in line (K) respects wide char boundary at start":
+    let grid = newTerminalGrid(80, 24)
+    grid.processOutput("日B")
+    # Move to col 1 (padding of "日") and erase to end of line
+    grid.processOutput("\x1b[1;2H") # 0-based: row 0, col 1
+    grid.processOutput("\x1b[0K")
+    # The wide char at col 0 should also be cleared since we erased from its padding
+    check grid.cells[0][0].ch == ""
+    check grid.cells[0][0].widePadding == false
+    check grid.cells[0][1].ch == ""
+
+  test "Erase in line (K) respects wide char boundary at end":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("AB日DE")
+    # Erase from start of line to col 2 (which is the main cell of "日")
+    grid.processOutput("\x1b[1;3H") # 0-based: row 0, col 2
+    grid.processOutput("\x1b[1K") # Erase from beginning to cursor
+    check grid.cells[0][0].ch == "" # erased
+    check grid.cells[0][1].ch == "" # erased
+    check grid.cells[0][2].ch == "" # erased (was "日")
+    # The padding at col 3 should also be cleared
+    check grid.cells[0][3].ch == "" # padding cleared
+    check grid.cells[0][3].widePadding == false
+
+  test "Erase K mode 1 does not damage wide char outside erase range":
+    # Regression: cleanWideCharBoundary must not split a wide char
+    # that is entirely outside the erase range.
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("A日B")
+    # cells: [0]="A", [1]="日", [2]=padding, [3]="B"
+    # Erase from beginning to cursor at col 0
+    grid.processOutput("\x1b[1;1H") # 0-based: row 0, col 0
+    grid.processOutput("\x1b[1K")
+    check grid.cells[0][0].ch == "" # erased
+    # Wide char at col 1 must remain intact
+    check grid.cells[0][1].ch == "日"
+    check grid.cells[0][2].widePadding == true
+    check grid.cells[0][3].ch == "B"
+
+  test "Insert character at wide char padding splits correctly":
+    let grid = newTerminalGrid(10, 3)
+    grid.processOutput("日BC")
+    # cells: [0]="日" [1]=padding [2]="B" [3]="C"
+    # Insert 1 blank at col 1 (the padding cell)
+    grid.processOutput("\x1b[1;2H") # 0-based: row 0, col 1
+    grid.processOutput("\x1b[1@") # Insert 1 character
+    # The wide char at col 0 should be cleaned up
+    check grid.cells[0][0].ch == "" # main cell cleared
+    check grid.cells[0][0].widePadding == false
+    check grid.cells[0][1].ch == "" # inserted blank
+    check grid.cells[0][1].widePadding == false
+
+  test "Insert character pushes wide char off right edge":
+    let grid = newTerminalGrid(6, 3)
+    grid.processOutput("AB日CD")
+    # cells: [0]="A" [1]="B" [2]="日" [3]=padding [4]="C" [5]="D"
+    # Insert 1 blank at col 0. Rightmost cell "D" is pushed off.
+    grid.processOutput("\x1b[1;1H")
+    grid.processOutput("\x1b[1@")
+    check grid.cells[0][0].ch == "" # inserted blank
+    check grid.cells[0][1].ch == "A"
+    check grid.cells[0][2].ch == "B"
+    check grid.cells[0][3].ch == "日"
+    check grid.cells[0][4].widePadding == true
+    check grid.cells[0][5].ch == "C" # "D" pushed off
+
+  test "Insert character at right edge of wide char cleans up pushed-off padding":
+    let grid = newTerminalGrid(5, 3)
+    grid.processOutput("A日BC")
+    # cells: [0]="A" [1]="日" [2]=padding [3]="B" [4]="C"
+    # Insert 1 blank at col 3. "C" at col 4 is pushed off.
+    # But also check: col 5 (cols-n=4) boundary.
+    grid.processOutput("\x1b[1;1H")
+    grid.processOutput("\x1b[2@") # Insert 2 blanks at col 0
+    # pushEdge = 5-2 = 3. cell[3] is "B" (not padding). No split.
+    # Shift: cells shift right by 2. [0]=blank [1]=blank [2]="A" [3]="日" [4]=padding
+    check grid.cells[0][0].ch == "" # inserted
+    check grid.cells[0][1].ch == "" # inserted
+    check grid.cells[0][2].ch == "A"
+    check grid.cells[0][3].ch == "日"
+    check grid.cells[0][4].widePadding == true
+
+  test "Wide chars in scrollback are handled correctly in toPlainText":
+    let grid = newTerminalGrid(10, 3)
+    # Fill lines to push "日本" into scrollback
+    grid.processOutput("日本\r\nLine2\r\nLine3\r\nLine4")
+    let text = grid.toPlainText()
+    check "日本" in text

--- a/tests/test_editor_render_views.nim
+++ b/tests/test_editor_render_views.nim
@@ -37,94 +37,140 @@ proc createTestBuffer(): Buffer =
   result.area = Rect(x: 0, y: 0, width: 80, height: 24)
 
 suite "updateViewportSize - Basic behavior":
-  test "Update viewport from buffer area":
+  test "Update screenSize from buffer area":
     let e = createTestEditor()
     var buffer = createTestBuffer()
     buffer.area = Rect(x: 0, y: 0, width: 100, height: 50)
 
-    # Initially viewport may have different size
-    e.viewport.width = 80
-    e.viewport.height = 24
+    e.screenSize.width = 80
+    e.screenSize.height = 24
 
     let resized = e.updateViewportSize(buffer)
 
     check resized == true
-    check e.viewport.width == 100
-    check e.viewport.height == 50
+    check e.screenSize.width == 100
+    check e.screenSize.height == 50
 
   test "No resize when size unchanged":
     let e = createTestEditor()
     var buffer = createTestBuffer()
     buffer.area = Rect(x: 0, y: 0, width: 80, height: 24)
 
-    e.viewport.width = 80
-    e.viewport.height = 24
+    e.screenSize.width = 80
+    e.screenSize.height = 24
 
     let resized = e.updateViewportSize(buffer)
 
     check resized == false
-    check e.viewport.width == 80
-    check e.viewport.height == 24
+    check e.screenSize.width == 80
+    check e.screenSize.height == 24
 
   test "Width change triggers resize":
     let e = createTestEditor()
     var buffer = createTestBuffer()
 
-    e.viewport.width = 80
-    e.viewport.height = 24
+    e.screenSize.width = 80
+    e.screenSize.height = 24
 
     buffer.area = Rect(x: 0, y: 0, width: 120, height: 24)
 
     let resized = e.updateViewportSize(buffer)
 
     check resized == true
-    check e.viewport.width == 120
-    check e.viewport.height == 24
+    check e.screenSize.width == 120
+    check e.screenSize.height == 24
 
   test "Height change triggers resize":
     let e = createTestEditor()
     var buffer = createTestBuffer()
 
-    e.viewport.width = 80
-    e.viewport.height = 24
+    e.screenSize.width = 80
+    e.screenSize.height = 24
 
     buffer.area = Rect(x: 0, y: 0, width: 80, height: 40)
 
     let resized = e.updateViewportSize(buffer)
 
     check resized == true
-    check e.viewport.width == 80
-    check e.viewport.height == 40
+    check e.screenSize.width == 80
+    check e.screenSize.height == 40
 
   test "Both dimensions change":
     let e = createTestEditor()
     var buffer = createTestBuffer()
 
-    e.viewport.width = 80
-    e.viewport.height = 24
+    e.screenSize.width = 80
+    e.screenSize.height = 24
 
     buffer.area = Rect(x: 0, y: 0, width: 120, height: 40)
 
     let resized = e.updateViewportSize(buffer)
 
     check resized == true
-    check e.viewport.width == 120
-    check e.viewport.height == 40
+    check e.screenSize.width == 120
+    check e.screenSize.height == 40
 
   test "Update from zero size":
     let e = createTestEditor()
     var buffer = createTestBuffer()
 
-    e.viewport.width = 0
-    e.viewport.height = 0
+    e.screenSize.width = 0
+    e.screenSize.height = 0
 
     buffer.area = Rect(x: 0, y: 0, width: 80, height: 24)
 
     let resized = e.updateViewportSize(buffer)
 
     check resized == true
-    check e.viewport.width == 80
-    check e.viewport.height == 24
+    check e.screenSize.width == 80
+    check e.screenSize.height == 24
+
+  test "Stores previous dimensions":
+    let e = createTestEditor()
+    var buffer = createTestBuffer()
+
+    e.screenSize.width = 80
+    e.screenSize.height = 24
+
+    buffer.area = Rect(x: 0, y: 0, width: 120, height: 40)
+
+    discard e.updateViewportSize(buffer)
+
+    check e.screenSize.prevWidth == 80
+    check e.screenSize.prevHeight == 24
+
+  test "Does not modify active window viewport":
+    ## Regression: updateViewportSize used to write to e.viewport which
+    ## is a ref shared with the active window, corrupting its dimensions.
+    let e = createTestEditor()
+    var buffer = createTestBuffer()
+
+    # Set up vsplit so the active window has half-width viewport
+    e.viewport.width = 80
+    e.viewport.height = 24
+    discard e.vsplit()
+    check e.windowManager.windows.len == 2
+
+    # Record active window viewport dimensions after split
+    let activeWin = e.activeWindow
+    let origWidth = activeWin.viewport.width
+    let origHeight = activeWin.viewport.height
+    check origWidth < 80 # Should be approximately half
+
+    # Simulate screen update with full screen dimensions
+    e.screenSize.width = origWidth # Set to current to avoid triggering resize
+    e.screenSize.height = origHeight
+    buffer.area = Rect(x: 0, y: 0, width: 200, height: 50)
+
+    discard e.updateViewportSize(buffer)
+
+    # screenSize should be updated
+    check e.screenSize.width == 200
+    check e.screenSize.height == 50
+
+    # Active window viewport must NOT be overwritten
+    check activeWin.viewport.width == origWidth
+    check activeWin.viewport.height == origHeight
 
 suite "renderSplitView - Basic behavior":
   test "Render single window":
@@ -1100,3 +1146,114 @@ suite "Bottom area - status line and command line share last row":
     check positions.len == 2
     # Bottom window's status line should be at y=23 (last row)
     check positions[^1] == 23
+
+suite "updateViewportSize - split mode regression":
+  ## Regression tests for the bug where updateViewportSize corrupted
+  ## the active window's viewport via the shared ref (e.viewport).
+
+  test "vsplit: repeated updateViewportSize preserves window viewports":
+    ## Simulates the render loop: updateViewportSize is called every frame
+    ## with the full screen buffer. Window viewports must remain at their
+    ## split dimensions.
+    let e = createTestEditor()
+    var buffer = newBuffer(200, 50)
+    buffer.area = Rect(x: 0, y: 0, width: 200, height: 50)
+
+    # Initial setup
+    e.viewport.width = 200
+    e.viewport.height = 50
+    e.screenSize.width = 200
+    e.screenSize.height = 50
+
+    discard e.vsplit()
+    check e.windowManager.windows.len == 2
+
+    let leftWin = e.windowManager.windows[0]
+    let rightWin = e.windowManager.windows[1]
+    let leftWidth = leftWin.viewport.width
+    let rightWidth = rightWin.viewport.width
+
+    # Both windows should be roughly half the screen
+    check leftWidth < 200
+    check rightWidth < 200
+    check leftWidth + rightWidth + 1 == 200 # +1 for separator
+
+    # Simulate multiple render frames calling updateViewportSize
+    for _ in 0 ..< 5:
+      discard e.updateViewportSize(buffer)
+
+    # Window viewports must NOT be changed
+    check leftWin.viewport.width == leftWidth
+    check rightWin.viewport.width == rightWidth
+
+  test "hsplit: repeated updateViewportSize preserves window viewports":
+    let e = createTestEditor()
+    var buffer = newBuffer(80, 50)
+    buffer.area = Rect(x: 0, y: 0, width: 80, height: 50)
+
+    e.viewport.width = 80
+    e.viewport.height = 50
+    e.screenSize.width = 80
+    e.screenSize.height = 50
+
+    discard e.hsplit()
+    check e.windowManager.windows.len == 2
+
+    let topWin = e.windowManager.windows[0]
+    let bottomWin = e.windowManager.windows[1]
+    let topHeight = topWin.viewport.height
+    let bottomHeight = bottomWin.viewport.height
+
+    check topHeight < 50
+    check bottomHeight < 50
+
+    for _ in 0 ..< 5:
+      discard e.updateViewportSize(buffer)
+
+    check topWin.viewport.height == topHeight
+    check bottomWin.viewport.height == bottomHeight
+
+  test "vsplit: full render cycle preserves window viewports":
+    ## Full integration: updateViewportSize + renderSplitView + renderBottomLines
+    let e = createTestEditor()
+    var buffer = newBuffer(200, 50)
+    buffer.area = Rect(x: 0, y: 0, width: 200, height: 50)
+
+    e.viewport.width = 200
+    e.viewport.height = 50
+    e.screenSize.width = 200
+    e.screenSize.height = 50
+
+    discard e.vsplit()
+    check e.windowManager.windows.len == 2
+
+    let leftWin = e.windowManager.windows[0]
+    let rightWin = e.windowManager.windows[1]
+    let leftWidth = leftWin.viewport.width
+    let rightWidth = rightWin.viewport.width
+
+    # Simulate 3 render frames
+    for _ in 0 ..< 3:
+      let wasResized = e.updateViewportSize(buffer)
+      clearBuffer(buffer)
+      e.renderSplitView(buffer, wasResized)
+      e.renderBottomLines(buffer)
+
+    check leftWin.viewport.width == leftWidth
+    check rightWin.viewport.width == rightWidth
+
+  test "screenSize tracks screen, not window dimensions":
+    let e = createTestEditor()
+    var buffer = newBuffer(200, 50)
+    buffer.area = Rect(x: 0, y: 0, width: 200, height: 50)
+
+    e.screenSize.width = 100
+    e.screenSize.height = 30
+
+    discard e.updateViewportSize(buffer)
+
+    # screenSize should reflect the full screen
+    check e.screenSize.width == 200
+    check e.screenSize.height == 50
+    check e.screenSize.prevWidth == 100
+    check e.screenSize.prevHeight == 30

--- a/tests/test_editor_window.nim
+++ b/tests/test_editor_window.nim
@@ -33,6 +33,76 @@ proc createTestEditor(): Editor =
   let config = newEditorConfig()
   result = newEditor(config)
 
+suite "calculateTerminalAreaDimensions":
+  test "single window, status line enabled":
+    let e = createTestEditor()
+    e.state.display.showStatusLine = true
+    e.state.display.showTabLine = false
+    let win = e.activeWindow
+    # Default viewport: width=80, height=20
+    let (cols, rows) = e.calculateTerminalAreaDimensions(win)
+    check cols == 80
+    # height(20) - StatusAndCommandReserve(1) - tabLineOffset(0)
+    check rows == 19
+
+  test "single window, status line disabled":
+    let e = createTestEditor()
+    e.state.display.showStatusLine = false
+    e.state.display.showTabLine = false
+    let win = e.activeWindow
+    let (cols, rows) = e.calculateTerminalAreaDimensions(win)
+    check cols == 80
+    # height(20) - CommandLineReserve(1) - tabLineOffset(0)
+    check rows == 19
+
+  test "single window, with tab line":
+    let e = createTestEditor()
+    e.state.display.showStatusLine = true
+    e.state.display.showTabLine = true
+    let win = e.activeWindow
+    let (cols, rows) = e.calculateTerminalAreaDimensions(win)
+    check cols == 80
+    # height(20) - StatusAndCommandReserve(1) - TabLineHeight(1)
+    check rows == 18
+
+  test "hsplit, top window (non-bottom)":
+    let e = createTestEditor()
+    e.state.display.showStatusLine = true
+    e.state.display.showTabLine = false
+    discard e.hsplit()
+    check e.windowManager.windows.len == 2
+    # Top window (index 0) is non-bottom
+    let topWin = e.windowManager.windows[0]
+    let (cols, rows) = e.calculateTerminalAreaDimensions(topWin)
+    check cols == topWin.viewport.width
+    # Non-bottom window: no reserved lines, no tab line
+    check rows == topWin.viewport.height
+
+  test "hsplit, bottom window":
+    let e = createTestEditor()
+    e.state.display.showStatusLine = true
+    e.state.display.showTabLine = false
+    discard e.hsplit()
+    check e.windowManager.windows.len == 2
+    # Bottom window (index 1) is the active one after hsplit
+    let bottomWin = e.windowManager.windows[1]
+    let (cols, rows) = e.calculateTerminalAreaDimensions(bottomWin)
+    check cols == bottomWin.viewport.width
+    # Bottom window: height - StatusAndCommandReserve(1)
+    check rows == bottomWin.viewport.height - 1
+
+  test "minimum rows is 1":
+    let e = createTestEditor()
+    e.state.display.showStatusLine = true
+    e.state.display.showTabLine = true
+    let win = e.activeWindow
+    # Set viewport height very small so rows would be <= 0
+    win.viewport = ViewPort(topLine: 0, leftColumn: 0, width: 80, height: 2, x: 0, y: 0)
+    let (cols, rows) = e.calculateTerminalAreaDimensions(win)
+    check cols == 80
+    # height(2) - StatusAndCommandReserve(1) - TabLineHeight(1) = 0, clamped to 1
+    check rows == 1
+
 suite "calculateReservedLines":
   test "status line enabled, multi status line, bottom window":
     let e = createTestEditor()

--- a/tests/test_terminal_handler.nim
+++ b/tests/test_terminal_handler.nim
@@ -21,7 +21,7 @@ import std/[unittest, options, os]
 import pkg/results
 import ../src/moepkg/[terminal_mode, key_bindings, buffer]
 import ../src/moepkg/command_handlers/terminal_handler
-import ../src/moepkg/terminal/pgy
+import ../src/moepkg/terminal/pty
 
 proc charKey(c: string, mods: set[KeyModifier] = {}): KeyCombo =
   KeyCombo(isSpecial: false, char: c, modifiers: mods)

--- a/tests/test_terminal_handler.nim
+++ b/tests/test_terminal_handler.nim
@@ -1,0 +1,337 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2026 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+import std/[unittest, options, os]
+import pkg/results
+import ../src/moepkg/[terminal_mode, key_bindings, buffer]
+import ../src/moepkg/command_handlers/terminal_handler
+import ../src/moepkg/terminal/pgy
+
+proc charKey(c: string, mods: set[KeyModifier] = {}): KeyCombo =
+  KeyCombo(isSpecial: false, char: c, modifiers: mods)
+
+proc specialKey(sk: SpecialKey, mods: set[KeyModifier] = {}): KeyCombo =
+  KeyCombo(isSpecial: true, special: sk, modifiers: mods)
+
+suite "TerminalHandler - Creation":
+  test "newTerminalHandler creates handler":
+    let handler = newTerminalHandler()
+    check handler != nil
+
+suite "keyComboToBytes - Regular characters":
+  test "Simple character 'a'":
+    check keyComboToBytes(charKey("a")) == "a"
+
+  test "Character 'Z'":
+    check keyComboToBytes(charKey("Z")) == "Z"
+
+  test "Space character":
+    check keyComboToBytes(charKey(" ")) == " "
+
+suite "keyComboToBytes - Special keys":
+  test "Enter key":
+    check keyComboToBytes(specialKey(skEnter)) == "\r"
+
+  test "Escape key":
+    check keyComboToBytes(specialKey(skEscape)) == "\x1b"
+
+  test "Backspace key":
+    check keyComboToBytes(specialKey(skBackspace)) == "\x7f"
+
+  test "Tab key":
+    check keyComboToBytes(specialKey(skTab)) == "\t"
+
+  test "Up arrow":
+    check keyComboToBytes(specialKey(skUp)) == "\x1b[A"
+
+  test "Down arrow":
+    check keyComboToBytes(specialKey(skDown)) == "\x1b[B"
+
+  test "Right arrow":
+    check keyComboToBytes(specialKey(skRight)) == "\x1b[C"
+
+  test "Left arrow":
+    check keyComboToBytes(specialKey(skLeft)) == "\x1b[D"
+
+  test "Home key":
+    check keyComboToBytes(specialKey(skHome)) == "\x1b[H"
+
+  test "End key":
+    check keyComboToBytes(specialKey(skEnd)) == "\x1b[F"
+
+  test "Delete key":
+    check keyComboToBytes(specialKey(skDelete)) == "\x1b[3~"
+
+  test "PageUp key":
+    check keyComboToBytes(specialKey(skPageUp)) == "\x1b[5~"
+
+  test "PageDown key":
+    check keyComboToBytes(specialKey(skPageDown)) == "\x1b[6~"
+
+suite "keyComboToBytes - Ctrl combinations":
+  test "Ctrl+a":
+    check keyComboToBytes(charKey("a", {kmCtrl})) == "\x01"
+
+  test "Ctrl+c":
+    check keyComboToBytes(charKey("c", {kmCtrl})) == "\x03"
+
+  test "Ctrl+d":
+    check keyComboToBytes(charKey("d", {kmCtrl})) == "\x04"
+
+  test "Ctrl+z":
+    check keyComboToBytes(charKey("z", {kmCtrl})) == "\x1a"
+
+  test "Ctrl+l":
+    check keyComboToBytes(charKey("l", {kmCtrl})) == "\x0c"
+
+suite "handleTerminalModeKey - Terminal-Input sub-mode":
+  test "Regular key in Input mode returns trHandled":
+    let handler = newTerminalHandler()
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      let result = handler.handleTerminalModeKey(termState.get, charKey("a"))
+      check result.kind == trHandled
+      termState.get.cleanup()
+
+  test "Ctrl-backslash sets waitingForCtrlN":
+    let handler = newTerminalHandler()
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      let result = handler.handleTerminalModeKey(termState.get, charKey("\\", {kmCtrl}))
+      check result.kind == trHandled
+      check termState.get.waitingForCtrlN == true
+      termState.get.cleanup()
+
+suite "handleTerminalModeKey - Terminal-Normal sub-mode":
+  test "'i' in Normal sub-mode returns trReturnToInput":
+    let handler = newTerminalHandler()
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      discard termState.get.enterNormalSubMode()
+      let result = handler.handleTerminalModeKey(termState.get, charKey("i"))
+      check result.kind == trReturnToInput
+      termState.get.cleanup()
+
+  test "'a' in Normal sub-mode returns trReturnToInput":
+    let handler = newTerminalHandler()
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      discard termState.get.enterNormalSubMode()
+      let result = handler.handleTerminalModeKey(termState.get, charKey("a"))
+      check result.kind == trReturnToInput
+      termState.get.cleanup()
+
+  test "':' in Normal sub-mode returns trEnterCommand":
+    let handler = newTerminalHandler()
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      discard termState.get.enterNormalSubMode()
+      let result = handler.handleTerminalModeKey(termState.get, charKey(":"))
+      check result.kind == trEnterCommand
+      termState.get.cleanup()
+
+# Bug fix regression tests
+
+suite "checkExitStatus - single waitpid call (regression)":
+  ## Regression test for the bug where isAlive() reaped the zombie via waitpid,
+  ## then getExitCode() called waitpid again on the already-reaped process and
+  ## returned none(int), causing the terminal to never detect process exit.
+  ## Fixed by replacing isAlive+getExitCode with a single checkExitStatus call.
+
+  test "checkExitStatus returns none for running process":
+    let pty = openPtyAndSpawn("sleep 10", 80, 24)
+    if pty.isOk:
+      let status = pty.get.checkExitStatus()
+      check status.isNone
+      pty.get.closePty()
+
+  test "checkExitStatus returns some after process exits":
+    let pty = openPtyAndSpawn("true", 80, 24)
+    if pty.isOk:
+      # Wait for the short-lived process to finish
+      sleep(200)
+      let status = pty.get.checkExitStatus()
+      check status.isSome
+      check status.get == 0
+      pty.get.closePty()
+
+  test "checkExitStatus returns some(-1) after already reaped":
+    let pty = openPtyAndSpawn("true", 80, 24)
+    if pty.isOk:
+      sleep(200)
+      # First call reaps the zombie
+      let status1 = pty.get.checkExitStatus()
+      check status1.isSome
+      # Second call: zombie already reaped, waitpid returns -1
+      let status2 = pty.get.checkExitStatus()
+      check status2.isSome # Must NOT be none (that was the bug)
+      check status2.get == -1
+      pty.get.closePty()
+
+  test "checkExitStatus captures non-zero exit code":
+    let pty = openPtyAndSpawn("false", 80, 24)
+    if pty.isOk:
+      sleep(200)
+      let status = pty.get.checkExitStatus()
+      check status.isSome
+      check status.get == 1
+      pty.get.closePty()
+
+suite "pollOutput sets exitCode on process exit (regression)":
+  ## Regression test: pollOutput must set TerminalState.exitCode when the
+  ## shell process exits, so pollTerminalWindows can detect it and close
+  ## the terminal window.
+
+  test "pollOutput sets exitCode after short command exits":
+    let termState = newTerminalState("true", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      check ts.exitCode.isNone
+
+      # Poll until process exit is detected (max ~2 seconds)
+      var detected = false
+      for _ in 0 ..< 100:
+        discard ts.pollOutput()
+        if ts.exitCode.isSome:
+          detected = true
+          break
+        sleep(20)
+
+      check detected
+      check ts.exitCode.isSome
+      ts.cleanup()
+
+  test "pollOutput sets exitCode = 0 for 'true' command":
+    let termState = newTerminalState("true", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      var detected = false
+      for _ in 0 ..< 100:
+        discard ts.pollOutput()
+        if ts.exitCode.isSome:
+          detected = true
+          break
+        sleep(20)
+
+      check detected
+      check ts.exitCode.get == 0
+      ts.cleanup()
+
+  test "pollOutput sets exitCode = 1 for 'false' command":
+    let termState = newTerminalState("false", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      var detected = false
+      for _ in 0 ..< 100:
+        discard ts.pollOutput()
+        if ts.exitCode.isSome:
+          detected = true
+          break
+        sleep(20)
+
+      check detected
+      check ts.exitCode.get == 1
+      ts.cleanup()
+
+suite "enterNormalSubMode after process exit (regression)":
+  ## Regression test: when a short-lived command (e.g. `ls`) exits,
+  ## pollTerminalWindows switches to Terminal-Normal sub-mode so the user
+  ## can review output. The snapshot buffer must contain the command output
+  ## and not be full of empty lines.
+
+  test "Snapshot buffer contains command output after exit":
+    let termState = newTerminalState("echo hello", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      # Poll until process exits
+      for _ in 0 ..< 100:
+        discard ts.pollOutput()
+        if ts.exitCode.isSome:
+          break
+        sleep(20)
+
+      check ts.exitCode.isSome
+      let snapshot = ts.enterNormalSubMode()
+      check ts.subMode == tsmNormal
+      check snapshot.len > 0
+      # Should not have 24 lines (grid height) of mostly empty content
+      check snapshot.len < 24
+      ts.cleanup()
+
+  test "Snapshot buffer is read-only":
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      for _ in 0 ..< 100:
+        discard ts.pollOutput()
+        if ts.exitCode.isSome:
+          break
+        sleep(20)
+
+      let snapshot = ts.enterNormalSubMode()
+      check snapshot.readOnly == true
+      ts.cleanup()
+
+suite "Process exit behavior depends on command (regression)":
+  ## `:terminal` (interactive shell, command="") should auto-close on exit.
+  ## `:terminal ls` (command specified) should switch to Terminal-Normal
+  ## so the user can review output.
+
+  test "Interactive shell (empty command) stays in tsmInput after exit":
+    # With empty command, pollTerminalWindows would auto-close.
+    # At the TerminalState level, subMode remains tsmInput (caller closes).
+    let termState = newTerminalState("true", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      # Simulate as if this were an interactive shell
+      ts.command = ""
+      for _ in 0 ..< 100:
+        discard ts.pollOutput()
+        if ts.exitCode.isSome:
+          break
+        sleep(20)
+
+      check ts.exitCode.isSome
+      # subMode should still be tsmInput (not switched by pollOutput itself)
+      check ts.subMode == tsmInput
+      ts.cleanup()
+
+  test "Command mode keeps command field non-empty":
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      check ts.command == "echo test"
+      for _ in 0 ..< 100:
+        discard ts.pollOutput()
+        if ts.exitCode.isSome:
+          break
+        sleep(20)
+
+      check ts.exitCode.isSome
+      # command field preserved after exit
+      check ts.command == "echo test"
+      ts.cleanup()
+
+  test "Default shell has empty command field":
+    # newTerminalState with empty command spawns default shell
+    let termState = newTerminalState("", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      check ts.command == ""
+      ts.cleanup()


### PR DESCRIPTION
Add built-in terminal emulator

 - Add `:terminal` command to open an interactive shell and `:terminal <command>` to run a specific command inside the editor
 - Implement Terminal mode with two sub-modes: Terminal-Input (keystrokes forwarded to PTY) and Terminal-Normal
 - VT100/xterm ANSI escape sequence parser with SGR colors, cursor control, scrollback buffer, and DCS/APC/PM/SOS string sequence handling

Close #662