### PR TITLE
feat: Add key mapping configuration to configuration file

### DIFF
--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -357,6 +357,92 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 | airDrag | float | 2.0 | Air drag coefficient (velocity resistance) |
 
 
+### KeyMapping table
+
+Persistent key remappings per editor mode. Uses the same key notation as `:nmap`/`:imap` runtime commands.
+
+Values can be either a command name (e.g., `"save"`) or a key sequence (e.g., `"Escape"`).
+
+Supported modes: `Normal`, `Insert`, `Visual`, `Replace`.
+
+```toml
+[KeyMapping.Normal]
+"C-s" = "save"
+
+[KeyMapping.Insert]
+"jj" = "Escape"
+
+[KeyMapping.Visual]
+"C-c" = "Escape"
+
+[KeyMapping.Replace]
+"C-c" = "Escape"
+```
+
+#### Available commands
+
+| Command | Description |
+|:----|:----|
+| save | Save file |
+| save-and-quit | Save and quit |
+| quit-force | Quit without saving |
+| close-window | Close current window |
+| undo | Undo |
+| redo | Redo |
+| move-left | Move cursor left |
+| move-right | Move cursor right |
+| move-up | Move cursor up |
+| move-down | Move cursor down |
+| page-up | Page up |
+| page-down | Page down |
+| half-page-up | Half page up |
+| half-page-down | Half page down |
+| line-home | Move to line start |
+| line-end | Move to line end |
+| line-first-non-blank | Move to first non-blank |
+| goto-first-line | Go to first line |
+| goto-last-line | Go to last line |
+| word-forward | Move to next word |
+| word-backward | Move to previous word |
+| word-end | Move to end of word |
+| paragraph-forward | Move to next paragraph |
+| paragraph-backward | Move to previous paragraph |
+| search-next | Next search match |
+| search-prev | Previous search match |
+| delete-line | Delete line |
+| yank-line | Yank line |
+| paste-after | Paste after cursor |
+| paste-before | Paste before cursor |
+| join-lines | Join lines |
+| indent-line | Indent line |
+| dedent-line | Dedent line |
+| fold-open | Open fold |
+| fold-close | Close fold |
+| fold-toggle | Toggle fold |
+| increment-number | Increment number |
+| decrement-number | Decrement number |
+| quickrun | Run QuickRun |
+| lsp-goto-definition | LSP go to definition |
+| lsp-find-references | LSP find references |
+| lsp-hover | LSP hover info |
+| lsp-rename | LSP rename symbol |
+| lsp-document-symbol | LSP document symbols |
+| lsp-selection-range | LSP selection range |
+| buffer-next-tab | Next buffer tab |
+| buffer-prev-tab | Previous buffer tab |
+
+#### Application order
+
+Key mappings are applied in this order (later overrides earlier):
+
+1. Built-in default bindings
+2. `keybindings.toml`
+3. `moerc.toml` `[KeyMapping]`
+4. Runtime `:nmap`/`:imap` commands
+
+Also see [Runtime Key Mapping](howtouse.md#runtime-key-mapping) for session-only mappings.
+
+
 ### Lsp table
 
 | Name | Type | Default Value | Description |

--- a/documents/features.md
+++ b/documents/features.md
@@ -86,7 +86,7 @@ moe supports Vim-like runtime key mapping commands. You can remap keys during an
 
 All mappings are non-recursive (equivalent to Vim's `noremap`). `noremap`, `nnoremap`, `inoremap`, `vnoremap` are available as aliases.
 
-Mappings are session-only and are not persisted across restarts. For persistent key bindings, use the TOML configuration file (`keybindings.toml`).
+Mappings are session-only and are not persisted across restarts. For persistent key mappings, use the `[KeyMapping]` section in `moerc.toml`. See [configfile.md](configfile.md#keymapping-table).
 
 Key notation supports regular keys (`a`, `j`), modifier keys (`C-s`, `M-x`), special keys (`Escape`, `Enter`, `Tab`, `F1`-`F12`), and multi-key sequences in both space-separated (`j j`) and Vim-style concatenated (`jj`) notation.
 

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -399,6 +399,7 @@ All keystrokes are forwarded to the running shell/command.
 
 Map, unmap, and clear runtime key mappings. All mappings are non-recursive (noremap).
 Mappings are session-only and not persisted across restarts.
+For persistent key mappings, use the `[KeyMapping]` section in `moerc.toml`. See [configfile.md](configfile.md#keymapping-table).
 
 | Command| Description |
 |:-----------------------------|:---------------------------|

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -250,6 +250,22 @@ airDrag = 2.0                          # Air drag coefficient (velocity resistan
 autoSplit = true                       # Auto-split on startup when opening multiple files
 splitType = "vertical"                 # Split type: "vertical" or "horizontal"
 
+# Key mapping settings - persistent key remappings per mode
+# Same key notation as :nmap/:imap commands
+# Values can be command names (e.g., "save") or key sequences (e.g., "Escape")
+#
+# [KeyMapping.Normal]
+# "C-s" = "save"
+#
+# [KeyMapping.Insert]
+# "jj" = "Escape"
+#
+# [KeyMapping.Visual]
+# "C-c" = "Escape"
+#
+# [KeyMapping.Replace]
+# "C-c" = "Escape"
+
 # Debug mode settings - controls what sections are shown in :debug view
 # Use :debug command to open the debug viewer (vertical split, auto-refreshes every 500ms)
 

--- a/src/moepkg/command_handlers/handler_manager.nim
+++ b/src/moepkg/command_handlers/handler_manager.nim
@@ -544,6 +544,9 @@ proc handleNormalMode*(
     return HandlerResult(kind: hrUnhandled)
   of nmrError:
     return HandlerResult(kind: hrError, errorMessage: r.errorMessage)
+  of nmrSave:
+    # Save file
+    return HandlerResult(kind: hrSave, saveFilename: none(string), forceSave: false)
   of nmrSaveAndQuit:
     # ZZ command - Save and quit
     return HandlerResult(

--- a/src/moepkg/command_handlers/normal_handler.nim
+++ b/src/moepkg/command_handlers/normal_handler.nim
@@ -37,6 +37,7 @@ type
     nmrHandled
     nmrUnhandled
     nmrError
+    nmrSave
     nmrSaveAndQuit
     nmrQuitWithoutSave
     nmrCloseWindow # Signal to handler_manager to close current window (Ctrl-W c)
@@ -74,6 +75,8 @@ type
       discard
     of nmrError:
       errorMessage*: string
+    of nmrSave:
+      discard
     of nmrSaveAndQuit:
       discard
     of nmrQuitWithoutSave:
@@ -634,6 +637,9 @@ proc handleNormalModeKey*(
         return NormalModeResult(kind: nmrHandled, modeTransition: none(EditorMode))
       else:
         return NormalModeResult(kind: nmrError, errorMessage: r.error)
+    of "file.save":
+      # Save file
+      return NormalModeResult(kind: nmrSave)
     of "file.save.and.quit":
       # ZZ command - Save and quit
       return NormalModeResult(kind: nmrSaveAndQuit)

--- a/src/moepkg/command_registry.nim
+++ b/src/moepkg/command_registry.nim
@@ -2861,6 +2861,18 @@ proc registerBuiltinCommands*(registry: CommandRegistry) =
     shouldRecordJump = true,
   )
 
+  # Word motion commands
+  registry.registerMotionCommand(
+    bcMotionWord, "Move Word", "Move to start of next word", Motion.WordForward
+  )
+  registry.registerMotionCommand(
+    bcMotionWordBack, "Move Word Back", "Move to start of previous word",
+    Motion.WordBackward,
+  )
+  registry.registerMotionCommand(
+    bcMotionWordEnd, "Move Word End", "Move to end of next word", Motion.WordEnd
+  )
+
   # Scroll commands
   registry.register(
     builtin(bcScrollCursorTop),

--- a/src/moepkg/config.nim
+++ b/src/moepkg/config.nim
@@ -342,6 +342,13 @@ type
     # Language server configs (language name -> config)
     servers*: Table[string, LspServerConfig]
 
+  # Key mapping settings
+  KeyMappingConfig* = object
+    normal*: OrderedTable[string, string]
+    insert*: OrderedTable[string, string]
+    visual*: OrderedTable[string, string]
+    replace*: OrderedTable[string, string]
+
   # Main configuration
   EditorConfig* = ref object
     standard*: StandardConfig
@@ -364,6 +371,7 @@ type
     debug*: DebugConfig
     theme*: ThemeConfig
     lsp*: LspConfig
+    keyMapping*: KeyMappingConfig
 
 proc isToolAvailable(toolCommand: string): bool =
   ## Check if a command-line tool is available in PATH
@@ -583,5 +591,11 @@ proc newEditorConfig*(): EditorConfig =
       semanticTokens: LspFeatureConfig(enable: true),
       executeCommand: LspFeatureConfig(enable: true),
       servers: initTable[string, LspServerConfig](),
+    ),
+    keyMapping: KeyMappingConfig(
+      normal: initOrderedTable[string, string](),
+      insert: initOrderedTable[string, string](),
+      visual: initOrderedTable[string, string](),
+      replace: initOrderedTable[string, string](),
     ),
   )

--- a/src/moepkg/config_loader.nim
+++ b/src/moepkg/config_loader.nim
@@ -22,11 +22,11 @@
 ## This module handles loading configuration from TOML files and converting
 ## them into EditorConfig structures.
 
-import std/[os, options, tables, strutils, sequtils]
+import std/[os, options, tables, sets, strutils, sequtils]
 
 import pkg/[parsetoml, results]
 
-import config, color, theme, vscode_theme
+import config, color, theme, vscode_theme, key_bindings
 
 # Configuration validation types and utilities
 
@@ -956,6 +956,65 @@ proc loadLspConfig(
       else:
         vr.errors.add(InvalidItem(kind: iikUnknownKey, name: fullKey(section, key)))
 
+proc loadKeyMappingModeConfig(
+    table: TomlTableRef,
+    target: var OrderedTable[string, string],
+    vr: var ValidationResult,
+    section: string,
+    validCommands: HashSet[string],
+) =
+  for key, value in table:
+    if value.kind != TomlValueKind.String:
+      vr.addError(fullKey(section, key), $value, "string")
+      continue
+
+    # LHS (key) validation
+    let lhsKeys = parseKeyString(key)
+    if lhsKeys.len == 0:
+      vr.addError(
+        fullKey(section, key), key, "valid key (e.g. \"C-s\", \"jj\", \"g d\")"
+      )
+      continue
+
+    # RHS (target) validation: command name or key sequence
+    let rhs = value.getStr()
+    let rhsKeys = parseKeyString(rhs)
+    if rhsKeys.len == 0 and rhs notin validCommands:
+      vr.addError(fullKey(section, key), rhs, "valid command name or key sequence")
+      continue
+
+    target[key] = rhs
+
+proc loadKeyMappingConfig(
+    table: TomlTableRef, config: var KeyMappingConfig, vr: var ValidationResult
+) =
+  const section = "KeyMapping"
+  const validKeys = ["Normal", "Insert", "Visual", "Replace"]
+  checkUnknownKeys(table, validKeys, section, vr)
+
+  let validCommands = getValidMappingCommands()
+
+  if table.hasKey("Normal"):
+    loadKeyMappingModeConfig(
+      table["Normal"].getTable(), config.normal, vr, "KeyMapping.Normal", validCommands
+    )
+  if table.hasKey("Insert"):
+    loadKeyMappingModeConfig(
+      table["Insert"].getTable(), config.insert, vr, "KeyMapping.Insert", validCommands
+    )
+  if table.hasKey("Visual"):
+    loadKeyMappingModeConfig(
+      table["Visual"].getTable(), config.visual, vr, "KeyMapping.Visual", validCommands
+    )
+  if table.hasKey("Replace"):
+    loadKeyMappingModeConfig(
+      table["Replace"].getTable(),
+      config.replace,
+      vr,
+      "KeyMapping.Replace",
+      validCommands,
+    )
+
 proc loadConfigFromToml*(
     path: string
 ): Result[(EditorConfig, ValidationResult), string] =
@@ -985,7 +1044,7 @@ proc loadConfigFromToml*(
     "Standard", "Clipboard", "BuildOnSave", "TabLine", "StatusLine", "Git",
     "SyntaxChecker", "Theme", "AutoSave", "Notification", "QuickRun", "AutoBackup",
     "SmoothScroll", "Highlight", "Filer", "Autocomplete", "Persist", "StartUp", "Lsp",
-    "Debug",
+    "Debug", "KeyMapping",
   ]
   checkUnknownKeys(toml.getTable(), knownSections, "", vr)
 
@@ -1055,6 +1114,9 @@ proc loadConfigFromToml*(
 
   if toml.hasKey("Debug"):
     loadDebugConfig(toml["Debug"].getTable(), config.debug, vr)
+
+  if toml.hasKey("KeyMapping"):
+    loadKeyMappingConfig(toml["KeyMapping"].getTable(), config.keyMapping, vr)
 
   return Result[(EditorConfig, ValidationResult), string].ok((config, vr))
 
@@ -1903,6 +1965,31 @@ proc saveConfigToToml*(config: EditorConfig, path: string): Result[void, string]
     lines.add "trace = " & toTomlString($server.trace)
     lines.add "rustAnalyzerRunSingle = " & toTomlBool(server.rustAnalyzerRunSingle)
     lines.add "rustAnalyzerDebugSingle = " & toTomlBool(server.rustAnalyzerDebugSingle)
+    lines.add ""
+
+  # KeyMapping section (only output modes that have mappings)
+  if config.keyMapping.normal.len > 0:
+    lines.add "[KeyMapping.Normal]"
+    for lhs, rhs in config.keyMapping.normal:
+      lines.add toTomlString(lhs) & " = " & toTomlString(rhs)
+    lines.add ""
+
+  if config.keyMapping.insert.len > 0:
+    lines.add "[KeyMapping.Insert]"
+    for lhs, rhs in config.keyMapping.insert:
+      lines.add toTomlString(lhs) & " = " & toTomlString(rhs)
+    lines.add ""
+
+  if config.keyMapping.visual.len > 0:
+    lines.add "[KeyMapping.Visual]"
+    for lhs, rhs in config.keyMapping.visual:
+      lines.add toTomlString(lhs) & " = " & toTomlString(rhs)
+    lines.add ""
+
+  if config.keyMapping.replace.len > 0:
+    lines.add "[KeyMapping.Replace]"
+    for lhs, rhs in config.keyMapping.replace:
+      lines.add toTomlString(lhs) & " = " & toTomlString(rhs)
     lines.add ""
 
   # Debug section

--- a/src/moepkg/editor.nim
+++ b/src/moepkg/editor.nim
@@ -462,6 +462,24 @@ proc newEditor*(editorConfig: EditorConfig, vr: ValidationResult): Editor =
   # Load custom key_bindings from TOML
   keyRegistry.loadDefaultKeybindings()
 
+  # Apply key mappings from config (moerc.toml [KeyMapping] section)
+  for lhs, rhs in editorConfig.keyMapping.normal:
+    let err = keyRegistry.addRuntimeMapping(EditorMode.Normal, lhs, rhs)
+    if err.len > 0:
+      logWarn("editor", "KeyMapping.Normal error: " & err)
+  for lhs, rhs in editorConfig.keyMapping.insert:
+    let err = keyRegistry.addRuntimeMapping(EditorMode.Insert, lhs, rhs)
+    if err.len > 0:
+      logWarn("editor", "KeyMapping.Insert error: " & err)
+  for lhs, rhs in editorConfig.keyMapping.visual:
+    let err = keyRegistry.addRuntimeMapping(EditorMode.Visual, lhs, rhs)
+    if err.len > 0:
+      logWarn("editor", "KeyMapping.Visual error: " & err)
+  for lhs, rhs in editorConfig.keyMapping.replace:
+    let err = keyRegistry.addRuntimeMapping(EditorMode.Replace, lhs, rhs)
+    if err.len > 0:
+      logWarn("editor", "KeyMapping.Replace error: " & err)
+
   # Load command configuration
   cmdConfig.loadDefaultConfig
 

--- a/src/moepkg/key_bindings.nim
+++ b/src/moepkg/key_bindings.nim
@@ -22,7 +22,7 @@
 ## This module provides a flexible keybinding system that allows
 ## mapping keys to commands through configuration files.
 
-import std/[tables, strutils, options, sequtils, hashes]
+import std/[tables, sets, strutils, options, sequtils, hashes]
 
 import pkg/celina
 
@@ -1603,6 +1603,17 @@ proc setupDefaultBindings*(registry: KeyBindingRegistry) =
   )
   registry.bindKey(EditorMode.Normal, "g l", "lsp-document-link")
 
+  # Save file
+  registry.registerCommand(
+    Command(
+      name: "save",
+      description: "Save file",
+      kind: ctAction,
+      commandId: "file.save",
+      args: @[],
+    )
+  )
+
   # ZZ - Save and quit
   registry.registerCommand(
     Command(
@@ -2800,3 +2811,10 @@ proc eventToKeyCombo*(event: celina.Event): Option[KeyCombo] =
   )
 
   return some(combo)
+
+proc getValidMappingCommands*(): HashSet[string] =
+  ## Returns a set of valid command names for key mapping validation.
+  var registry = newKeyBindingRegistry()
+  registry.setupDefaultBindings()
+  for name in registry.commandRegistry.keys:
+    result.incl(name)

--- a/tests/test_config_loader.nim
+++ b/tests/test_config_loader.nim
@@ -17,7 +17,7 @@
 #                                                                              #
 #[############################################################################]#
 
-import std/[unittest, os, strutils, tables, options]
+import std/[unittest, os, strutils, tables, options, sequtils]
 
 import pkg/results
 
@@ -1638,3 +1638,161 @@ suite "Config - saveConfigToToml saves theme file":
 
     let result = saveConfigToToml(config, configFile)
     check result.isOk
+
+suite "Config Validation - KeyMapping section":
+  test "Normal key mappings":
+    let toml = """
+[KeyMapping.Normal]
+"C-s" = "save"
+"jj" = "Escape"
+"""
+    let (config, vr) = loadFromTomlString(toml)
+    check not vr.hasErrors
+    check config.keyMapping.normal.len == 2
+    check config.keyMapping.normal["C-s"] == "save"
+    check config.keyMapping.normal["jj"] == "Escape"
+
+  test "All four modes":
+    let toml = """
+[KeyMapping.Normal]
+"C-s" = "save"
+
+[KeyMapping.Insert]
+"jj" = "Escape"
+
+[KeyMapping.Visual]
+"C-c" = "Escape"
+
+[KeyMapping.Replace]
+"C-c" = "Escape"
+"""
+    let (config, vr) = loadFromTomlString(toml)
+    check not vr.hasErrors
+    check config.keyMapping.normal.len == 1
+    check config.keyMapping.insert.len == 1
+    check config.keyMapping.visual.len == 1
+    check config.keyMapping.replace.len == 1
+    check config.keyMapping.normal["C-s"] == "save"
+    check config.keyMapping.insert["jj"] == "Escape"
+    check config.keyMapping.visual["C-c"] == "Escape"
+    check config.keyMapping.replace["C-c"] == "Escape"
+
+  test "Empty KeyMapping section":
+    let toml = """
+[KeyMapping]
+"""
+    let (config, vr) = loadFromTomlString(toml)
+    check not vr.hasErrors
+    check config.keyMapping.normal.len == 0
+    check config.keyMapping.insert.len == 0
+    check config.keyMapping.visual.len == 0
+    check config.keyMapping.replace.len == 0
+
+  test "No KeyMapping section uses defaults":
+    let toml = """
+[Standard]
+number = true
+"""
+    let (config, vr) = loadFromTomlString(toml)
+    check not vr.hasErrors
+    check config.keyMapping.normal.len == 0
+    check config.keyMapping.insert.len == 0
+    check config.keyMapping.visual.len == 0
+    check config.keyMapping.replace.len == 0
+
+  test "Unknown mode name reports error":
+    let toml = """
+[KeyMapping.Unknown]
+"C-s" = "save"
+"""
+    let (_, vr) = loadFromTomlString(toml)
+    check vr.hasErrors
+    let errorNames = vr.errors.mapIt(it.name)
+    check "KeyMapping.Unknown" in errorNames
+
+  test "Non-string value reports error":
+    let toml = """
+[KeyMapping.Normal]
+"C-s" = 42
+"""
+    let (_, vr) = loadFromTomlString(toml)
+    check vr.hasErrors
+    let errorNames = vr.errors.mapIt(it.name)
+    check "KeyMapping.Normal.C-s" in errorNames
+
+  test "Invalid LHS key reports error":
+    let toml = """
+[KeyMapping.Normal]
+"C-1" = "save"
+"""
+    let (_, vr) = loadFromTomlString(toml)
+    check vr.hasErrors
+    let errorNames = vr.errors.mapIt(it.name)
+    check "KeyMapping.Normal.C-1" in errorNames
+
+  test "Invalid RHS (not a command name or key sequence) reports error":
+    let toml = """
+[KeyMapping.Normal]
+"C-s" = "not-a-command"
+"""
+    let (_, vr) = loadFromTomlString(toml)
+    check vr.hasErrors
+    let errorNames = vr.errors.mapIt(it.name)
+    check "KeyMapping.Normal.C-s" in errorNames
+
+  test "Valid command name RHS passes validation":
+    let toml = """
+[KeyMapping.Normal]
+"C-s" = "save"
+"""
+    let (config, vr) = loadFromTomlString(toml)
+    check not vr.hasErrors
+    check config.keyMapping.normal["C-s"] == "save"
+
+  test "Valid key sequence RHS passes validation":
+    let toml = """
+[KeyMapping.Insert]
+"jj" = "Escape"
+"""
+    let (config, vr) = loadFromTomlString(toml)
+    check not vr.hasErrors
+    check config.keyMapping.insert["jj"] == "Escape"
+
+suite "Config - saveConfigToToml with KeyMapping":
+  test "KeyMapping round-trip":
+    inc testFileCounter
+    let testFile = "/tmp/moe_test_keymap_save_" & $testFileCounter & ".toml"
+    defer:
+      removeFile(testFile)
+
+    var config = newEditorConfig()
+    config.keyMapping.normal["C-s"] = "save"
+    config.keyMapping.insert["jj"] = "Escape"
+
+    let saveResult = saveConfigToToml(config, testFile)
+    check saveResult.isOk
+
+    let loadResult = loadConfigFromToml(testFile)
+    check loadResult.isOk
+    let (loaded, vr) = loadResult.get
+    check not vr.hasErrors
+    check loaded.keyMapping.normal.len == 1
+    check loaded.keyMapping.normal["C-s"] == "save"
+    check loaded.keyMapping.insert.len == 1
+    check loaded.keyMapping.insert["jj"] == "Escape"
+    check loaded.keyMapping.visual.len == 0
+    check loaded.keyMapping.replace.len == 0
+
+  test "Empty KeyMapping not saved":
+    inc testFileCounter
+    let testFile = "/tmp/moe_test_keymap_empty_save_" & $testFileCounter & ".toml"
+    defer:
+      removeFile(testFile)
+
+    var config = newEditorConfig()
+
+    let saveResult = saveConfigToToml(config, testFile)
+    check saveResult.isOk
+
+    let content = readFile(testFile)
+    check "KeyMapping" notin content

--- a/tests/test_configmode.nim
+++ b/tests/test_configmode.nim
@@ -1792,7 +1792,8 @@ suite "ConfigMode - descriptor completeness":
       "theme", "lsp",
     ].toHashSet
     let excluded = [
-      "buildOnSave", "tabLine", "quickRun", "persist", "startUpFileOpen", "debug"
+      "buildOnSave", "tabLine", "quickRun", "persist", "startUpFileOpen", "debug",
+      "keyMapping",
     ].toHashSet
 
     var cfg = newEditorConfig()

--- a/tests/test_runtime_keymapping.nim
+++ b/tests/test_runtime_keymapping.nim
@@ -1042,3 +1042,39 @@ suite "Integration - mapping removal and clear":
 
     check manager.keyBindingRegistry.getRuntimeKeySeqMappings(Normal).len == 0
     check manager.keyBindingRegistry.getRuntimeKeySeqMappings(Insert).len == 1
+
+suite "All mapping commands are valid":
+  test "All BuiltinCommandId values are registered in CommandRegistry":
+    # Commands dispatched by normal_handler/handler_manager at a higher level.
+    # These require editor-level context (buffer switching, LSP client, etc.)
+    # and are intentionally not registered in CommandRegistry.
+    const dispatchedByHandler = [
+      bcJumpBack, bcJumpForward, bcFileSave, bcFileOpen, bcFileNew, bcFileClose,
+      bcFiler, bcLspGotoDefinition, bcLspFindReferences, bcLspCodeLensExecute,
+      bcLspCallHierarchyIncoming, bcLspCallHierarchyOutgoing,
+    ]
+
+    let cmdRegistry = newCommandRegistry()
+    cmdRegistry.registerBuiltinCommands()
+
+    var missing: seq[string] = @[]
+    for id in BuiltinCommandId:
+      if id == bcNone or id in dispatchedByHandler:
+        continue
+      let cmd = cmdRegistry.findCommand(builtin(id))
+      if cmd.isNone or cmd.get.handler.isNil:
+        missing.add($id)
+
+    if missing.len > 0:
+      echo "Missing commands: ", missing
+    check missing.len == 0
+
+  test "All commands from setupDefaultBindings are valid mapping targets":
+    var registry = newKeyBindingRegistry()
+    registry.setupDefaultBindings()
+
+    for commandName in registry.commandRegistry.keys:
+      let err = registry.addRuntimeMapping(Normal, "C-t", commandName)
+      check err == ""
+      # Clean up by removing the mapping for the next iteration
+      discard registry.removeRuntimeMapping(Normal, "C-t")


### PR DESCRIPTION
 Support `KeyMapping.Normal`, `KeyMapping.Insert`, `KeyMapping.Visual`, and `KeyMapping.Replace` tables in configuration file for persistent key remapping.

Close #2388 