### PR TITLE
feat(terminal): Keep an interactive shell running after `:terminal <c…

### DIFF
--- a/src/moe.nim
+++ b/src/moe.nim
@@ -57,44 +57,11 @@ proc pollTerminalWindows*(e: Editor) =
           e.state.windowDisplay.needsFullRedraw = true
 
         if termState.exitCode.isSome:
-          if termState.command.len > 0:
-            # Command mode (e.g. `:terminal ls`): swap the live terminal
-            # buffer for its scrollback snapshot, keeping the tab slot
-            # and the `terminalStates` association intact so `:q` can
-            # close it through the normal Terminal path.
-            let oldBufId = window.buffer.id
-            let snapshot = termState.enterNormalSubMode()
-            snapshot.displayName = some(
-              "[Terminal: " & termState.command & "] (done: " & $termState.exitCode.get &
-                ")"
-            )
-            e.addBuffer(snapshot)
-            for w in e.windowManager.windows:
-              for j in 0 ..< w.bufferIds.len:
-                if w.bufferIds[j] == oldBufId:
-                  w.bufferIds[j] = snapshot.id
-              # Repoint any other window also displaying the dead terminal
-              # buffer at the snapshot, so its `.buffer` ref doesn't dangle
-              # after `deleteBufferAt` evicts the old id from `bufferIdIndex`.
-              if w.buffer != nil and w.buffer.id == oldBufId:
-                w.buffer = snapshot
-            if e.terminalStates.hasKey(oldBufId):
-              e.terminalStates[snapshot.id] = e.terminalStates[oldBufId]
-              e.terminalStates.del(oldBufId)
-            let oldIdx = e.bufferIndexById(oldBufId)
-            if oldIdx >= 0:
-              e.deleteBufferAt(oldIdx)
-            # `window.mode` / `window.modeState` are left as-is on purpose:
-            # they keep pointing to the same `TerminalState` object (only its
-            # `terminalStates` key changed), and `subMode == tsmNormal` is
-            # what flips the renderer over to the scrollback snapshot — the
-            # `tsmInput` guard at the top of pollTerminalWindows prevents
-            # this branch from re-running against the now-static snapshot.
-            window.cursor = BufferPosition(line: max(0, snapshot.len - 1), column: 0)
-            window.viewport.topLine = max(0, snapshot.len - window.viewport.height)
-          else:
-            # Interactive shell (`:terminal`): tear down the tab.
-            e.closeTerminalBuffer(window.buffer.id)
+          # The session always runs as a persistent interactive shell (even
+          # `:terminal ls` runs the command and then drops into a live shell),
+          # so an exit only happens when the user quits the shell itself.
+          # Tear down the tab in every case.
+          e.closeTerminalBuffer(window.buffer.id)
           e.state.windowDisplay.needsFullRedraw = true
           return
 

--- a/src/moepkg/terminal/pty.nim
+++ b/src/moepkg/terminal/pty.nim
@@ -84,11 +84,10 @@ proc openPtyAndSpawn*(
     # Child process
     putEnv("TERM", "xterm-256color")
 
+    let shell = getEnv("SHELL", "/bin/sh")
     if command.len > 0:
-      let shell = getEnv("SHELL", "/bin/sh")
       discard execl(shell.cstring, shell.cstring, "-c".cstring, command.cstring, nil)
     else:
-      let shell = getEnv("SHELL", "/bin/sh")
       discard execl(shell.cstring, shell.cstring, nil)
 
     # execl only returns on error

--- a/src/moepkg/terminal_mode.nim
+++ b/src/moepkg/terminal_mode.nim
@@ -20,7 +20,7 @@
 ## Terminal mode state management.
 ## Integrates PTY handle with ANSI parser grid and manages sub-modes.
 
-import std/options
+import std/[options, os]
 
 import pkg/results
 
@@ -37,7 +37,6 @@ type
     grid*: TerminalGrid
     subMode*: TerminalSubMode
     scrollbackSnapshot*: TextBuffer # Snapshot for Terminal-Normal mode
-    command*: string
     exitCode*: Option[int]
     waitingForCtrlN*: bool # Waiting for Ctrl-N after Ctrl-\
     needsBufferRefresh*: bool
@@ -46,7 +45,16 @@ proc newTerminalState*(
     command: string = "", cols: int = 80, rows: int = 24
 ): Result[TerminalState, string] =
   ## Create a new terminal state: open PTY, spawn shell, initialize grid.
-  let ptyResult = openPtyAndSpawn(command, cols, rows)
+  ##
+  ## When a command is given (e.g. `:terminal ls`) it is run first and then the
+  ## session hands control to an interactive shell via `exec`, so the terminal
+  ## keeps running instead of exiting once the command finishes.
+  let spawnCommand =
+    if command.len > 0:
+      command & "; exec " & getEnv("SHELL", "/bin/sh")
+    else:
+      ""
+  let ptyResult = openPtyAndSpawn(spawnCommand, cols, rows)
   if ptyResult.isErr:
     return err(ptyResult.error)
 
@@ -55,7 +63,6 @@ proc newTerminalState*(
     grid: newTerminalGrid(cols, rows),
     subMode: tsmInput,
     scrollbackSnapshot: nil,
-    command: command,
     exitCode: none(int),
     waitingForCtrlN: false,
     needsBufferRefresh: false,

--- a/tests/test_terminal_handler.nim
+++ b/tests/test_terminal_handler.nim
@@ -186,13 +186,16 @@ suite "checkExitStatus - single waitpid call (regression)":
 suite "pollOutput sets exitCode on process exit (regression)":
   ## Regression test: pollOutput must set TerminalState.exitCode when the
   ## shell process exits, so pollTerminalWindows can detect it and close
-  ## the terminal window.
+  ## the terminal window. A `:terminal` session always runs a persistent
+  ## interactive shell, so the exit happens when the user quits the shell.
 
-  test "pollOutput sets exitCode after short command exits":
-    let termState = newTerminalState("true", 80, 24)
+  test "pollOutput sets exitCode after the shell is quit":
+    let termState = newTerminalState("", 80, 24)
     if termState.isOk:
       let ts = termState.get
       check ts.exitCode.isNone
+
+      ts.feedInput("exit\n")
 
       # Poll until process exit is detected (max ~2 seconds)
       var detected = false
@@ -207,10 +210,11 @@ suite "pollOutput sets exitCode on process exit (regression)":
       check ts.exitCode.isSome
       ts.cleanup()
 
-  test "pollOutput sets exitCode = 0 for 'true' command":
-    let termState = newTerminalState("true", 80, 24)
+  test "pollOutput sets exitCode = 0 when the shell exits cleanly":
+    let termState = newTerminalState("", 80, 24)
     if termState.isOk:
       let ts = termState.get
+      ts.feedInput("exit 0\n")
       var detected = false
       for _ in 0 ..< 100:
         discard ts.pollOutput()
@@ -223,10 +227,11 @@ suite "pollOutput sets exitCode on process exit (regression)":
       check ts.exitCode.get == 0
       ts.cleanup()
 
-  test "pollOutput sets exitCode = 1 for 'false' command":
-    let termState = newTerminalState("false", 80, 24)
+  test "pollOutput captures non-zero exit code from the shell":
+    let termState = newTerminalState("", 80, 24)
     if termState.isOk:
       let ts = termState.get
+      ts.feedInput("exit 1\n")
       var detected = false
       for _ in 0 ..< 100:
         discard ts.pollOutput()
@@ -239,24 +244,22 @@ suite "pollOutput sets exitCode on process exit (regression)":
       check ts.exitCode.get == 1
       ts.cleanup()
 
-suite "enterNormalSubMode after process exit (regression)":
-  ## Regression test: when a short-lived command (e.g. `ls`) exits,
-  ## pollTerminalWindows switches to Terminal-Normal sub-mode so the user
-  ## can review output. The snapshot buffer must contain the command output
-  ## and not be full of empty lines.
+suite "enterNormalSubMode snapshots live session (regression)":
+  ## `enterNormalSubMode` (entered manually via Ctrl-\ Ctrl-N) snapshots the
+  ## current grid into a read-only TextBuffer for scrollback browsing. The
+  ## snapshot must contain the command output and not be full of empty lines.
 
-  test "Snapshot buffer contains command output after exit":
+  test "Snapshot buffer contains command output":
     let termState = newTerminalState("echo hello", 80, 24)
     if termState.isOk:
       let ts = termState.get
-      # Poll until process exits
-      for _ in 0 ..< 100:
+      # Poll long enough for the command output to reach the grid. The session
+      # itself stays alive (the command runs, then `exec $SHELL` takes over),
+      # so we do not wait for an exit.
+      for _ in 0 ..< 20:
         discard ts.pollOutput()
-        if ts.exitCode.isSome:
-          break
         sleep(20)
 
-      check ts.exitCode.isSome
       let snapshot = ts.enterNormalSubMode()
       check ts.subMode == tsmNormal
       check snapshot.len > 0
@@ -268,45 +271,43 @@ suite "enterNormalSubMode after process exit (regression)":
     let termState = newTerminalState("echo test", 80, 24)
     if termState.isOk:
       let ts = termState.get
-      for _ in 0 ..< 100:
+      for _ in 0 ..< 20:
         discard ts.pollOutput()
-        if ts.exitCode.isSome:
-          break
         sleep(20)
 
       let snapshot = ts.enterNormalSubMode()
       check snapshot.readOnly == true
       ts.cleanup()
 
-suite "Process exit behavior depends on command (regression)":
-  ## `:terminal` (interactive shell, command="") should auto-close on exit.
-  ## `:terminal ls` (command specified) should switch to Terminal-Normal
-  ## so the user can review output.
+suite "Persistent shell behavior (regression)":
+  ## The session always runs as a persistent interactive shell. `:terminal ls`
+  ## runs the command and then keeps the shell alive instead of exiting and
+  ## recording the output into a snapshot buffer.
 
-  test "Interactive shell (empty command) stays in tsmInput after exit":
-    # With empty command, pollTerminalWindows would auto-close.
-    # At the TerminalState level, subMode remains tsmInput (caller closes).
-    let termState = newTerminalState("true", 80, 24)
-    if termState.isOk:
-      let ts = termState.get
-      # Simulate as if this were an interactive shell
-      ts.command = ""
-      for _ in 0 ..< 100:
-        discard ts.pollOutput()
-        if ts.exitCode.isSome:
-          break
-        sleep(20)
-
-      check ts.exitCode.isSome
-      # subMode should still be tsmInput (not switched by pollOutput itself)
-      check ts.subMode == tsmInput
-      ts.cleanup()
-
-  test "Command mode keeps command field non-empty":
+  test "Command mode keeps the shell alive after the command finishes":
     let termState = newTerminalState("echo test", 80, 24)
     if termState.isOk:
       let ts = termState.get
-      check ts.command == "echo test"
+      # The `echo` finishes quickly, but `exec $SHELL` keeps the session
+      # running, so the process must not have exited on its own.
+      for _ in 0 ..< 20:
+        discard ts.pollOutput()
+        sleep(20)
+
+      check ts.exitCode.isNone
+      ts.cleanup()
+
+  test "Shell exits when the user quits it":
+    let termState = newTerminalState("echo test", 80, 24)
+    if termState.isOk:
+      let ts = termState.get
+      # Let the command run and the interactive shell take over.
+      for _ in 0 ..< 20:
+        discard ts.pollOutput()
+        sleep(20)
+
+      # Quitting the shell (sending `exit`) terminates the session.
+      ts.feedInput("exit\n")
       for _ in 0 ..< 100:
         discard ts.pollOutput()
         if ts.exitCode.isSome:
@@ -314,14 +315,4 @@ suite "Process exit behavior depends on command (regression)":
         sleep(20)
 
       check ts.exitCode.isSome
-      # command field preserved after exit
-      check ts.command == "echo test"
-      ts.cleanup()
-
-  test "Default shell has empty command field":
-    # newTerminalState with empty command spawns default shell
-    let termState = newTerminalState("", 80, 24)
-    if termState.isOk:
-      let ts = termState.get
-      check ts.command == ""
       ts.cleanup()

--- a/tests/test_terminal_tabs.nim
+++ b/tests/test_terminal_tabs.nim
@@ -32,14 +32,13 @@ proc createTestEditor(): Editor =
   result = newEditor(config)
   result.syncActiveWindow()
 
-proc fakeTerminalState(command: string = "bash"): TerminalState =
+proc fakeTerminalState(): TerminalState =
   ## Build a TerminalState whose PTY is pre-closed so cleanup() is a no-op.
   ## Lets tests drive the tab/state lifecycle without spawning a real shell.
   TerminalState(
     pty: PtyHandle(masterFd: -1, childPid: Pid(0), closed: true),
     grid: newTerminalGrid(80, 24),
     subMode: tsmInput,
-    command: command,
     exitCode: none(int),
     waitingForCtrlN: false,
     needsBufferRefresh: false,
@@ -51,7 +50,7 @@ proc registerFakeTerminal(e: Editor, command: string = "bash"): TextBuffer =
   result.displayName = some("[Terminal: " & command & "]")
   e.addBuffer(result)
   e.addBufferToWindowList(result)
-  e.terminalStates[result.id] = fakeTerminalState(command)
+  e.terminalStates[result.id] = fakeTerminalState()
   e.activeWindow.buffer = result
   e.activeWindow.modeState =
     ModeState(kind: mskTerminal, terminal: e.terminalStates[result.id])
@@ -73,7 +72,6 @@ suite "Terminal tabs - applyBufferMode":
 
     check e.activeWindow.mode == EditorMode.Terminal
     check e.activeWindow.modeState.kind == mskTerminal
-    check e.activeWindow.modeState.terminal.command == "bash"
     # The original file buffer is untouched.
     check originalBuf != termBuf
 


### PR DESCRIPTION
…md>`