### PR TITLE
fix(pty): fix freebsd include and add libutil link

### DIFF
--- a/src/moepkg/terminal/pty.nim
+++ b/src/moepkg/terminal/pty.nim
@@ -39,6 +39,12 @@ when defined(macosx):
     amaster: var cint, name: cstring, termp: pointer, winp: pointer
   ): Pid {.importc, header: "<util.h>".}
 
+elif defined(freebsd):
+  {.passL: "-lutil".}
+  proc forkpty(
+    amaster: var cint, name: cstring, termp: pointer, winp: pointer
+  ): Pid {.importc, header: "<libutil.h>".}
+
 else:
   proc forkpty(
     amaster: var cint, name: cstring, termp: pointer, winp: pointer


### PR DESCRIPTION
On FreeBSD, pty is declared in `libutil.h`, not `util.h` and you have to link against it. Adding this `elif` fix to the FreeBSD build, and I can give a try to `moe`. Thanks