### PR TITLE
fix(lsp): bound incoming frame header and Content-Length size to prev…

### DIFF
--- a/src/moepkg/lsp/jsonrpc.nim
+++ b/src/moepkg/lsp/jsonrpc.nim
@@ -324,6 +324,14 @@ type
     input*: InputStream
     output*: OutputStream
 
+const
+  ## Sanity limits on incoming frames. A malicious or buggy server can
+  ## otherwise force unbounded allocation: an endless header block with no
+  ## "\r\n\r\n" terminator, or a huge Content-Length that `read` would try to
+  ## allocate up front. Both ceilings sit far above any legitimate LSP message.
+  MaxHeaderBlockLen* = 8 * 1024 # 8 KiB of headers is already absurd
+  MaxContentLength* = 256 * 1024 * 1024 # 256 MiB body ceiling
+
 proc isInvalidContentType(s: string, valueStart: int): bool {.inline.} =
   s.find("utf-8", valueStart) == -1 and s.find("utf8", valueStart) == -1
 
@@ -362,6 +370,10 @@ proc parseFrameHeaders*(headerBlock: string): Result[int, string] =
 
   if contentLen < 0:
     return Result[int, string].err("Missing Content-Length header")
+  if contentLen > MaxContentLength:
+    return Result[int, string].err(
+      "Content-Length exceeds limit: " & $contentLen & " > " & $MaxContentLength
+    )
   Result[int, string].ok(contentLen)
 
 proc readFrame(s: AsyncStreamReader): Future[Result[string, string]] {.async.} =
@@ -369,12 +381,16 @@ proc readFrame(s: AsyncStreamReader): Future[Result[string, string]] {.async.} =
 
   let buf =
     try:
-      await s.readLine(sep = "\r\n\r\n")
+      await s.readLine(limit = MaxHeaderBlockLen, sep = "\r\n\r\n")
     except CatchableError as e:
       return Result[string, string].err("readLine failed: " & e.msg)
 
   if buf.len == 0:
     return Result[string, string].err("readLine: empty")
+
+  if buf.len >= MaxHeaderBlockLen:
+    # readLine stopped at the limit without finding the header terminator.
+    return Result[string, string].err("LSP header block exceeds limit")
 
   # `buf` is the whole header block (readLine consumed up to the blank line)
   let headers = parseFrameHeaders(buf)

--- a/tests/test_jsonrpc.nim
+++ b/tests/test_jsonrpc.nim
@@ -251,6 +251,16 @@ suite "Header Parsing - parseFrameHeaders (readFrame block)":
     check r.isErr
     check r.error.contains("Invalid Content-Length")
 
+  test "Content-Length at the limit is accepted":
+    let r = parseFrameHeaders("Content-Length: " & $MaxContentLength)
+    check r.isOk
+    check r.get == MaxContentLength
+
+  test "Content-Length above the limit is rejected":
+    let r = parseFrameHeaders("Content-Length: " & $(MaxContentLength + 1))
+    check r.isErr
+    check r.error.contains("exceeds limit")
+
 suite "Message Parsing - parseJsonRpcMessage":
   test "parses request message":
     let body = """{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"""


### PR DESCRIPTION
…ent unbounded allocation