### PR TITLE
feat: Add timeoutlen for runtime key mapping disambiguation

### DIFF
--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -101,6 +101,7 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 | popupWindowInExmode | bool | true | Show Pop-up window in Ex mode |
 | colorMode | TerminalColorMode | 24bit | Terminal color mode |
 | mouse | bool | false | Enable mouse cursor movement |
+| timeoutlen | integer | 1000 | Key mapping timeout in milliseconds (0 = no timeout) |
 
 
 ### Clipboard table

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -44,6 +44,8 @@ mouse = true                           # Enable mouse support
 
 lineWrap = true                        # Wrap long lines
 
+timeoutlen = 1000                      # Key mapping timeout in ms (0 = no timeout)
+
 mouse = true
 
 [Clipboard]

--- a/moe.nimble
+++ b/moe.nimble
@@ -11,7 +11,7 @@ bin = @["moe"]
 
 requires "nim >= 2.0.10"
 requires "results >= 0.5.1"
-requires "celina >= 0.9.0"
+requires "celina#head"
 requires "parsetoml >= 0.7.1"
 requires "chronos >= 4.0.4"
 requires "stew >= 0.2.0"

--- a/nimble.lock
+++ b/nimble.lock
@@ -35,14 +35,14 @@
     },
     "celina": {
       "version": "0.9.0",
-      "vcsRevision": "472215af92547e57a6d972eb44e9a6f3a3e5137c",
+      "vcsRevision": "020064efff3ca1ec764af4f7199271d2af75ce62",
       "url": "https://github.com/fox0430/celina",
       "downloadMethod": "git",
       "dependencies": [
         "unicodedb"
       ],
       "checksums": {
-        "sha1": "21204f39c99880dad87e770bcd3259199065360a"
+        "sha1": "6c1b3df37765048741b7ebb5a783085730748f38"
       }
     },
     "results": {

--- a/src/moe.nim
+++ b/src/moe.nim
@@ -147,7 +147,22 @@ proc runEditor(
             except Exception as e:
               logError("moe", "handlePendingAsyncOperations failed: " & e.msg)
 
+          # Key mapping timeout control
+          if editor.keyBindingRegistry.runtimeMappingState.keys.len > 0:
+            let tl = editor.config.standard.timeoutlen
+            if tl > 0 and app.getApplicationTimeout() == 0:
+              app.setApplicationTimeout(tl)
+          elif app.getApplicationTimeout() > 0:
+            app.setApplicationTimeout(0)
+
           return shouldContinue
+
+    app.onTimeoutAsync proc(app: AsyncApp): Future[bool] {.async.} =
+      {.cast(gcsafe).}:
+        {.cast(raises: []).}:
+          editor.handleKeyMappingTimeout()
+          app.setApplicationTimeout(0) # One-shot: disable until next prefix match
+          return true
 
     app.onRenderAsync proc(buffer: var Buffer) =
       {.cast(gcsafe).}:

--- a/src/moepkg/command_handlers/handler_manager.nim
+++ b/src/moepkg/command_handlers/handler_manager.nim
@@ -1586,8 +1586,9 @@ proc checkRuntimeKeySeqMapping(
   if hasLongerMatch:
     # Prefix match exists: wait for more keys
     if exactMatch.isSome:
-      # Both exact and longer match possible; for now, wait for longer match
-      # (Timeout-based disambiguation would go here in the future)
+      # Both exact and longer match possible: wait for more keys.
+      # If no key arrives within timeoutlen, handleKeyMappingTimeout
+      # will flush and execute the exact match.
       discard
     return some(
       HandlerResult(

--- a/src/moepkg/config.nim
+++ b/src/moepkg/config.nim
@@ -80,6 +80,7 @@ type
     colorMode*: ColorMode
     mouse*: bool
     lineWrap*: bool
+    timeoutlen*: int ## Key mapping timeout in ms (0 = no timeout)
 
   # Clipboard settings
   ClipboardConfig* = object
@@ -430,6 +431,7 @@ proc newEditorConfig*(): EditorConfig =
       colorMode: cm24bit,
       mouse: false,
       lineWrap: true,
+      timeoutlen: 1000,
     ),
     clipboard: ClipboardConfig(enable: true, tool: detectClipboardTool()),
     buildOnSave: BuildOnSaveConfig(

--- a/src/moepkg/config_loader.nim
+++ b/src/moepkg/config_loader.nim
@@ -345,7 +345,7 @@ proc loadStandardConfig(
     "sidebar", "autoCloseParen", "autoIndent", "ignorecase", "smartcase",
     "disableChangeCursor", "defaultCursor", "normalModeCursor", "insertModeCursor",
     "liveReloadOfConf", "incrementalSearch", "popupWindowInExmode", "autoDeleteParen",
-    "liveReloadOfFile", "colorMode", "mouse", "lineWrap",
+    "liveReloadOfFile", "colorMode", "mouse", "lineWrap", "timeoutlen",
   ]
   checkUnknownKeys(table, validKeys, section, vr)
   loadBool(table, "number", config.number, vr, section)
@@ -382,6 +382,7 @@ proc loadStandardConfig(
   )
   loadBool(table, "mouse", config.mouse, vr, section)
   loadBool(table, "lineWrap", config.lineWrap, vr, section)
+  loadInt(table, "timeoutlen", config.timeoutlen, vr, section, minVal = 0)
 
 proc loadClipboardConfig(
     table: TomlTableRef, config: var ClipboardConfig, vr: var ValidationResult
@@ -1686,6 +1687,7 @@ proc saveConfigToToml*(config: EditorConfig, path: string): Result[void, string]
   lines.add "colorMode = " & toTomlString($config.standard.colorMode)
   lines.add "mouse = " & toTomlBool(config.standard.mouse)
   lines.add "lineWrap = " & toTomlBool(config.standard.lineWrap)
+  lines.add "timeoutlen = " & $config.standard.timeoutlen
   lines.add ""
 
   # Clipboard section

--- a/src/moepkg/config_mode.nim
+++ b/src/moepkg/config_mode.nim
@@ -349,6 +349,17 @@ proc makeDescriptors(): seq[ConfigItemDescriptor] =
     boolSet: proc(c: EditorConfig, v: bool) =
       c.standard.lineWrap = v,
   )
+  result.add ConfigItemDescriptor(
+    kind: cvkInt,
+    displayName: "timeoutlen",
+    section: "Standard",
+    intGet: proc(c: EditorConfig): int =
+      c.standard.timeoutlen,
+    intSet: proc(c: EditorConfig, v: int) =
+      c.standard.timeoutlen = v,
+    intMin: 0,
+    intMax: 10000,
+  )
 
   # Clipboard section
   result.add ConfigItemDescriptor(

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -3244,3 +3244,55 @@ proc handlePendingAsyncOperations*(
   ## Wrapper for handlePendingAsyncOperationsImpl with gcsafe cast
   {.cast(gcsafe).}:
     await handlePendingAsyncOperationsImpl(e)
+
+proc handleKeyMappingTimeout*(e: Editor) =
+  ## Called when the key mapping timeout fires.
+  ## If keys are accumulated in runtimeMappingState, flush them:
+  ## - If an exact match exists, execute the mapping
+  ## - Otherwise, replay each key individually
+
+  let registry = e.keyBindingRegistry
+  if registry.runtimeMappingState.keys.len == 0:
+    return
+
+  let accKeys = registry.runtimeMappingState.keys
+
+  e.syncStateFromWindow()
+
+  let activeBuffer = e.activeBuffer
+  let activeViewport = e.viewport
+
+  # Check for exact match among runtime key-seq mappings
+  let mappings = registry.getRuntimeKeySeqMappings(e.state.mode)
+  var exactMatch: Option[RuntimeKeyMapping] = none(RuntimeKeyMapping)
+  for m in mappings:
+    if m.triggerKeys == accKeys:
+      exactMatch = some(m)
+      break
+
+  registry.clearRuntimeMappingState()
+
+  if exactMatch.isSome:
+    # Exact match found: execute the mapping via playbackMacro
+    registry.isReplayingMapping = true
+    let r = e.handlerManager.playbackMacro(
+      activeBuffer, e.state, activeViewport, exactMatch.get.targetKeys
+    )
+    registry.isReplayingMapping = false
+
+    # Handle mode transition
+    if r.kind == hrHandled and r.modeTransition.isSome:
+      e.state.mode = r.modeTransition.get
+  else:
+    # No exact match: replay each accumulated key individually
+    registry.isReplayingMapping = true
+    for k in accKeys:
+      let r = e.handlerManager.handleKeyCombo(activeBuffer, e.state, activeViewport, k)
+      if r.kind == hrHandled and r.modeTransition.isSome:
+        e.state.mode = r.modeTransition.get
+      if r.kind == hrError or r.kind == hrQuit:
+        break
+    registry.isReplayingMapping = false
+
+  e.syncStateToWindow()
+  e.state.needsFullRedraw = true

--- a/tests/test_config_loader.nim
+++ b/tests/test_config_loader.nim
@@ -98,6 +98,43 @@ number = true
     check not vr.hasErrors
     check config.standard.lineWrap == true
 
+  test "timeoutlen loads from TOML":
+    let tomlStr = """
+[Standard]
+timeoutlen = 500
+"""
+    let (config, vr) = loadFromTomlString(tomlStr)
+    check not vr.hasErrors
+    check config.standard.timeoutlen == 500
+
+  test "timeoutlen defaults to 1000 when not specified":
+    let tomlStr = """
+[Standard]
+number = true
+"""
+    let (config, vr) = loadFromTomlString(tomlStr)
+    check not vr.hasErrors
+    check config.standard.timeoutlen == 1000
+
+  test "timeoutlen = 0 is valid (no timeout)":
+    let tomlStr = """
+[Standard]
+timeoutlen = 0
+"""
+    let (config, vr) = loadFromTomlString(tomlStr)
+    check not vr.hasErrors
+    check config.standard.timeoutlen == 0
+
+  test "timeoutlen negative value is detected":
+    let tomlStr = """
+[Standard]
+timeoutlen = -1
+"""
+    let (config, vr) = loadFromTomlString(tomlStr)
+    check vr.hasErrors
+    check "Standard.timeoutlen" in vr.errors[0].name
+    check config.standard.timeoutlen == 1000 # Default value
+
   test "Invalid bool type is detected":
     let tomlStr = """
 [Standard]

--- a/tests/test_runtime_keymapping.nim
+++ b/tests/test_runtime_keymapping.nim
@@ -1043,6 +1043,154 @@ suite "Integration - mapping removal and clear":
     check manager.keyBindingRegistry.getRuntimeKeySeqMappings(Normal).len == 0
     check manager.keyBindingRegistry.getRuntimeKeySeqMappings(Insert).len == 1
 
+suite "Timeout flush - exact match with longer match pending":
+  test "Exact match and longer match: keys accumulate (wait state)":
+    ## When both "j" (exact) and "jj" (longer) are mapped,
+    ## pressing 'j' should accumulate (hasLongerMatch = true)
+    let manager = createTestManager()
+    let buffer = newTextBuffer()
+    discard buffer.insertText(BufferPosition(line: 0, column: 0), "hello")
+    let state = createTestState(EditorMode.Insert)
+    let viewport = createTestViewport()
+
+    # Map both "j" → "a" and "jj" → Escape in Insert mode
+    let err1 = manager.keyBindingRegistry.addRuntimeMapping(Insert, "j", "a")
+    check err1 == ""
+    let err2 = manager.keyBindingRegistry.addRuntimeMapping(Insert, "jj", "Escape")
+    check err2 == ""
+
+    # Press 'j': should accumulate because both exact and longer match exist
+    let j = KeyCombo(isSpecial: false, char: "j", modifiers: {})
+    let r = manager.handleKeyCombo(buffer, state, viewport, j)
+    check r.kind == hrHandled
+    check manager.keyBindingRegistry.runtimeMappingState.keys.len == 1
+
+  test "Timeout flush finds exact match for accumulated keys":
+    ## Simulate what handleKeyMappingTimeout does:
+    ## accumulated keys = ["j"], mappings include "j" → "a"
+    ## → exact match should be found and executed
+    let manager = createTestManager()
+    let buffer = newTextBuffer()
+    discard buffer.insertText(BufferPosition(line: 0, column: 0), "hello")
+    let state = createTestState(EditorMode.Insert)
+    let viewport = createTestViewport()
+
+    let err1 = manager.keyBindingRegistry.addRuntimeMapping(Insert, "j", "a")
+    check err1 == ""
+    let err2 = manager.keyBindingRegistry.addRuntimeMapping(Insert, "jj", "Escape")
+    check err2 == ""
+
+    # Simulate accumulated state (as if 'j' was pressed and we're waiting)
+    let j = KeyCombo(isSpecial: false, char: "j", modifiers: {})
+    manager.keyBindingRegistry.runtimeMappingState.keys = @[j]
+
+    # Simulate timeout flush logic: find exact match
+    let accKeys = manager.keyBindingRegistry.runtimeMappingState.keys
+    let mappings = manager.keyBindingRegistry.getRuntimeKeySeqMappings(state.mode)
+    var exactMatch: Option[RuntimeKeyMapping] = none(RuntimeKeyMapping)
+    for m in mappings:
+      if m.triggerKeys == accKeys:
+        exactMatch = some(m)
+        break
+
+    check exactMatch.isSome
+    check exactMatch.get.targetKeys.len == 1
+    check exactMatch.get.targetKeys[0] == "a"
+
+    # Execute the exact match via playbackMacro
+    manager.keyBindingRegistry.clearRuntimeMappingState()
+    manager.keyBindingRegistry.isReplayingMapping = true
+    let r = manager.playbackMacro(buffer, state, viewport, exactMatch.get.targetKeys)
+    manager.keyBindingRegistry.isReplayingMapping = false
+    check r.kind == hrHandled
+    # Should still be in Insert mode (mapping target was 'a', not Escape)
+    check state.mode == EditorMode.Insert
+
+  test "Timeout flush executes exact match that causes mode transition":
+    ## accumulated keys = ["j"], mappings include "j" → Escape
+    ## → exact match executes Escape, causing Insert → Normal transition
+    let manager = createTestManager()
+    let buffer = newTextBuffer()
+    discard buffer.insertText(BufferPosition(line: 0, column: 0), "hello")
+    let state = createTestState(EditorMode.Insert)
+    let viewport = createTestViewport()
+
+    let err1 = manager.keyBindingRegistry.addRuntimeMapping(Insert, "j", "Escape")
+    check err1 == ""
+    let err2 = manager.keyBindingRegistry.addRuntimeMapping(Insert, "jj", "a")
+    check err2 == ""
+
+    # Simulate accumulated state
+    let j = KeyCombo(isSpecial: false, char: "j", modifiers: {})
+    manager.keyBindingRegistry.runtimeMappingState.keys = @[j]
+
+    # Find exact match
+    let accKeys = manager.keyBindingRegistry.runtimeMappingState.keys
+    let mappings = manager.keyBindingRegistry.getRuntimeKeySeqMappings(state.mode)
+    var exactMatch: Option[RuntimeKeyMapping] = none(RuntimeKeyMapping)
+    for m in mappings:
+      if m.triggerKeys == accKeys:
+        exactMatch = some(m)
+        break
+
+    check exactMatch.isSome
+
+    # Execute via playbackMacro (mirrors handleKeyMappingTimeout logic)
+    manager.keyBindingRegistry.clearRuntimeMappingState()
+    manager.keyBindingRegistry.isReplayingMapping = true
+    let r = manager.playbackMacro(buffer, state, viewport, exactMatch.get.targetKeys)
+    manager.keyBindingRegistry.isReplayingMapping = false
+
+    # playbackMacro applies mode transitions internally
+    check state.mode == EditorMode.Normal
+
+  test "Timeout flush replays keys when no exact match":
+    ## accumulated keys = ["j"], but only "jj" → Escape is mapped (no "j" mapping)
+    ## → no exact match, replay 'j' as literal key
+    let manager = createTestManager()
+    let buffer = newTextBuffer()
+    discard buffer.insertText(BufferPosition(line: 0, column: 0), "hello")
+    let state = createTestState(EditorMode.Insert)
+    let viewport = createTestViewport()
+
+    let err = manager.keyBindingRegistry.addRuntimeMapping(Insert, "jj", "Escape")
+    check err == ""
+
+    # Simulate accumulated state
+    let j = KeyCombo(isSpecial: false, char: "j", modifiers: {})
+    manager.keyBindingRegistry.runtimeMappingState.keys = @[j]
+
+    # Simulate timeout flush logic: find exact match
+    let accKeys = manager.keyBindingRegistry.runtimeMappingState.keys
+    let mappings = manager.keyBindingRegistry.getRuntimeKeySeqMappings(state.mode)
+    var exactMatch: Option[RuntimeKeyMapping] = none(RuntimeKeyMapping)
+    for m in mappings:
+      if m.triggerKeys == accKeys:
+        exactMatch = some(m)
+        break
+
+    check exactMatch.isNone
+
+    # No exact match: replay keys individually
+    manager.keyBindingRegistry.clearRuntimeMappingState()
+    manager.keyBindingRegistry.isReplayingMapping = true
+    for k in accKeys:
+      let r = manager.handleKeyCombo(buffer, state, viewport, k)
+      check r.kind == hrHandled
+    manager.keyBindingRegistry.isReplayingMapping = false
+
+    # Should still be in Insert mode (j was inserted as text, not expanded)
+    check state.mode == EditorMode.Insert
+    # 'j' should have been inserted into the buffer
+    let line = buffer.getLine(0)
+    check $line == "jhello"
+
+  test "Empty accumulated keys: timeout flush is no-op":
+    let manager = createTestManager()
+    # No keys accumulated
+    check manager.keyBindingRegistry.runtimeMappingState.keys.len == 0
+    # Nothing to flush - this is the guard check in handleKeyMappingTimeout
+
 suite "All mapping commands are valid":
   test "All BuiltinCommandId values are registered in CommandRegistry":
     # Commands dispatched by normal_handler/handler_manager at a higher level.


### PR DESCRIPTION
Add `timeoutlen` to `Standard` config

Close #2386 