### PR TITLE
fix(editor_render_modes): use display columns instead of byte offsets…

### DIFF
--- a/src/moepkg/config_mode.nim
+++ b/src/moepkg/config_mode.nim
@@ -590,6 +590,13 @@ proc formatItemForDisplay*(item: ConfigItem, maxNameWidth: int): string =
   of cvkColor:
     return indent & name & " : " & item.colorValue
 
+proc calcMaxNameWidth*(items: seq[ConfigItem], maxWidth: int): int =
+  ## Calculate the maximum display name width for config item layout.
+  for item in items:
+    if item.kind != cvkSection:
+      result = max(result, item.displayName.len + item.depth * 2)
+  result = min(result + 4, maxWidth div 2)
+
 # Edit mode (Int/String editing)
 
 proc startEdit*(state: ConfigModeState) =

--- a/src/moepkg/editor_render_modes.nim
+++ b/src/moepkg/editor_render_modes.nim
@@ -57,11 +57,7 @@ proc renderConfig*(
     startX = window.viewport.x
 
   # Calculate max name width for alignment
-  var maxNameWidth = 0
-  for item in configState.items:
-    if item.kind != cvkSection:
-      maxNameWidth = max(maxNameWidth, item.displayName.len + item.depth * 2)
-  maxNameWidth = min(maxNameWidth + 4, width div 2) # Limit to half of width
+  let maxNameWidth = calcMaxNameWidth(configState.items, width)
 
   # Ensure selected entry is visible
   let visibleLines = listEndY - listStartY
@@ -129,8 +125,7 @@ proc renderConfig*(
 
     # Overlay the search highlight on just the matched characters (like buffer
     # search), instead of repainting the whole line. Skip while editing — the
-    # edit style owns that line. Uses byte offsets as cell columns, matching the
-    # ASCII width assumption the rest of this renderer already relies on.
+    # edit style owns that line.
     if searchQuery.len > 0 and not isBeingEdited:
       let
         hlStyle = searchHighlightStyle()
@@ -141,8 +136,10 @@ proc renderConfig*(
         let idx = lineLower.find(queryLower, searchPos)
         if idx < 0:
           break
+        let charIdx = displayLine.byteToCharPos(idx)
+        let screenX = startX + displayLine.displayWidthUpTo(charIdx)
         buffer.setString(
-          startX + idx, screenY, displayLine[idx ..< idx + queryLower.len], hlStyle
+          screenX, screenY, displayLine[idx ..< idx + queryLower.len], hlStyle
         )
         searchPos = idx + queryLower.len
 

--- a/tests/test_editor_render_modes.nim
+++ b/tests/test_editor_render_modes.nim
@@ -19,11 +19,13 @@
 
 ## Tests for editor_render_modes.nim
 
-import std/unittest
+import std/[unittest, strutils]
 
 import pkg/celina
 
-import ../src/moepkg/[editor, config, config_loader, config_mode, render_utils, color]
+import
+  ../src/moepkg/
+    [editor, config, config_loader, config_mode, render_utils, color, unicode_utils]
 import ../src/moepkg/editor_render_modes
 import ../src/moepkg/types/config_mode_types
 
@@ -282,3 +284,107 @@ suite "renderConfig - narrow viewport / multibyte":
       for w in [4, 8, 12]:
         e.activeWindow.viewport.width = w
         e.renderConfig(buffer, e.activeWindow, true, 0)
+
+suite "renderConfig - search highlight with multibyte displayName":
+  proc findHighlightedXs(buffer: Buffer, hlBg: ColorValue): seq[int] =
+    ## Find X positions of all cells drawn with the search highlight background.
+    ## Only returns cells on the first screen row that has any highlighted cells.
+    for y in 0 ..< buffer.area.height:
+      for x in 0 ..< buffer.area.width:
+        if buffer[x, y].style.bg == hlBg:
+          result.add x
+
+  test "Highlight positioned by display columns, not byte offsets":
+    let e = createTestEditor()
+    var buffer = createTestBuffer()
+    let configState = newConfigModeState(e.config)
+
+    # Give the first string item a CJK displayName (multibyte / wide chars)
+    # and a short distinctive value so the search match lands after the wide
+    # section where byte offset ≠ display columns.
+    var strIdx = -1
+    for i, item in configState.items:
+      if item.kind == cvkString:
+        configState.items[i].displayName = "あいう"
+        configState.items[i].stringValue = "XY"
+        strIdx = i
+        break
+
+    if strIdx < 0:
+      skip()
+    else:
+      let maxNameWidth = calcMaxNameWidth(configState.items, buffer.area.width)
+
+      configState.selectedIndex = strIdx
+      configState.topLine = strIdx
+      configState.setSearchQuery("XY")
+      e.windowManager.windows[e.windowManager.activeWindowIndex].modeState =
+        ModeState(kind: mskConfig, config: configState)
+      e.state.input.search.hlsearch = true
+      e.state.input.search.hlsearchTempDisabled = false
+
+      e.renderConfig(buffer, e.activeWindow, true, 0)
+
+      let hlBg = searchHighlightStyle().bg
+      let hlXs = buffer.findHighlightedXs(hlBg)
+
+      check hlXs.len == 2 # "XY" = 2 characters
+
+      # Compute the expected screen X of the first highlighted cell using the
+      # same display-width-aware conversion the fix applies.
+      let displayedLine = formatItemForDisplay(configState.items[strIdx], maxNameWidth)
+      let byteIdx = displayedLine.find("XY")
+      check byteIdx > 0
+      let charIdx = displayedLine.byteToCharPos(byteIdx)
+      let expectedX = displayWidthUpTo(displayedLine, charIdx)
+
+      check expectedX != byteIdx
+        # Precondition: CJK chars make byte offset ≠ display cols
+      check hlXs.len > 0
+      check hlXs[0] == expectedX
+
+  test "Highlight handles zero-width and combining characters":
+    let e = createTestEditor()
+    var buffer = createTestBuffer()
+    let configState = newConfigModeState(e.config)
+
+    # displayName with combining acute accent (U+0301, 2 bytes, 0 cols) and
+    # zero-width space (U+200B, 3 bytes, 0 cols). Together these add 5 bytes
+    # that contribute 0 display columns, creating a byte/column mismatch.
+    var strIdx = -1
+    for i, item in configState.items:
+      if item.kind == cvkString:
+        configState.items[i].displayName = "a\u0301\u200Bb"
+        configState.items[i].stringValue = "XY"
+        strIdx = i
+        break
+
+    if strIdx < 0:
+      skip()
+    else:
+      let maxNameWidth = calcMaxNameWidth(configState.items, buffer.area.width)
+
+      configState.selectedIndex = strIdx
+      configState.topLine = strIdx
+      configState.setSearchQuery("XY")
+      e.windowManager.windows[e.windowManager.activeWindowIndex].modeState =
+        ModeState(kind: mskConfig, config: configState)
+      e.state.input.search.hlsearch = true
+      e.state.input.search.hlsearchTempDisabled = false
+
+      e.renderConfig(buffer, e.activeWindow, true, 0)
+
+      let hlBg = searchHighlightStyle().bg
+      let hlXs = buffer.findHighlightedXs(hlBg)
+
+      check hlXs.len == 2
+
+      let displayedLine = formatItemForDisplay(configState.items[strIdx], maxNameWidth)
+      let byteIdx = displayedLine.find("XY")
+      check byteIdx > 0
+      let charIdx = displayedLine.byteToCharPos(byteIdx)
+      let expectedX = displayWidthUpTo(displayedLine, charIdx)
+
+      check expectedX != byteIdx # Precondition: zero-width/combining chars create gap
+      check hlXs.len > 0
+      check hlXs[0] == expectedX


### PR DESCRIPTION
… for config search highlight