### PR TITLE
fix(lsp): sync codeLens/inlayHint display state on config reload and …

### DIFF
--- a/src/moepkg/editor.nim
+++ b/src/moepkg/editor.nim
@@ -729,7 +729,7 @@ proc newEditor*(editorConfig: EditorConfig, vr: ValidationResult): Editor =
         showModifiedLines: editorConfig.standard.showModifiedLines,
         showGitDiff: editorConfig.git.showChangedLine,
         showSyntaxChecker: editorConfig.syntaxChecker.enable,
-        showCodeLens: true,
+        showCodeLens: editorConfig.lsp.codeLens.enable,
         showDocumentHighlight: editorConfig.lsp.documentHighlight.enable,
         showInlayHint: editorConfig.lsp.inlayHint.enable,
         lineWrap: editorConfig.standard.lineWrap,
@@ -1130,7 +1130,9 @@ proc applyConfigSettings*(e: Editor, newConfig: EditorConfig) =
   e.state.display.showModifiedLines = newConfig.standard.showModifiedLines
   e.state.display.showGitDiff = newConfig.git.showChangedLine
   e.state.display.showSyntaxChecker = newConfig.syntaxChecker.enable
+  e.state.display.showCodeLens = newConfig.lsp.codeLens.enable
   e.state.display.showDocumentHighlight = newConfig.lsp.documentHighlight.enable
+  e.state.display.showInlayHint = newConfig.lsp.inlayHint.enable
   e.state.display.tabStop = newConfig.standard.tabStop
   e.state.display.shiftWidth = newConfig.standard.shiftWidth
   e.state.display.softTabStop = newConfig.standard.softTabStop

--- a/tests/test_editor.nim
+++ b/tests/test_editor.nim
@@ -1048,6 +1048,28 @@ suite "Editor - applyConfigSettings syncs display state":
     e.applyConfigSettings(e.config)
     check e.state.display.showDocumentHighlight == true
 
+  test "Syncs showCodeLens from config.lsp.codeLens.enable":
+    let e = createTestEditor()
+
+    e.config.lsp.codeLens.enable = true
+    e.applyConfigSettings(e.config)
+    check e.state.display.showCodeLens == true
+
+    e.config.lsp.codeLens.enable = false
+    e.applyConfigSettings(e.config)
+    check e.state.display.showCodeLens == false
+
+  test "Syncs showInlayHint from config.lsp.inlayHint.enable":
+    let e = createTestEditor()
+
+    e.config.lsp.inlayHint.enable = false
+    e.applyConfigSettings(e.config)
+    check e.state.display.showInlayHint == false
+
+    e.config.lsp.inlayHint.enable = true
+    e.applyConfigSettings(e.config)
+    check e.state.display.showInlayHint == true
+
   test "Syncs showIndentationLines from config.standard.indentationLines":
     let e = createTestEditor()
 


### PR DESCRIPTION
…honor codeLens.enable at startup