### PR TITLE
Better text object supports

### DIFF
--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -80,13 +80,29 @@
 | <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**(**</kbd> OR <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**)**</kbd><br> | Delete inside round brackets and enter insert mode |
 | <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**[**</kbd> OR <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**]**</kbd><br> | Delete inside square brackets and enter insert mode |
 | <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**{**</kbd> OR <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**}**</kbd><br> | Delete inside curly brackets and enter insert mode |
-| <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**w**</kbd><br> | Delete word and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**w**</kbd><br> | Delete inner word and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**i**</kbd> <kbd>**W**</kbd><br> | Delete inner WORD and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**"**</kbd><br> | Delete around double quotes and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**'**</kbd><br> | Delete around single quotes and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**(**</kbd> OR <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**)**</kbd><br> | Delete around round brackets and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**[**</kbd> OR <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**]**</kbd><br> | Delete around square brackets and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**{**</kbd> OR <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**}**</kbd><br> | Delete around curly brackets and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**w**</kbd><br> | Delete a word and enter insert mode |
+| <kbd>**c**</kbd> <kbd>**a**</kbd> <kbd>**W**</kbd><br> | Delete a WORD and enter insert mode |
 | <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**"**</kbd><br> | Delete inside double quotes |
 | <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**'**</kbd><br> | Delete inside single quotes |
 | <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**(**</kbd> OR <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**)**</kbd><br> | Delete inside round brackets |
 | <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**[**</kbd> OR <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**]**</kbd><br> | Delete inside square brackets |
 | <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**{**</kbd> OR <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**}**</kbd><br> | Delete inside curly brackets |
-| <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**w**</kbd><br> | Delete word |
+| <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**w**</kbd><br> | Delete inner word |
+| <kbd>**d**</kbd> <kbd>**i**</kbd> <kbd>**W**</kbd><br> | Delete inner WORD (space-separated) |
+| <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**"**</kbd><br> | Delete around double quotes (including quotes) |
+| <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**'**</kbd><br> | Delete around single quotes (including quotes) |
+| <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**(**</kbd> OR <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**)**</kbd><br> | Delete around round brackets (including brackets) |
+| <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**[**</kbd> OR <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**]**</kbd><br> | Delete around square brackets (including brackets) |
+| <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**{**</kbd> OR <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**}**</kbd><br> | Delete around curly brackets (including brackets) |
+| <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**w**</kbd><br> | Delete a word (including surrounding whitespace) |
+| <kbd>**d**</kbd> <kbd>**a**</kbd> <kbd>**W**</kbd><br> | Delete a WORD (including surrounding whitespace) |
 | <kbd>**x**</kbd><br> | Delete current character |
 | <kbd>**S**</kbd> OR <kbd>**c**</kbd> <kbd>**c**</kbd><br> | Delete the characters in current line and start insert mode |
 | <kbd>**y**</kbd> <kbd>**y**</kbd> OR <kbd>**Y**</kbd><br> |Copy a line |
@@ -112,6 +128,15 @@
 | <kbd>**y**</kbd><kbd>**{**</kbd><br> | Yank to the previous blank line |
 | <kbd>**y**</kbd><kbd>**}**</kbd><br> | Yank to the next blank line |
 | <kbd>**y**</kbd><kbd>**l**</kbd><br> | Yank a character |
+| <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**w**</kbd><br> | Yank inner word |
+| <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**W**</kbd><br> | Yank inner WORD |
+| <kbd>**y**</kbd><kbd>**a**</kbd><kbd>**w**</kbd><br> | Yank a word (including surrounding whitespace) |
+| <kbd>**y**</kbd><kbd>**a**</kbd><kbd>**W**</kbd><br> | Yank a WORD (including surrounding whitespace) |
+| <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**"**</kbd><br> | Yank inside double quotes |
+| <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**'**</kbd><br> | Yank inside single quotes |
+| <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**(**</kbd> OR <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**)**</kbd><br> | Yank inside round brackets |
+| <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**[**</kbd> OR <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**]**</kbd><br> | Yank inside square brackets |
+| <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**{**</kbd> OR <kbd>**y**</kbd><kbd>**i**</kbd><kbd>**}**</kbd><br> | Yank inside curly brackets |
 | <kbd>**X**</kbd> OR <kbd>**d**</kbd><kbd>**h**</kbd><br> | Cut a character before cursor |
 | <kbd>**g**</kbd><kbd>**a**</kbd><br> | Show current character info |
 | <kbd>**t**</kbd><kbd>**x**</kbd><br> | Move to the left of the next ```x``` (any character) on the current line |

--- a/src/moepkg/command_handlers/visual_handler.nim
+++ b/src/moepkg/command_handlers/visual_handler.nim
@@ -142,10 +142,6 @@ proc isPositionInSelection*(selection: VisualSelection, pos: BufferPosition): bo
       # Position is on a middle line
       return true
 
-proc isVisualMode*(mode: EditorMode): bool {.inline.} =
-  ## Check if the mode is any visual mode variant
-  mode in {EditorMode.Visual, EditorMode.VisualBlock, EditorMode.VisualLine}
-
 proc executeCommand*(
     handler: VisualModeHandler,
     buffer: TextBuffer,
@@ -171,7 +167,7 @@ proc executeCommand*(
   if r.isOk:
     # Check if mode changed from a visual mode to something else
     let modeTransition =
-      if not isVisualMode(state.mode) or state.mode != originalMode:
+      if not isVisualAllMode(state.mode) or state.mode != originalMode:
         some(state.mode)
       else:
         none(EditorMode)
@@ -195,9 +191,54 @@ proc handleVisualModeKey*(
 
   # Special handling for ESC to clear selection
   if keyCombo.isSpecial and keyCombo.special == skEscape:
+    state.editState.pendingTextObject = none(PendingTextObject)
     state.clearSelection()
 
   let originalMode = state.mode
+
+  # Handle pending text object - waiting for text object kind (w, ", (, etc.)
+  # This handles viw, va", vi( etc. in Visual mode
+  if state.editState.pendingTextObject.isSome:
+    if not keyCombo.isSpecial and keyCombo.modifiers == {}:
+      let textObjectCommandId =
+        case keyCombo.char
+        of "w": "textobject.word"
+        of "W": "textobject.wideword"
+        of "\"": "textobject.quote.double"
+        of "'": "textobject.quote.single"
+        of "`": "textobject.quote.backtick"
+        of "(", ")", "b": "textobject.paren"
+        of "[", "]": "textobject.bracket"
+        of "{", "}": "textobject.brace"
+        of "<", ">": "textobject.angle"
+        else: ""
+
+      if textObjectCommandId.len > 0:
+        let ctx = CommandContext(
+          buffer: buffer,
+          state: state,
+          viewport: viewport,
+          cursor: state.cursor,
+          motionController: handler.motionController,
+          keyBindingRegistry: handler.keyBindingRegistry,
+          notificationConfig: handler.notificationConfig,
+        )
+
+        let cmdResult = handler.commandRegistry.execute(ctx, textObjectCommandId, @[])
+        state.cursor = ctx.cursor
+
+        if cmdResult.isOk:
+          return VisualModeResult(kind: vmrHandled, modeTransition: none(EditorMode))
+        else:
+          return VisualModeResult(kind: vmrError, errorMessage: cmdResult.error)
+      else:
+        # Unknown text object kind - cancel pending state
+        state.editState.pendingTextObject = none(PendingTextObject)
+        return VisualModeResult(kind: vmrHandled, modeTransition: none(EditorMode))
+    else:
+      # Special key or key with modifiers - cancel pending state
+      state.editState.pendingTextObject = none(PendingTextObject)
+      # Fall through to process the key normally
 
   # Try to find a binding for this key in the current mode first,
   # then fall back to Visual mode for shared bindings
@@ -235,7 +276,7 @@ proc handleVisualModeKey*(
   state.cursor = ctx.cursor
 
   # Update visual selection current position if still in visual mode
-  if isVisualMode(state.mode) and state.visualSelection.active:
+  if isVisualAllMode(state.mode) and state.visualSelection.active:
     state.visualSelection.current = state.cursor
 
   if cmdResult.isErr:
@@ -243,7 +284,7 @@ proc handleVisualModeKey*(
 
   # Check for mode transition (exiting any visual mode)
   let modeTransition =
-    if not isVisualMode(state.mode) or state.mode != originalMode:
+    if not isVisualAllMode(state.mode) or state.mode != originalMode:
       some(state.mode)
     else:
       none(EditorMode)

--- a/src/moepkg/command_registry.nim
+++ b/src/moepkg/command_registry.nim
@@ -496,7 +496,145 @@ proc executeOperatorOnRange(
     ctx.state.needsFullRedraw = true
 
     return ok(())
-  else:
+  of OpIndent:
+    # Indent lines in the range
+    # For character-wise ranges (e.g., i{), adjust start/end lines:
+    # If start column is at/past end of line, content starts on the next line.
+    # If end column is negative or end line has closing delimiter only, exclude it.
+    var startLine = range.start.line
+    var endLine = range.endPos.line
+    if not range.isLinewise and startLine != endLine:
+      if startLine < ctx.buffer.len:
+        let startLineContent = ctx.buffer.getLine(startLine)
+        if range.start.column >= startLineContent.charLen:
+          startLine += 1
+      if endLine < ctx.buffer.len and range.endPos.column < 0:
+        endLine -= 1
+
+    let transactionResult = ctx.buffer.beginTransaction("Indent lines")
+    if transactionResult.isErr:
+      return err("Failed to begin transaction: " & transactionResult.error)
+
+    let indentStr = getIndentString(ctx.state)
+    for lineNum in startLine .. endLine:
+      if lineNum < ctx.buffer.len:
+        let insertPos = BufferPosition(line: lineNum, column: 0)
+        discard ctx.buffer.insertText(insertPos, indentStr)
+
+    discard ctx.buffer.commitTransaction()
+
+    # Move cursor to first non-blank of start line
+    ctx.cursor.line = startLine
+    ctx.cursor.column = 0
+    if startLine < ctx.buffer.len:
+      let line = ctx.buffer.getLine(startLine)
+      for r in line.runes:
+        if $r == " " or $r == "\t":
+          ctx.cursor.column += 1
+        else:
+          break
+
+    ctx.state.needsFullRedraw = true
+    return ok(())
+  of OpOutdent:
+    # Dedent lines in the range (same line adjustment as indent)
+    var startLine = range.start.line
+    var endLine = range.endPos.line
+    if not range.isLinewise and startLine != endLine:
+      if startLine < ctx.buffer.len:
+        let startLineContent = ctx.buffer.getLine(startLine)
+        if range.start.column >= startLineContent.charLen:
+          startLine += 1
+      if endLine < ctx.buffer.len and range.endPos.column < 0:
+        endLine -= 1
+
+    let transactionResult = ctx.buffer.beginTransaction("Dedent lines")
+    if transactionResult.isErr:
+      return err("Failed to begin transaction: " & transactionResult.error)
+
+    let indentWidth = effectiveShiftWidth(ctx.state)
+    for lineNum in startLine .. endLine:
+      if lineNum < ctx.buffer.len:
+        let lineContent = ctx.buffer.getLine(lineNum)
+        let currentIndent = getLineIndent(lineContent)
+        let removeCount = min(indentWidth, currentIndent.len)
+        if removeCount > 0:
+          for i in 1 .. removeCount:
+            let deletePos = BufferPosition(line: lineNum, column: 0)
+            discard ctx.buffer.deleteChar(deletePos)
+
+    discard ctx.buffer.commitTransaction()
+
+    # Move cursor to first non-blank of start line
+    ctx.cursor.line = startLine
+    ctx.cursor.column = 0
+    if startLine < ctx.buffer.len:
+      let outdentLine = ctx.buffer.getLine(startLine)
+      for r in outdentLine.runes:
+        if $r == " " or $r == "\t":
+          ctx.cursor.column += 1
+        else:
+          break
+
+    ctx.state.needsFullRedraw = true
+    return ok(())
+  of OpLowerCase:
+    # Convert text in range to lowercase
+    let transactionResult = ctx.buffer.beginTransaction("Lowercase")
+    if transactionResult.isErr:
+      return err("Failed to begin transaction: " & transactionResult.error)
+
+    if range.isLinewise:
+      for lineNum in range.start.line .. range.endPos.line:
+        if lineNum < ctx.buffer.len:
+          let lineText = $ctx.buffer.getLine(lineNum)
+          let lineCharLen = lineText.charLen
+          if lineCharLen > 0:
+            let lowerText = lineText.toLowerAscii()
+            let startPos = BufferPosition(line: lineNum, column: 0)
+            let endPos = BufferPosition(line: lineNum, column: lineCharLen - 1)
+            discard ctx.buffer.deleteRange(startPos, endPos)
+            discard ctx.buffer.insertText(startPos, lowerText)
+    else:
+      let text = extractRangeText(ctx.buffer, range)
+      let lowerText = text.toLowerAscii()
+      discard ctx.buffer.deleteRange(range.start, range.endPos)
+      discard ctx.buffer.insertText(range.start, lowerText)
+
+    discard ctx.buffer.commitTransaction()
+
+    ctx.cursor = range.start
+    ctx.state.needsFullRedraw = true
+    return ok(())
+  of OpUpperCase:
+    # Convert text in range to uppercase
+    let transactionResult = ctx.buffer.beginTransaction("Uppercase")
+    if transactionResult.isErr:
+      return err("Failed to begin transaction: " & transactionResult.error)
+
+    if range.isLinewise:
+      for lineNum in range.start.line .. range.endPos.line:
+        if lineNum < ctx.buffer.len:
+          let lineText = $ctx.buffer.getLine(lineNum)
+          let lineCharLen = lineText.charLen
+          if lineCharLen > 0:
+            let upperText = lineText.toUpperAscii()
+            let startPos = BufferPosition(line: lineNum, column: 0)
+            let endPos = BufferPosition(line: lineNum, column: lineCharLen - 1)
+            discard ctx.buffer.deleteRange(startPos, endPos)
+            discard ctx.buffer.insertText(startPos, upperText)
+    else:
+      let text = extractRangeText(ctx.buffer, range)
+      let upperText = text.toUpperAscii()
+      discard ctx.buffer.deleteRange(range.start, range.endPos)
+      discard ctx.buffer.insertText(range.start, upperText)
+
+    discard ctx.buffer.commitTransaction()
+
+    ctx.cursor = range.start
+    ctx.state.needsFullRedraw = true
+    return ok(())
+  of OpSwapCase:
     return err("Operator " & $operatorType & " not yet implemented")
 
 # Forward declaration for recordJump (defined below)
@@ -2464,6 +2602,68 @@ proc handleOperatorChange(ctx: CommandContext, count: int = 1): Result[(), strin
     setPendingOperator(ctx, OpChange, count, "c")
     return ok(())
 
+proc handleOperatorIndent(ctx: CommandContext, count: int = 1): Result[(), string] =
+  ## Indent operator - waits for motion (>2w, >$, etc.) or >> for line
+  ## count: number of times to apply the operator (default: 1)
+
+  # Check if same operator was pressed (>> for indent line)
+  if ctx.state.editState.pendingOperator.isSome and
+      ctx.state.editState.pendingOperator.get.operatorType == OpIndent:
+    let startLine = ctx.cursor.line
+    let operatorCount = ctx.state.editState.pendingOperator.get.operatorCount
+    let endLine = min(startLine + operatorCount - 1, ctx.buffer.len - 1)
+    ctx.state.editState.pendingOperator = none(PendingOperator)
+
+    let range = OperatorRange(
+      start: BufferPosition(line: startLine, column: 0),
+      endPos: BufferPosition(line: endLine, column: 0),
+      isLinewise: true,
+    )
+    return executeOperatorOnRange(ctx, OpIndent, range, 1)
+  else:
+    # Set pending operator for motion
+    setPendingOperator(ctx, OpIndent, count, ">")
+    return ok(())
+
+proc handleOperatorOutdent(ctx: CommandContext, count: int = 1): Result[(), string] =
+  ## Outdent operator - waits for motion (<2w, <$, etc.) or << for line
+  ## count: number of times to apply the operator (default: 1)
+
+  # Check if same operator was pressed (<< for dedent line)
+  if ctx.state.editState.pendingOperator.isSome and
+      ctx.state.editState.pendingOperator.get.operatorType == OpOutdent:
+    let startLine = ctx.cursor.line
+    let operatorCount = ctx.state.editState.pendingOperator.get.operatorCount
+    let endLine = min(startLine + operatorCount - 1, ctx.buffer.len - 1)
+    ctx.state.editState.pendingOperator = none(PendingOperator)
+
+    let range = OperatorRange(
+      start: BufferPosition(line: startLine, column: 0),
+      endPos: BufferPosition(line: endLine, column: 0),
+      isLinewise: true,
+    )
+    return executeOperatorOnRange(ctx, OpOutdent, range, 1)
+  else:
+    # Set pending operator for motion
+    setPendingOperator(ctx, OpOutdent, count, "<")
+    return ok(())
+
+proc handleOperatorLowerCase(ctx: CommandContext, count: int = 1): Result[(), string] =
+  ## Lowercase operator - waits for motion (guw, gu$, etc.)
+  ## count: number of times to apply the operator (default: 1)
+
+  # Set pending operator for motion
+  setPendingOperator(ctx, OpLowerCase, count, "gu")
+  return ok(())
+
+proc handleOperatorUpperCase(ctx: CommandContext, count: int = 1): Result[(), string] =
+  ## Uppercase operator - waits for motion (gUw, gU$, etc.)
+  ## count: number of times to apply the operator (default: 1)
+
+  # Set pending operator for motion
+  setPendingOperator(ctx, OpUpperCase, count, "gU")
+  return ok(())
+
 ## Text object command handlers
 
 proc handleTextObjectInner(ctx: CommandContext): Result[(), string] =
@@ -2477,6 +2677,11 @@ proc handleTextObjectInner(ctx: CommandContext): Result[(), string] =
       some(PendingTextObject(modifier: tomInner, operatorCount: operatorCount))
     ctx.state.statusMessage =
       $ctx.state.editState.pendingOperator.get.operatorType & "i"
+    return ok(())
+  elif isVisualAllMode(ctx.state.mode):
+    # In Visual mode - set text object modifier for visual selection
+    ctx.state.editState.pendingTextObject =
+      some(PendingTextObject(modifier: tomInner, operatorCount: 1))
     return ok(())
   else:
     # No pending operator - enter Insert mode
@@ -2499,6 +2704,11 @@ proc handleTextObjectAround(ctx: CommandContext): Result[(), string] =
       some(PendingTextObject(modifier: tomAround, operatorCount: operatorCount))
     ctx.state.statusMessage =
       $ctx.state.editState.pendingOperator.get.operatorType & "a"
+    return ok(())
+  elif isVisualAllMode(ctx.state.mode):
+    # In Visual mode - set text object modifier for visual selection
+    ctx.state.editState.pendingTextObject =
+      some(PendingTextObject(modifier: tomAround, operatorCount: 1))
     return ok(())
   else:
     # No pending operator - enter Append mode (move cursor right, then Insert)
@@ -4075,6 +4285,50 @@ proc registerBuiltinCommands*(registry: CommandRegistry) =
     1, # Accept optional count
   )
 
+  registry.register(
+    custom("operator.indent"),
+    "Indent Operator",
+    "Indent operator - waits for motion (>w, >$, etc.) or >> for line",
+    proc(ctx: CommandContext, args: seq[string]): Result[(), string] =
+      let count = parseCount(args, default = 1)
+      handleOperatorIndent(ctx, count),
+    0,
+    1, # Accept optional count
+  )
+
+  registry.register(
+    custom("operator.outdent"),
+    "Outdent Operator",
+    "Outdent operator - waits for motion (<w, <$, etc.) or << for line",
+    proc(ctx: CommandContext, args: seq[string]): Result[(), string] =
+      let count = parseCount(args, default = 1)
+      handleOperatorOutdent(ctx, count),
+    0,
+    1, # Accept optional count
+  )
+
+  registry.register(
+    custom("operator.lowercase"),
+    "Lowercase Operator",
+    "Lowercase operator - waits for motion (guw, gu$, etc.)",
+    proc(ctx: CommandContext, args: seq[string]): Result[(), string] =
+      let count = parseCount(args, default = 1)
+      handleOperatorLowerCase(ctx, count),
+    0,
+    1, # Accept optional count
+  )
+
+  registry.register(
+    custom("operator.uppercase"),
+    "Uppercase Operator",
+    "Uppercase operator - waits for motion (gUw, gU$, etc.)",
+    proc(ctx: CommandContext, args: seq[string]): Result[(), string] =
+      let count = parseCount(args, default = 1)
+      handleOperatorUpperCase(ctx, count),
+    0,
+    1, # Accept optional count
+  )
+
   # D - Delete to end of line (equivalent to d$)
   registry.register(
     custom("operator.delete.to.end"),
@@ -4197,7 +4451,34 @@ proc registerBuiltinCommands*(registry: CommandRegistry) =
         if rangeResult.isErr:
           return err(rangeResult.error)
 
-        let toRange = rangeResult.value
+        var toRange = rangeResult.value
+
+        # Count extension for word/WORD text objects (e.g., d2iw, d3aw)
+        # textObj.operatorCount already contains the count from the pending operator
+        let effectiveCount = max(textObj.operatorCount, 1)
+
+        if effectiveCount > 1 and kind in {toWord, toWideWord}:
+          for i in 1 ..< effectiveCount:
+            # Move cursor past current range end
+            var nextLine = toRange.endPos.line
+            var nextCol = toRange.endPos.column + 1
+            let lineRunes = ctx.buffer.getLine(nextLine).toRunes()
+            if nextCol >= lineRunes.len:
+              # Move to next line
+              nextLine.inc
+              nextCol = 0
+              if nextLine >= ctx.buffer.len:
+                break
+
+            # Use inner for intermediate words, original modifier for last
+            let modifier = if i == effectiveCount - 1: textObj.modifier else: tomInner
+
+            let nextCursor = BufferPosition(line: nextLine, column: nextCol)
+            let nextResult =
+              calculateTextObjectRange(ctx.buffer, nextCursor, kind, modifier)
+            if nextResult.isErr:
+              break
+            toRange.endPos = nextResult.value.endPos
 
         # Convert TextObjectRange to OperatorRange
         let opRange = OperatorRange(
@@ -4211,9 +4492,16 @@ proc registerBuiltinCommands*(registry: CommandRegistry) =
 
           # Execute operator on text object
           return executeOperatorOnRange(ctx, op.operatorType, opRange, op.operatorCount)
+        elif isVisualAllMode(ctx.state.mode):
+          # In Visual mode - update selection to text object range
+          ctx.state.visualSelection.start = toRange.start
+          ctx.state.visualSelection.current = toRange.endPos
+          ctx.state.visualSelection.active = true
+          ctx.cursor = toRange.endPos
+          ctx.state.needsFullRedraw = true
+          return ok(())
         else:
-          # No operator - just select the text object in visual mode (future feature)
-          return err("Text objects without operators not yet implemented"),
+          return err("Text objects require an operator or Visual mode"),
       0,
       0,
     )

--- a/src/moepkg/editor_render_helpers.nim
+++ b/src/moepkg/editor_render_helpers.nim
@@ -292,10 +292,6 @@ proc getSelectionStyle*(
     else:
       normalStyle()
 
-proc isVisualMode*(mode: EditorMode): bool {.inline.} =
-  ## Check if the mode is any visual mode variant
-  mode in {EditorMode.Visual, EditorMode.VisualBlock, EditorMode.VisualLine}
-
 proc getVisualSelection*(
     e: Editor, windowMode: EditorMode, windowActive: bool = true
 ): tuple[hasSelection: bool, selStart, selEnd: BufferPosition] =
@@ -303,7 +299,7 @@ proc getVisualSelection*(
   ## windowMode: The mode of the window being rendered
   ## windowActive: only show selection in active window (default true for compatibility)
   let hasSelection =
-    isVisualMode(windowMode) and e.state.visualSelection.active and windowActive
+    isVisualAllMode(windowMode) and e.state.visualSelection.active and windowActive
 
   if hasSelection:
     let (start, endPos) = e.state.visualSelection.getSelectionRange()

--- a/src/moepkg/help_viewer.nim
+++ b/src/moepkg/help_viewer.nim
@@ -94,18 +94,43 @@ s or cl    - Delete the current character and enter insert mode
 ci"        - Delete the inside of double quotes and enter insert mode
 ci'        - Delete the inside of single quotes and enter insert mode
 ciw        - Delete the current word and enter insert mode
+ciW        - Delete the current WORD and enter insert mode
 ci( or ci) - Delete the inside of round brackets and enter insert mode
 ci[ or ci] - Delete the inside of square brackets and enter insert mode
 ci{ or ci} - Delete the inside of curly brackets and enter insert mode
+ca"        - Delete around double quotes and enter insert mode
+ca'        - Delete around single quotes and enter insert mode
+caw        - Delete a word (with surrounding whitespace) and enter insert mode
+caW        - Delete a WORD (with surrounding whitespace) and enter insert mode
+ca( or ca) - Delete around round brackets and enter insert mode
+ca[ or ca] - Delete around square brackets and enter insert mode
+ca{ or ca} - Delete around curly brackets and enter insert mode
 cf any     - Delete characters to the any character and enter insert mode
 ct any     - Delete characters until the character and enter insert mode
 di"        - Delete the inside of double quotes
 di'        - Delete the inside of single quotes
 diw        - Delete the current word
+diW        - Delete the current WORD
 di( or di) - Delete the inside of round brackets
 di[ or di] - Delete the inside of square brackets
 di{ or di} - Delete the inside of curly brackets
+da"        - Delete around double quotes (including quotes)
+da'        - Delete around single quotes (including quotes)
+daw        - Delete a word (including surrounding whitespace)
+daW        - Delete a WORD (including surrounding whitespace)
+da( or da) - Delete around round brackets (including brackets)
+da[ or da] - Delete around square brackets (including brackets)
+da{ or da} - Delete around curly brackets (including brackets)
 dt any     - Delete characters until the character
+yiw        - Yank the current word
+yiW        - Yank the current WORD
+yi"        - Yank the inside of double quotes
+yi'        - Yank the inside of single quotes
+yi( or yi) - Yank the inside of round brackets
+yi[ or yi] - Yank the inside of square brackets
+yi{ or yi} - Yank the inside of curly brackets
+yaw        - Yank a word (including surrounding whitespace)
+yaW        - Yank a WORD (including surrounding whitespace)
 *          - Search forwards for the word under cursor
 #          - Search backwards for the word under cursor
 f          - Move to next any character on the current line

--- a/src/moepkg/key_bindings.nim
+++ b/src/moepkg/key_bindings.nim
@@ -1815,30 +1815,28 @@ proc setupDefaultBindings*(registry: KeyBindingRegistry) =
     )
   )
 
-  # Indent/dedent commands
+  # Indent/outdent operator commands (> and <)
   registry.registerCommand(
     Command(
-      name: "indent-line",
-      description: "Indent current line",
+      name: "operator-indent",
+      description: "Indent operator",
       kind: ctCustom,
-      commandId: "indent.line",
+      commandId: "operator.indent",
       args: @[],
     )
   )
+  registry.bindKey(EditorMode.Normal, ">", "operator-indent")
 
   registry.registerCommand(
     Command(
-      name: "dedent-line",
-      description: "Dedent current line",
+      name: "operator-outdent",
+      description: "Outdent operator",
       kind: ctCustom,
-      commandId: "dedent.line",
+      commandId: "operator.outdent",
       args: @[],
     )
   )
-
-  # Bind >> and << sequences for indent/dedent
-  registry.bindKey(EditorMode.Normal, "> >", "indent-line")
-  registry.bindKey(EditorMode.Normal, "< <", "dedent-line")
+  registry.bindKey(EditorMode.Normal, "<", "operator-outdent")
 
   # Auto indent command (==)
   registry.registerCommand(
@@ -2025,6 +2023,30 @@ proc setupDefaultBindings*(registry: KeyBindingRegistry) =
     )
   )
   registry.bindKey(EditorMode.Normal, "y", "operator-yank")
+
+  # gu - Lowercase operator
+  registry.registerCommand(
+    Command(
+      name: "operator-lowercase",
+      description: "Lowercase operator",
+      kind: ctCustom,
+      commandId: "operator.lowercase",
+      args: @[],
+    )
+  )
+  registry.bindKey(EditorMode.Normal, "g u", "operator-lowercase")
+
+  # gU - Uppercase operator
+  registry.registerCommand(
+    Command(
+      name: "operator-uppercase",
+      description: "Uppercase operator",
+      kind: ctCustom,
+      commandId: "operator.uppercase",
+      args: @[],
+    )
+  )
+  registry.bindKey(EditorMode.Normal, "g U", "operator-uppercase")
 
   # D - Delete to end of line
   registry.registerCommand(
@@ -2805,6 +2827,10 @@ proc setupDefaultBindings*(registry: KeyBindingRegistry) =
   registry.bindKey(EditorMode.Visual, "o", "visual-swap-selection")
   registry.bindKey(EditorMode.Visual, "p", "visual-paste")
   registry.bindKey(EditorMode.Visual, "P", "visual-paste")
+  registry.bindKey(EditorMode.Visual, "i", "textobject-inner")
+    # Inner text object (viw, vi", etc.)
+  registry.bindKey(EditorMode.Visual, "a", "textobject-around")
+    # Around text object (vaw, va", etc.)
   registry.bindKey(EditorMode.Visual, "z f", "fold-create") # Create fold from selection
   registry.bindKey(EditorMode.Visual, "Escape", "switch-to-normal") # Exit to normal mode
   registry.bindKey(EditorMode.Visual, "C-c", "switch-to-normal") # Exit to normal mode

--- a/src/moepkg/modes.nim
+++ b/src/moepkg/modes.nim
@@ -87,6 +87,10 @@ proc modeLabel*(m: EditorMode): string =
   of EditorMode.CallHierarchy: "CALL HIERARCHY"
   of EditorMode.Terminal: "TERMINAL"
 
+proc isVisualAllMode*(mode: EditorMode): bool =
+  ## Check if the mode is any visual mode variant
+  mode in {EditorMode.Visual, EditorMode.VisualBlock, EditorMode.VisualLine}
+
 proc overlayLabel*(o: OverlayKind): string =
   case o
   of okCommand: "COMMAND"

--- a/src/moepkg/motion.nim
+++ b/src/moepkg/motion.nim
@@ -345,15 +345,18 @@ proc tillCharBackward(
 # Helper functions for word motion
 proc isWordChar(r: Rune): bool =
   ## Check if a character is part of a word (alphanumeric or underscore)
+  ## Uses Unicode-aware isAlpha to support Japanese, accented Latin, etc.
   let c = r.int32
-  return
-    (c >= 'a'.ord and c <= 'z'.ord) or (c >= 'A'.ord and c <= 'Z'.ord) or
-    (c >= '0'.ord and c <= '9'.ord) or c == '_'.ord
+  return r.isAlpha or (c >= '0'.ord and c <= '9'.ord) or c == '_'.ord
 
 proc isWhitespace(r: Rune): bool =
   ## Check if a character is whitespace
   let c = r.int32
   return c == ' '.ord or c == '\t'.ord or c == '\n'.ord or c == '\r'.ord
+
+proc isSymbolChar(r: Rune): bool =
+  ## Check if a character is a symbol (non-word, non-whitespace)
+  return not isWordChar(r) and not isWhitespace(r)
 
 proc moveWordForward(
     e: MotionExecutor, currentPos: CursorPosition, count: int
@@ -1500,62 +1503,212 @@ proc findWordBoundaries(
 
   let cursorCol = min(cursor.column, runes.len - 1)
 
-  # Find start of word
-  var startCol = cursorCol
-  # If cursor is on whitespace, move to next word
-  if isWhitespace(runes[startCol]):
-    while startCol < runes.len and isWhitespace(runes[startCol]):
-      startCol.inc
-    if startCol >= runes.len:
-      return err("No word found")
-
-  # Now find the actual word start
-  while startCol > 0 and isWordChar(runes[startCol - 1]):
-    startCol.dec
-
-  # Find end of word
-  var endCol = startCol
-  while endCol < runes.len and isWordChar(runes[endCol]):
-    endCol.inc
-
-  if inner:
-    # Inner word: just the word itself
-    # endCol points to one past the last character, so use endCol - 1 for inclusive range
-    if endCol <= startCol:
-      return err("Empty word")
-    return ok(
-      TextObjectRange(
-        start: BufferPosition(line: cursor.line, column: startCol),
-        endPos: BufferPosition(line: cursor.line, column: endCol - 1),
-        isLinewise: false,
-      )
-    )
-  else:
-    # Around word: word + trailing whitespace
-    var extendedEnd = endCol
-    while extendedEnd < runes.len and isWhitespace(runes[extendedEnd]):
-      extendedEnd.inc
-
-    # If no trailing whitespace, try leading
-    if extendedEnd == endCol and startCol > 0:
-      var extendedStart = startCol
-      while extendedStart > 0 and isWhitespace(runes[extendedStart - 1]):
-        extendedStart.dec
+  # Case 1: Cursor is on whitespace
+  if isWhitespace(runes[cursorCol]):
+    if inner:
+      # Inner whitespace: select the whitespace sequence
+      var startCol = cursorCol
+      while startCol > 0 and isWhitespace(runes[startCol - 1]):
+        startCol.dec
+      var endCol = cursorCol
+      while endCol + 1 < runes.len and isWhitespace(runes[endCol + 1]):
+        endCol.inc
       return ok(
         TextObjectRange(
-          start: BufferPosition(line: cursor.line, column: extendedStart),
-          endPos: BufferPosition(line: cursor.line, column: endCol - 1),
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
+          isLinewise: false,
+        )
+      )
+    else:
+      # Around: skip whitespace and include the next word
+      var wordStart = cursorCol
+      while wordStart < runes.len and isWhitespace(runes[wordStart]):
+        wordStart.inc
+
+      if wordStart >= runes.len:
+        # No word after whitespace on this line - search subsequent lines
+        var foundLine = -1
+        var nextCol = 0
+        var nextEndCol = 0
+        for searchLine in (cursor.line + 1) ..< buffer.len:
+          let searchLineStr = buffer.getLine(searchLine)
+          let searchRunes = searchLineStr.toRunes()
+          var col = 0
+          # Skip leading whitespace
+          while col < searchRunes.len and isWhitespace(searchRunes[col]):
+            col.inc
+          if col < searchRunes.len:
+            # Found a non-whitespace character
+            foundLine = searchLine
+            nextCol = col
+            nextEndCol = col
+            if isWordChar(searchRunes[col]):
+              while nextEndCol + 1 < searchRunes.len and
+                  isWordChar(searchRunes[nextEndCol + 1]):
+                nextEndCol.inc
+            elif isSymbolChar(searchRunes[col]):
+              while nextEndCol + 1 < searchRunes.len and
+                  isSymbolChar(searchRunes[nextEndCol + 1]):
+                nextEndCol.inc
+            break
+
+        if foundLine >= 0:
+          # Include leading whitespace on current line
+          var startCol = cursorCol
+          while startCol > 0 and isWhitespace(runes[startCol - 1]):
+            startCol.dec
+          return ok(
+            TextObjectRange(
+              start: BufferPosition(line: cursor.line, column: startCol),
+              endPos: BufferPosition(line: foundLine, column: nextEndCol),
+              isLinewise: false,
+            )
+          )
+
+        # Fallback: select whitespace on current line only
+        var startCol = cursorCol
+        while startCol > 0 and isWhitespace(runes[startCol - 1]):
+          startCol.dec
+        return ok(
+          TextObjectRange(
+            start: BufferPosition(line: cursor.line, column: startCol),
+            endPos: BufferPosition(line: cursor.line, column: runes.len - 1),
+            isLinewise: false,
+          )
+        )
+
+      # Found word on same line after whitespace
+      var endCol = wordStart
+      if isWordChar(runes[wordStart]):
+        while endCol + 1 < runes.len and isWordChar(runes[endCol + 1]):
+          endCol.inc
+      elif isSymbolChar(runes[wordStart]):
+        while endCol + 1 < runes.len and isSymbolChar(runes[endCol + 1]):
+          endCol.inc
+
+      # Include leading whitespace
+      var startCol = cursorCol
+      while startCol > 0 and isWhitespace(runes[startCol - 1]):
+        startCol.dec
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
           isLinewise: false,
         )
       )
 
-    return ok(
-      TextObjectRange(
-        start: BufferPosition(line: cursor.line, column: startCol),
-        endPos: BufferPosition(line: cursor.line, column: extendedEnd - 1),
-        isLinewise: false,
+  # Case 2: Cursor is on a word character
+  if isWordChar(runes[cursorCol]):
+    var startCol = cursorCol
+    while startCol > 0 and isWordChar(runes[startCol - 1]):
+      startCol.dec
+
+    var endCol = cursorCol
+    while endCol + 1 < runes.len and isWordChar(runes[endCol + 1]):
+      endCol.inc
+
+    if inner:
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
+          isLinewise: false,
+        )
       )
-    )
+    else:
+      # Around word: word + trailing whitespace
+      var extendedEnd = endCol + 1
+      while extendedEnd < runes.len and isWhitespace(runes[extendedEnd]):
+        extendedEnd.inc
+
+      if extendedEnd > endCol + 1:
+        # Has trailing whitespace
+        return ok(
+          TextObjectRange(
+            start: BufferPosition(line: cursor.line, column: startCol),
+            endPos: BufferPosition(line: cursor.line, column: extendedEnd - 1),
+            isLinewise: false,
+          )
+        )
+
+      # No trailing whitespace, try leading
+      if startCol > 0:
+        var extendedStart = startCol
+        while extendedStart > 0 and isWhitespace(runes[extendedStart - 1]):
+          extendedStart.dec
+        return ok(
+          TextObjectRange(
+            start: BufferPosition(line: cursor.line, column: extendedStart),
+            endPos: BufferPosition(line: cursor.line, column: endCol),
+            isLinewise: false,
+          )
+        )
+
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
+          isLinewise: false,
+        )
+      )
+
+  # Case 3: Cursor is on a symbol character
+  if isSymbolChar(runes[cursorCol]):
+    var startCol = cursorCol
+    while startCol > 0 and isSymbolChar(runes[startCol - 1]):
+      startCol.dec
+
+    var endCol = cursorCol
+    while endCol + 1 < runes.len and isSymbolChar(runes[endCol + 1]):
+      endCol.inc
+
+    if inner:
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
+          isLinewise: false,
+        )
+      )
+    else:
+      # Around symbol: symbols + trailing whitespace
+      var extendedEnd = endCol + 1
+      while extendedEnd < runes.len and isWhitespace(runes[extendedEnd]):
+        extendedEnd.inc
+
+      if extendedEnd > endCol + 1:
+        return ok(
+          TextObjectRange(
+            start: BufferPosition(line: cursor.line, column: startCol),
+            endPos: BufferPosition(line: cursor.line, column: extendedEnd - 1),
+            isLinewise: false,
+          )
+        )
+
+      # No trailing whitespace, try leading
+      if startCol > 0:
+        var extendedStart = startCol
+        while extendedStart > 0 and isWhitespace(runes[extendedStart - 1]):
+          extendedStart.dec
+        return ok(
+          TextObjectRange(
+            start: BufferPosition(line: cursor.line, column: extendedStart),
+            endPos: BufferPosition(line: cursor.line, column: endCol),
+            isLinewise: false,
+          )
+        )
+
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
+          isLinewise: false,
+        )
+      )
+
+  return err("Unexpected character class")
 
 proc findWideWordBoundaries(
     buffer: TextBuffer, cursor: BufferPosition, inner: bool
@@ -1576,51 +1729,130 @@ proc findWideWordBoundaries(
 
   let cursorCol = min(cursor.column, runes.len - 1)
 
-  # Find start of WORD
-  var startCol = cursorCol
-  # If cursor is on whitespace, move to next WORD
-  if isWhitespace(runes[startCol]):
-    while startCol < runes.len and isWhitespace(runes[startCol]):
-      startCol.inc
-    if startCol >= runes.len:
-      return err("No WORD found")
+  # Case 1: Cursor is on whitespace
+  if isWhitespace(runes[cursorCol]):
+    if inner:
+      # Inner whitespace: select the whitespace sequence
+      var startCol = cursorCol
+      while startCol > 0 and isWhitespace(runes[startCol - 1]):
+        startCol.dec
+      var endCol = cursorCol
+      while endCol + 1 < runes.len and isWhitespace(runes[endCol + 1]):
+        endCol.inc
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
+          isLinewise: false,
+        )
+      )
+    else:
+      # Around: skip whitespace and include the next WORD
+      var wordStart = cursorCol
+      while wordStart < runes.len and isWhitespace(runes[wordStart]):
+        wordStart.inc
 
-  # Find the actual WORD start (any non-whitespace)
+      if wordStart >= runes.len:
+        # No WORD after whitespace on this line - search subsequent lines
+        var foundLine = -1
+        var nextCol = 0
+        var nextEndCol = 0
+        for searchLine in (cursor.line + 1) ..< buffer.len:
+          let searchLineStr = buffer.getLine(searchLine)
+          let searchRunes = searchLineStr.toRunes()
+          var col = 0
+          while col < searchRunes.len and isWhitespace(searchRunes[col]):
+            col.inc
+          if col < searchRunes.len:
+            foundLine = searchLine
+            nextCol = col
+            nextEndCol = col
+            while nextEndCol + 1 < searchRunes.len and
+                not isWhitespace(searchRunes[nextEndCol + 1]):
+              nextEndCol.inc
+            break
+
+        if foundLine >= 0:
+          var startCol = cursorCol
+          while startCol > 0 and isWhitespace(runes[startCol - 1]):
+            startCol.dec
+          return ok(
+            TextObjectRange(
+              start: BufferPosition(line: cursor.line, column: startCol),
+              endPos: BufferPosition(line: foundLine, column: nextEndCol),
+              isLinewise: false,
+            )
+          )
+
+        # Fallback: select whitespace on current line only
+        var startCol = cursorCol
+        while startCol > 0 and isWhitespace(runes[startCol - 1]):
+          startCol.dec
+        return ok(
+          TextObjectRange(
+            start: BufferPosition(line: cursor.line, column: startCol),
+            endPos: BufferPosition(line: cursor.line, column: runes.len - 1),
+            isLinewise: false,
+          )
+        )
+
+      # Found WORD on same line after whitespace
+      var endCol = wordStart
+      while endCol + 1 < runes.len and not isWhitespace(runes[endCol + 1]):
+        endCol.inc
+
+      var startCol = cursorCol
+      while startCol > 0 and isWhitespace(runes[startCol - 1]):
+        startCol.dec
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
+          isLinewise: false,
+        )
+      )
+
+  # Case 2: Cursor is on a non-whitespace character (WORD)
+  var startCol = cursorCol
   while startCol > 0 and not isWhitespace(runes[startCol - 1]):
     startCol.dec
 
-  # Find end of WORD (any non-whitespace)
-  var endCol = startCol
-  while endCol < runes.len and not isWhitespace(runes[endCol]):
+  var endCol = cursorCol
+  while endCol + 1 < runes.len and not isWhitespace(runes[endCol + 1]):
     endCol.inc
 
   if inner:
-    # Inner WORD: just the WORD itself
-    # endCol points to one past the last character, so use endCol - 1 for inclusive range
-    if endCol <= startCol:
-      return err("Empty WORD")
     return ok(
       TextObjectRange(
         start: BufferPosition(line: cursor.line, column: startCol),
-        endPos: BufferPosition(line: cursor.line, column: endCol - 1),
+        endPos: BufferPosition(line: cursor.line, column: endCol),
         isLinewise: false,
       )
     )
   else:
     # Around WORD: WORD + trailing whitespace
-    var extendedEnd = endCol
+    var extendedEnd = endCol + 1
     while extendedEnd < runes.len and isWhitespace(runes[extendedEnd]):
       extendedEnd.inc
 
-    # If no trailing whitespace, try leading
-    if extendedEnd == endCol and startCol > 0:
+    if extendedEnd > endCol + 1:
+      return ok(
+        TextObjectRange(
+          start: BufferPosition(line: cursor.line, column: startCol),
+          endPos: BufferPosition(line: cursor.line, column: extendedEnd - 1),
+          isLinewise: false,
+        )
+      )
+
+    # No trailing whitespace, try leading
+    if startCol > 0:
       var extendedStart = startCol
       while extendedStart > 0 and isWhitespace(runes[extendedStart - 1]):
         extendedStart.dec
       return ok(
         TextObjectRange(
           start: BufferPosition(line: cursor.line, column: extendedStart),
-          endPos: BufferPosition(line: cursor.line, column: endCol - 1),
+          endPos: BufferPosition(line: cursor.line, column: endCol),
           isLinewise: false,
         )
       )
@@ -1628,7 +1860,7 @@ proc findWideWordBoundaries(
     return ok(
       TextObjectRange(
         start: BufferPosition(line: cursor.line, column: startCol),
-        endPos: BufferPosition(line: cursor.line, column: extendedEnd - 1),
+        endPos: BufferPosition(line: cursor.line, column: endCol),
         isLinewise: false,
       )
     )

--- a/tests/test_command_registry_integration.nim
+++ b/tests/test_command_registry_integration.nim
@@ -2612,3 +2612,687 @@ suite "Handler - Special Commands":
     # Buffer should be unchanged
     check buffer[0] == "hello world"
     check ctx.cursor.column == 0
+
+suite "Handler - Indent/Outdent operator with text objects":
+  test "operator.indent sets pending operator":
+    let buffer = newTextBuffer("hello world")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, custom("operator.indent")).isOk
+    check ctx.state.editState.pendingOperator.isSome
+    check ctx.state.editState.pendingOperator.get.operatorType == OpIndent
+
+  test "operator.outdent sets pending operator":
+    let buffer = newTextBuffer("  hello world")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 2)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, custom("operator.outdent")).isOk
+    check ctx.state.editState.pendingOperator.isSome
+    check ctx.state.editState.pendingOperator.get.operatorType == OpOutdent
+
+  test "double indent (>>) indents current line":
+    let buffer = newTextBuffer("hello\nworld\ntest")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 1, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # First > sets pending operator
+    discard registry.execute(ctx, custom("operator.indent"))
+    check ctx.state.editState.pendingOperator.isSome
+
+    # Second > completes >> (indent line)
+    check registry.execute(ctx, custom("operator.indent")).isOk
+    check buffer[0] == "hello"
+    check buffer[1] == "  world"
+    check buffer[2] == "test"
+
+  test "double outdent (<<) dedents current line":
+    let buffer = newTextBuffer("hello\n  world\ntest")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 1, column: 2)
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # First < sets pending operator
+    discard registry.execute(ctx, custom("operator.outdent"))
+    check ctx.state.editState.pendingOperator.isSome
+
+    # Second < completes << (dedent line)
+    check registry.execute(ctx, custom("operator.outdent")).isOk
+    check buffer[0] == "hello"
+    check buffer[1] == "world"
+    check buffer[2] == "test"
+
+  test "indent with text object (>iw) indents word line":
+    let buffer = newTextBuffer("hello\nworld\ntest")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 1, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # Set pending operator (>)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpIndent, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i)
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # Execute text object kind (word)
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    # Line containing the word should be indented
+    check "  " in buffer[1]
+
+  test "outdent with text object (<i{) dedents brace block":
+    let buffer = newTextBuffer("{\n  hello\n  world\n}")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 1, column: 2)
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # Set pending operator (<)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpOutdent, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i)
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # Execute text object kind (brace)
+    check registry.execute(ctx, custom("textobject.brace")).isOk
+    # Lines inside braces should be dedented
+    check buffer[1] == "hello"
+    check buffer[2] == "world"
+
+suite "Handler - Lowercase/Uppercase operator with text objects":
+  test "operator.lowercase sets pending operator":
+    let buffer = newTextBuffer("HELLO WORLD")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, custom("operator.lowercase")).isOk
+    check ctx.state.editState.pendingOperator.isSome
+    check ctx.state.editState.pendingOperator.get.operatorType == OpLowerCase
+
+  test "operator.uppercase sets pending operator":
+    let buffer = newTextBuffer("hello world")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, custom("operator.uppercase")).isOk
+    check ctx.state.editState.pendingOperator.isSome
+    check ctx.state.editState.pendingOperator.get.operatorType == OpUpperCase
+
+  test "lowercase with text object (guiw) lowercases inner word":
+    let buffer = newTextBuffer("hello WORLD test")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # On 'W' in "WORLD"
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator (gu)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpLowerCase, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i)
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # Execute text object kind (word)
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    check "world" in buffer[0]
+    check "WORLD" notin buffer[0]
+
+  test "uppercase with text object (gUiw) uppercases inner word":
+    let buffer = newTextBuffer("hello world test")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # On 'w' in "world"
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator (gU)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpUpperCase, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i)
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # Execute text object kind (word)
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    check "WORLD" in buffer[0]
+    check "hello" in buffer[0] # Other words unchanged
+    check "test" in buffer[0] # Other words unchanged
+
+  test "lowercase with quoted text object (gui\")":
+    let buffer = newTextBuffer("say \"HELLO WORLD\" now")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # Inside quotes
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator (gu)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpLowerCase, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i)
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # Execute text object kind (double quote)
+    check registry.execute(ctx, custom("textobject.quote.double")).isOk
+    check "hello world" in buffer[0]
+
+  test "uppercase with parenthesis text object (gUi()":
+    let buffer = newTextBuffer("func(hello world)")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # Inside parens
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator (gU)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpUpperCase, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i)
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # Execute text object kind (paren)
+    check registry.execute(ctx, custom("textobject.paren")).isOk
+    check "HELLO WORLD" in buffer[0]
+    check buffer[0].startsWith("func(")
+    check buffer[0].endsWith(")")
+
+  test "indent with brace text object (>i{) multi-line":
+    let buffer = newTextBuffer("if true {\nhello\nworld\n}")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 1, column: 0) # Inside braces
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # Set pending operator (>)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpIndent, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i)
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # Execute text object kind (brace)
+    check registry.execute(ctx, custom("textobject.brace")).isOk
+    check buffer[0] == "if true {"
+    check buffer[1] == "  hello"
+    check buffer[2] == "  world"
+    check buffer[3] == "}"
+
+suite "Handler - Visual mode text object selection":
+  test "viw selects inner word":
+    let buffer = newTextBuffer("hello world test")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 7) # On 'o' in "world"
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 0, column: 7),
+      current: BufferPosition(line: 0, column: 7),
+    )
+    let registry = createTestRegistry()
+
+    # i - sets pending text object modifier in Visual mode
+    check registry.execute(ctx, custom("textobject.inner")).isOk
+    check ctx.state.editState.pendingTextObject.isSome
+    check ctx.state.editState.pendingTextObject.get.modifier == tomInner
+    check ctx.state.mode == EditorMode.Visual # Stays in visual mode
+
+    # w - selects word
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    check ctx.state.visualSelection.active == true
+    # Selection should cover "world" (columns 6-10)
+    check ctx.state.visualSelection.start.column == 6
+    check ctx.state.visualSelection.current.column == 10
+
+  test "vaw selects around word":
+    let buffer = newTextBuffer("hello world test")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 7) # On 'o' in "world"
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 0, column: 7),
+      current: BufferPosition(line: 0, column: 7),
+    )
+    let registry = createTestRegistry()
+
+    # a - sets around text object modifier
+    check registry.execute(ctx, custom("textobject.around")).isOk
+    check ctx.state.editState.pendingTextObject.isSome
+    check ctx.state.editState.pendingTextObject.get.modifier == tomAround
+
+    # w - selects around word
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    check ctx.state.visualSelection.active == true
+    # "world " should be selected (columns 6-11, including trailing space)
+    check ctx.state.visualSelection.start.column == 6
+    check ctx.state.visualSelection.current.column == 11
+
+  test "vi\" selects inner quoted string":
+    let buffer = newTextBuffer("say \"hello world\" now")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # Inside quotes
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 0, column: 6),
+      current: BufferPosition(line: 0, column: 6),
+    )
+    let registry = createTestRegistry()
+
+    # i - inner modifier
+    check registry.execute(ctx, custom("textobject.inner")).isOk
+
+    # " - double quote text object
+    check registry.execute(ctx, custom("textobject.quote.double")).isOk
+    check ctx.state.visualSelection.active == true
+    # "hello world" (content inside quotes) should be selected
+    check ctx.state.visualSelection.start.column == 5
+    check ctx.state.visualSelection.current.column == 15
+
+  test "vi{ selects inner brace block (multi-line)":
+    let buffer = newTextBuffer("if true {\nhello\nworld\n}")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 1, column: 0) # Inside braces
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 1, column: 0),
+      current: BufferPosition(line: 1, column: 0),
+    )
+    let registry = createTestRegistry()
+
+    # i - inner modifier
+    check registry.execute(ctx, custom("textobject.inner")).isOk
+
+    # { - brace text object
+    check registry.execute(ctx, custom("textobject.brace")).isOk
+    check ctx.state.visualSelection.active == true
+    # Selection should span from after { to before }
+    check ctx.state.visualSelection.start.line == 0
+    check ctx.state.visualSelection.current.line == 3
+
+  test "textobject.inner in Visual mode does not enter Insert mode":
+    let buffer = newTextBuffer("hello world")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 0, column: 0),
+      current: BufferPosition(line: 0, column: 0),
+    )
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, custom("textobject.inner")).isOk
+    check ctx.state.mode == EditorMode.Visual # Must stay in Visual mode
+    check ctx.state.editState.pendingTextObject.isSome
+
+  test "textobject.around in Visual mode does not enter Insert mode":
+    let buffer = newTextBuffer("hello world")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 0, column: 0),
+      current: BufferPosition(line: 0, column: 0),
+    )
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, custom("textobject.around")).isOk
+    check ctx.state.mode == EditorMode.Visual # Must stay in Visual mode
+    check ctx.state.editState.pendingTextObject.isSome
+
+suite "Multibyte character support":
+  test "lowercase operator with mixed ASCII and multibyte (guiw)":
+    # Multibyte characters should pass through toLowerAscii unchanged
+    let buffer = newTextBuffer("こんにちは HELLO 世界")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # On 'H' in "HELLO"
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator (gu)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpLowerCase, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i) and execute kind (w)
+    discard registry.execute(ctx, custom("textobject.inner"))
+    check registry.execute(ctx, custom("textobject.word")).isOk
+
+    check "hello" in buffer[0]
+    check "HELLO" notin buffer[0]
+    # Multibyte characters must remain unchanged
+    check "こんにちは" in buffer[0]
+    check "世界" in buffer[0]
+
+  test "uppercase operator with mixed ASCII and multibyte (gUiw)":
+    let buffer = newTextBuffer("こんにちは hello 世界")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # On 'h' in "hello"
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator (gU)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpUpperCase, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i) and execute kind (w)
+    discard registry.execute(ctx, custom("textobject.inner"))
+    check registry.execute(ctx, custom("textobject.word")).isOk
+
+    check "HELLO" in buffer[0]
+    check "こんにちは" in buffer[0]
+    check "世界" in buffer[0]
+
+  test "lowercase linewise with multibyte lines":
+    let buffer = newTextBuffer("日本語 ABC\nこんにちは DEF\n漢字 GHI")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    let range = OperatorRange(
+      start: BufferPosition(line: 0, column: 0),
+      endPos: BufferPosition(line: 2, column: 0),
+      isLinewise: true,
+    )
+    check executeOperatorOnRange(ctx, OpLowerCase, range, 1).isOk
+
+    check buffer[0] == "日本語 abc"
+    check buffer[1] == "こんにちは def"
+    check buffer[2] == "漢字 ghi"
+
+  test "uppercase linewise with multibyte lines":
+    let buffer = newTextBuffer("日本語 abc\nこんにちは def\n漢字 ghi")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    let range = OperatorRange(
+      start: BufferPosition(line: 0, column: 0),
+      endPos: BufferPosition(line: 2, column: 0),
+      isLinewise: true,
+    )
+    check executeOperatorOnRange(ctx, OpUpperCase, range, 1).isOk
+
+    check buffer[0] == "日本語 ABC"
+    check buffer[1] == "こんにちは DEF"
+    check buffer[2] == "漢字 GHI"
+
+  test "lowercase character-wise range with multibyte":
+    # Character-wise range within a line containing multibyte chars
+    let buffer = newTextBuffer("あいう ABC うえお")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 4) # On 'A'
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    let range = OperatorRange(
+      start: BufferPosition(line: 0, column: 4),
+      endPos: BufferPosition(line: 0, column: 6), # "ABC"
+      isLinewise: false,
+    )
+    check executeOperatorOnRange(ctx, OpLowerCase, range, 1).isOk
+
+    check buffer[0] == "あいう abc うえお"
+
+  test "uppercase character-wise range with multibyte":
+    let buffer = newTextBuffer("あいう abc うえお")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 4)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    let range = OperatorRange(
+      start: BufferPosition(line: 0, column: 4),
+      endPos: BufferPosition(line: 0, column: 6), # "abc"
+      isLinewise: false,
+    )
+    check executeOperatorOnRange(ctx, OpUpperCase, range, 1).isOk
+
+    check buffer[0] == "あいう ABC うえお"
+
+  test "indent line with multibyte content (>>)":
+    let buffer = newTextBuffer("日本語テスト\nこんにちは\nASCII")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # >> (double indent)
+    discard registry.execute(ctx, custom("operator.indent"))
+    check registry.execute(ctx, custom("operator.indent")).isOk
+
+    check buffer[0] == "  日本語テスト"
+    check buffer[1] == "こんにちは" # Untouched
+    check buffer[2] == "ASCII" # Untouched
+
+  test "outdent line with multibyte content (<<)":
+    let buffer = newTextBuffer("  日本語テスト\n  こんにちは\nASCII")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 2)
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # << (double outdent)
+    discard registry.execute(ctx, custom("operator.outdent"))
+    check registry.execute(ctx, custom("operator.outdent")).isOk
+
+    check buffer[0] == "日本語テスト"
+    check buffer[1] == "  こんにちは" # Untouched
+    check buffer[2] == "ASCII" # Untouched
+
+  test "indent with brace text object containing multibyte (>i{)":
+    let buffer = newTextBuffer("関数 {\nあいうえお\nかきくけこ\n}")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 1, column: 0) # Inside braces
+    ctx.state.mode = EditorMode.Normal
+    ctx.state.display.expandTab = true
+    ctx.state.display.tabStop = 2
+    ctx.state.display.shiftWidth = 2
+    let registry = createTestRegistry()
+
+    # Set pending operator (>)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpIndent, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i) and execute kind (brace)
+    discard registry.execute(ctx, custom("textobject.inner"))
+    check registry.execute(ctx, custom("textobject.brace")).isOk
+
+    check buffer[0] == "関数 {"
+    check buffer[1] == "  あいうえお"
+    check buffer[2] == "  かきくけこ"
+    check buffer[3] == "}"
+
+  test "lowercase with quoted multibyte text (gui\")":
+    let buffer = newTextBuffer("say \"HELLO こんにちは WORLD\" end")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # Inside quotes
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator (gu)
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpLowerCase, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # Set text object modifier (i) and execute kind (double quote)
+    discard registry.execute(ctx, custom("textobject.inner"))
+    check registry.execute(ctx, custom("textobject.quote.double")).isOk
+
+    check "hello こんにちは world" in buffer[0]
+    check buffer[0].startsWith("say \"")
+    check "\" end" in buffer[0]
+
+  test "visual mode text object selection with multibyte (viw)":
+    let buffer = newTextBuffer("あいう hello かきく")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 5) # On 'l' in "hello"
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 0, column: 5),
+      current: BufferPosition(line: 0, column: 5),
+    )
+    let registry = createTestRegistry()
+
+    # i - sets pending text object modifier in Visual mode
+    check registry.execute(ctx, custom("textobject.inner")).isOk
+    check ctx.state.editState.pendingTextObject.isSome
+
+    # w - selects word
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    check ctx.state.visualSelection.active == true
+    # Selection should cover "hello" (columns 4-8)
+    check ctx.state.visualSelection.start.column == 4
+    check ctx.state.visualSelection.current.column == 8
+
+  test "visual mode text object selection with quoted multibyte (vi\")":
+    let buffer = newTextBuffer("関数 \"あいうえお\" 結果")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 4) # Inside quotes
+    ctx.state.mode = EditorMode.Visual
+    ctx.state.visualSelection = VisualSelection(
+      active: true,
+      start: BufferPosition(line: 0, column: 4),
+      current: BufferPosition(line: 0, column: 4),
+    )
+    let registry = createTestRegistry()
+
+    # i - inner modifier
+    check registry.execute(ctx, custom("textobject.inner")).isOk
+
+    # " - double quote text object
+    check registry.execute(ctx, custom("textobject.quote.double")).isOk
+    check ctx.state.visualSelection.active == true
+    # Should select "あいうえお" inside quotes (columns 4-8)
+    check ctx.state.visualSelection.start.column == 4
+    check ctx.state.visualSelection.current.column == 8
+
+suite "Handler - Text Object Count (d2iw, d2aw)":
+  test "d2iw deletes two words":
+    let buffer = newTextBuffer("hello world test")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator d with count 2
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpDelete, operatorCount: 2, startPos: ctx.cursor)
+    )
+
+    # i - inner modifier
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # w - word text object
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    # "hello " should be deleted (hello + trailing space as 2nd iw unit)
+    check buffer[0] == "world test"
+
+  test "d1iw is same as diw":
+    let buffer = newTextBuffer("hello world test")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator d with count 1
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpDelete, operatorCount: 1, startPos: ctx.cursor)
+    )
+
+    # i - inner modifier
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # w - word text object
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    # Only "hello" should be deleted
+    check buffer[0] == " world test"
+
+  test "d2aw deletes two words with trailing space":
+    let buffer = newTextBuffer("hello world test end")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator d with count 2
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpDelete, operatorCount: 2, startPos: ctx.cursor)
+    )
+
+    # a - around modifier
+    discard registry.execute(ctx, custom("textobject.around"))
+
+    # w - word text object
+    check registry.execute(ctx, custom("textobject.word")).isOk
+    # "hello world " should be deleted
+    check buffer[0] == "test end"
+
+  test "d2i\" ignores count for quote text objects":
+    let buffer = newTextBuffer("say \"hello\" world")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 6) # Inside quotes
+    ctx.state.mode = EditorMode.Normal
+    let registry = createTestRegistry()
+
+    # Set pending operator d with count 2
+    ctx.state.editState.pendingOperator = some(
+      PendingOperator(operatorType: OpDelete, operatorCount: 2, startPos: ctx.cursor)
+    )
+
+    # i - inner modifier
+    discard registry.execute(ctx, custom("textobject.inner"))
+
+    # " - quote text object (count should be ignored)
+    check registry.execute(ctx, custom("textobject.quote.double")).isOk
+    # Only "hello" inside quotes should be deleted (count ignored)
+    check buffer[0] == "say \"\" world"

--- a/tests/test_editor_render_helpers.nim
+++ b/tests/test_editor_render_helpers.nim
@@ -109,22 +109,22 @@ suite "analyzeIndentation - Edge cases":
     check info.leadingWhitespaceEnd == 31
     check info.hasContent == true
 
-suite "isVisualMode - Comprehensive":
+suite "isVisualAllMode - Comprehensive":
   test "All visual modes return true":
-    check renderHelpers.isVisualMode(EditorMode.Visual) == true
-    check renderHelpers.isVisualMode(EditorMode.VisualLine) == true
-    check renderHelpers.isVisualMode(EditorMode.VisualBlock) == true
+    check isVisualAllMode(EditorMode.Visual) == true
+    check isVisualAllMode(EditorMode.VisualLine) == true
+    check isVisualAllMode(EditorMode.VisualBlock) == true
 
   test "All non-visual modes return false":
-    check renderHelpers.isVisualMode(EditorMode.Normal) == false
-    check renderHelpers.isVisualMode(EditorMode.Insert) == false
-    check renderHelpers.isVisualMode(EditorMode.Replace) == false
-    check renderHelpers.isVisualMode(EditorMode.Filer) == false
-    check renderHelpers.isVisualMode(EditorMode.LogViewer) == false
-    check renderHelpers.isVisualMode(EditorMode.Help) == false
-    check renderHelpers.isVisualMode(EditorMode.BufferManager) == false
-    check renderHelpers.isVisualMode(EditorMode.Config) == false
-    check renderHelpers.isVisualMode(EditorMode.Debug) == false
+    check isVisualAllMode(EditorMode.Normal) == false
+    check isVisualAllMode(EditorMode.Insert) == false
+    check isVisualAllMode(EditorMode.Replace) == false
+    check isVisualAllMode(EditorMode.Filer) == false
+    check isVisualAllMode(EditorMode.LogViewer) == false
+    check isVisualAllMode(EditorMode.Help) == false
+    check isVisualAllMode(EditorMode.BufferManager) == false
+    check isVisualAllMode(EditorMode.Config) == false
+    check isVisualAllMode(EditorMode.Debug) == false
 
 suite "getVisualSelection - Detailed":
   test "Default hasSelection is false":

--- a/tests/test_motion.nim
+++ b/tests/test_motion.nim
@@ -255,6 +255,34 @@ suite "Word Motion":
     let result = executor.moveWordEnd(currentPos, 1)
     check result.x == 10 # End of "world"
 
+  test "moveWordForward with Unicode":
+    let buffer = newTextBuffer("hello 日本語 world")
+    let executor = newMotionExecutor(buffer)
+    let currentPos = CursorPosition(x: 0, y: 0)
+    let result = executor.moveWordForward(currentPos, 1)
+    check result.x == 6 # Start of '日本語'
+
+  test "moveWordForward past Unicode word":
+    let buffer = newTextBuffer("hello 日本語 world")
+    let executor = newMotionExecutor(buffer)
+    let currentPos = CursorPosition(x: 6, y: 0)
+    let result = executor.moveWordForward(currentPos, 1)
+    check result.x == 10 # Start of 'world'
+
+  test "moveWordBackward with Unicode":
+    let buffer = newTextBuffer("hello 日本語 world")
+    let executor = newMotionExecutor(buffer)
+    let currentPos = CursorPosition(x: 10, y: 0)
+    let result = executor.moveWordBackward(currentPos, 1)
+    check result.x == 6 # Start of '日本語'
+
+  test "moveWordEnd with Unicode":
+    let buffer = newTextBuffer("hello 日本語 world")
+    let executor = newMotionExecutor(buffer)
+    let currentPos = CursorPosition(x: 6, y: 0)
+    let result = executor.moveWordEnd(currentPos, 1)
+    check result.x == 8 # End of '日本語'
+
 suite "Find/Till Char Backward":
   test "findCharBackward finds previous occurrence":
     let buffer = newTextBuffer("abcxabc")
@@ -362,6 +390,131 @@ suite "Text Objects - Word":
     let range = result.get
     check range.start.column == 0
     check range.endPos.column == 5 # 'hello ' including trailing space
+
+  test "findWordBoundaries inner word - Unicode (Japanese)":
+    let buffer = newTextBuffer("hello 日本語 world")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = true)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 6
+    check range.endPos.column == 8 # 日本語 is columns 6-8
+
+  test "findWordBoundaries around word - Unicode (Japanese)":
+    let buffer = newTextBuffer("hello 日本語 world")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 6
+    check range.endPos.column == 9 # 日本語 + trailing space
+
+  test "findWordBoundaries inner on symbol":
+    let buffer = newTextBuffer("hello ++ world")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = true)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 6
+    check range.endPos.column == 7 # ++ is columns 6-7
+
+  test "findWordBoundaries around on symbol":
+    let buffer = newTextBuffer("hello ++ world")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 6
+    check range.endPos.column == 8 # ++ + trailing space
+
+  test "findWordBoundaries inner on whitespace":
+    let buffer = newTextBuffer("hello   world")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = true)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 5
+    check range.endPos.column == 7 # spaces at columns 5-7
+
+  test "findWordBoundaries around on whitespace":
+    let buffer = newTextBuffer("hello   world")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 5
+    check range.endPos.column == 12 # spaces + 'world'
+
+  test "findWordBoundaries aw cross-line from trailing whitespace":
+    let buffer = newTextBuffer("hello   \nworld")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.line == 0
+    check range.start.column == 5
+    check range.endPos.line == 1
+    check range.endPos.column == 4 # 'world' on next line
+
+  test "findWordBoundaries iw on whitespace stays on same line":
+    let buffer = newTextBuffer("hello   \nworld")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = true)
+    check result.isOk
+    let range = result.get
+    check range.start.line == 0
+    check range.endPos.line == 0 # stays on same line
+
+  test "findWideWordBoundaries inner on whitespace":
+    let buffer = newTextBuffer("hello   world")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWideWordBoundaries(buffer, cursor, inner = true)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 5
+    check range.endPos.column == 7
+
+  test "findWideWordBoundaries aW cross-line from trailing whitespace":
+    let buffer = newTextBuffer("hello   \nworld")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWideWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.line == 0
+    check range.start.column == 5
+    check range.endPos.line == 1
+    check range.endPos.column == 4
+
+  test "findWordBoundaries aw at end of line (no trailing space) uses leading":
+    let buffer = newTextBuffer("hello world")
+    let cursor = BufferPosition(line: 0, column: 7)
+    let result = findWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.column == 5 # Leading space included
+    check range.endPos.column == 10 # 'world' ends at 10
+
+  test "findWordBoundaries aw cross-line skips empty lines":
+    let buffer = newTextBuffer("hello   \n\nworld")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.line == 0
+    check range.start.column == 5
+    check range.endPos.line == 2
+    check range.endPos.column == 4 # 'world' on line 2
+
+  test "findWideWordBoundaries aW cross-line skips empty lines":
+    let buffer = newTextBuffer("hello   \n\nworld")
+    let cursor = BufferPosition(line: 0, column: 6)
+    let result = findWideWordBoundaries(buffer, cursor, inner = false)
+    check result.isOk
+    let range = result.get
+    check range.start.line == 0
+    check range.start.column == 5
+    check range.endPos.line == 2
+    check range.endPos.column == 4
 
 suite "Text Objects - Quoted":
   test "findQuotedBoundaries inner double quote":

--- a/tests/test_visual_handler.nim
+++ b/tests/test_visual_handler.nim
@@ -324,30 +324,30 @@ suite "VisualModeHandler - isPositionInSelection":
 
     check isPositionInSelection(selection, BufferPosition(line: 0, column: 5)) == false
 
-suite "VisualModeHandler - isVisualMode":
+suite "VisualModeHandler - isVisualAllMode":
   test "Visual mode is visual":
-    check isVisualMode(EditorMode.Visual) == true
+    check isVisualAllMode(EditorMode.Visual) == true
 
   test "VisualLine mode is visual":
-    check isVisualMode(EditorMode.VisualLine) == true
+    check isVisualAllMode(EditorMode.VisualLine) == true
 
   test "VisualBlock mode is visual":
-    check isVisualMode(EditorMode.VisualBlock) == true
+    check isVisualAllMode(EditorMode.VisualBlock) == true
 
   test "Normal mode is not visual":
-    check isVisualMode(EditorMode.Normal) == false
+    check isVisualAllMode(EditorMode.Normal) == false
 
   test "Insert mode is not visual":
-    check isVisualMode(EditorMode.Insert) == false
+    check isVisualAllMode(EditorMode.Insert) == false
 
   test "Command mode is not visual":
-    check isVisualMode(EditorMode.Normal) == false
+    check isVisualAllMode(EditorMode.Normal) == false
 
   test "Search mode is not visual":
-    check isVisualMode(EditorMode.Insert) == false
+    check isVisualAllMode(EditorMode.Insert) == false
 
   test "Replace mode is not visual":
-    check isVisualMode(EditorMode.Replace) == false
+    check isVisualAllMode(EditorMode.Replace) == false
 
 suite "VisualModeHandler - VisualModeResult":
   test "vmrHandled result with mode transition":


### PR DESCRIPTION
- isWordChar: Fix Unicode support
- Added isSymbolChar helper for non-word, non-whitespace character classification
- findWordBoundaries: Rewritten to handle 3 character classes (whitespace, word, symbol) separately
  - `iw` on whitespace selects the whitespace sequence
  - `aw` on whitespace selects whitespace + next word (with cross-line support, skipping empty lines)
  - `iw`/`aw` on symbols (e.g. ++) now works correctly
- findWideWordBoundaries: Same rewrite for `iW`/`aW` with cross-line and empty-line-skip support

- Added count extension logic in registerTextObjectKind — `d2iw`, `d3aw`, etc. now expand the range by repeating calculateTextObjectRange
- Count is ignored for quote/paren text objects (only applies to toWord/toWideWord)

- Added key bindings for new text object types (W, backtick, angle brackets)

- Updated visual mode text object selection support

- Added around text objects (`da"`, `daw`, `ca"`, `caw`, etc.) to help
- Added W (WORD) variants (`diW`, `ciW`, `daW`, `caW`) to help
- Added yank text objects (`yiw`, `yaw`, `yi"`, etc.) to help