### PR TITLE
docs(buffer): fix backend docstrings that say "character" but mean "b…

### DIFF
--- a/src/moepkg/buffer_backends/gap_buffer.nim
+++ b/src/moepkg/buffer_backends/gap_buffer.nim
@@ -119,7 +119,7 @@ proc findLineStart*(gb: GapBuffer, lineNumber: int): int =
     result += gb.lines[physicalLine].len + 1 # +1 for newline
 
 proc findLineEnd*(gb: GapBuffer, lineNumber: int): int =
-  ## Return the linear index of the end of the given line (last character position)
+  ## Return the linear index of the end of the given line (last byte position)
   ## Returns -1 if lineNumber is invalid or line is empty
   if lineNumber < 0 or lineNumber >= gb.lineCount:
     return -1
@@ -374,7 +374,7 @@ proc getLine*(gb: GapBuffer, lineNumber: int): string =
   gb.lines[physicalLine]
 
 proc charAtLineCol*(gb: GapBuffer, line: int, col: int): char =
-  ## Get character at (line, column) position
+  ## Get the byte at (line, col) position (col is a byte offset)
   if line < 0 or line >= gb.len:
     raise newException(IndexDefect, "GapBuffer line out of bounds")
 
@@ -422,8 +422,8 @@ proc indexToLineCol*(gb: GapBuffer, index: int): tuple[line: int, col: int] =
   return (0, 0)
 
 proc charAt*(gb: GapBuffer, index: int): char =
-  ## Get character at linear index position.
-  ## Treats the buffer as a flat sequence of characters with newlines between
+  ## Get the byte at linear (byte) index position.
+  ## Treats the buffer as a flat sequence of bytes with newlines between
   ## lines. Shares the index->(line, col) scan with `indexToLineCol`; a column
   ## equal to the line length maps to the trailing newline (or out-of-bounds on
   ## the last line) via `charAtLineCol`.
@@ -563,11 +563,11 @@ proc insert*(gb: GapBuffer, index: int, text: string) =
     gb.insertLine(line + parts.len, currentPart & suffix)
 
 proc insert*(gb: GapBuffer, index: int, ch: char) =
-  ## Insert a single character at linear index position
+  ## Insert a single byte at linear index position
   gb.insert(index, $ch)
 
 proc delete*(gb: GapBuffer, index: int, count: int = 1) =
-  ## Delete 'count' characters starting at linear index position
+  ## Delete 'count' bytes starting at linear index position
   if count <= 0 or index < 0:
     return
 
@@ -634,7 +634,7 @@ proc substring*(gb: GapBuffer, start: int, length: int): string =
 # Iterator support
 
 iterator chars*(gb: GapBuffer): char =
-  ## Iterate over all characters in the buffer, including newlines
+  ## Iterate over each byte in the buffer, including newlines
   ## Consistent with $ operator: newlines between lines, trailing newline only for explicit empty final line
   for i in 0 ..< gb.len:
     let

--- a/src/moepkg/buffer_backends/piece_table.nim
+++ b/src/moepkg/buffer_backends/piece_table.nim
@@ -1185,7 +1185,7 @@ proc `$`*(pt: PieceTable): string =
     result.add('\n')
 
 iterator chars*(pt: PieceTable): char =
-  ## Yields characters matching `$` output (includes implicit trailing newline).
+  ## Yields each byte matching `$` output (includes implicit trailing newline).
   var stack: array[64, PieceTreeNode]
   var sp = 0
   var cur = pt.root

--- a/src/moepkg/buffer_backends/rope.nim
+++ b/src/moepkg/buffer_backends/rope.nim
@@ -564,7 +564,7 @@ proc findLineStart*(rope: Rope, lineNumber: int): int =
   rope.lineStartByteOffset(lineNumber)
 
 proc findLineEnd*(rope: Rope, lineNumber: int): int =
-  ## Return the linear index of the end of the given line (last character position). O(log n).
+  ## Return the linear index of the end of the given line (last byte position). O(log n).
   if lineNumber < 0 or lineNumber >= rope.cachedLineCount:
     return -1
   rope.lineEndByteOffset(lineNumber) - 1

--- a/src/moepkg/buffer_backends/sqrt_decomp.nim
+++ b/src/moepkg/buffer_backends/sqrt_decomp.nim
@@ -182,7 +182,7 @@ proc maybeMerge(sd: SqrtDecomp, blockIdx: int) =
       sd.blocks.delete(blockIdx)
 
 proc blockSpan(sd: SqrtDecomp, bi: int): int =
-  ## Number of flat-string char positions owned by block `bi` for index-math:
+  ## Number of flat-string byte positions owned by block `bi` for index-math:
   ## its content plus a trailing newline per line, EXCEPT the buffer's final line
   ## (in the last block) has no trailing newline.
   let m = sd.blocks[bi].lines.len
@@ -259,7 +259,7 @@ proc findLineStart*(sd: SqrtDecomp, lineNumber: int): int =
       inc lineNum
 
 proc findLineEnd*(sd: SqrtDecomp, lineNumber: int): int =
-  ## Return the linear index of the end of the given line (last character position)
+  ## Return the linear index of the end of the given line (last byte position)
   ## Returns -1 if lineNumber is invalid or line is empty
   if lineNumber < 0 or lineNumber >= sd.cachedLineCount:
     return -1
@@ -318,7 +318,7 @@ proc modifyLineContent*(sd: SqrtDecomp, lineNumber: int, f: proc(s: var string))
   sd.blocks[blockIdx].cachedCharLen += line.len - oldLen
 
 proc charAtLineCol*(sd: SqrtDecomp, line: int, col: int): char =
-  ## Get character at (line, column) position
+  ## Get the byte at (line, col) position (col is a byte offset)
   if line < 0 or line >= sd.cachedLineCount:
     raise newException(IndexDefect, "SqrtDecomp line out of bounds")
 
@@ -334,8 +334,8 @@ proc charAtLineCol*(sd: SqrtDecomp, line: int, col: int): char =
     raise newException(IndexDefect, "SqrtDecomp column out of bounds")
 
 proc charAt*(sd: SqrtDecomp, index: int): char =
-  ## Get character at linear index position
-  ## Treats buffer as a flat sequence of characters with newlines between lines
+  ## Get the byte at linear (byte) index position
+  ## Treats buffer as a flat sequence of bytes with newlines between lines
   if index < 0:
     raise newException(IndexDefect, "SqrtDecomp index out of bounds: " & $index)
 
@@ -737,11 +737,11 @@ proc insert*(sd: SqrtDecomp, index: int, text: string) =
     sd.maybeRebalance()
 
 proc insert*(sd: SqrtDecomp, index: int, ch: char) =
-  ## Insert a single character at linear index position
+  ## Insert a single byte at linear index position
   sd.insert(index, $ch)
 
 proc delete*(sd: SqrtDecomp, index: int, count: int = 1) =
-  ## Delete 'count' characters starting at linear index position
+  ## Delete 'count' bytes starting at linear index position
   if count <= 0 or index < 0:
     return
 
@@ -783,7 +783,7 @@ proc `$`*(sd: SqrtDecomp): string =
       inc lineNum
 
 iterator chars*(sd: SqrtDecomp): char =
-  ## Iterate over all characters in the buffer, including newlines
+  ## Iterate over each byte in the buffer, including newlines
   ## Consistent with $ operator
   var lineNum = 0
   for b in sd.blocks:


### PR DESCRIPTION
…yte"