### PR TITLE
fix(ansi_parser): defer ST's trailing '\' to apsEscape to avoid chunk…

### DIFF
--- a/src/moepkg/terminal/ansi_parser.nim
+++ b/src/moepkg/terminal/ansi_parser.nim
@@ -962,10 +962,12 @@ proc processOutput*(grid: TerminalGrid, data: string) =
           if oscType in {'0', '2'}:
             grid.title = oscStr[2 .. ^1]
         if ch == '\x1b':
-          # OSC terminated by ESC \ (ST), skip the backslash
-          if i + 1 < actualData.len and actualData[i + 1] == '\\':
-            i += 1
-        grid.parserState = apsNormal
+          # Defer ST's trailing '\' to apsEscape so it's handled even when the
+          # chunk ends here (peeking i+1 would leak the '\' into normal output).
+          grid.parserState = apsEscape
+          grid.escapeBuffer = ""
+        else:
+          grid.parserState = apsNormal
       elif grid.escapeBuffer.len >= MaxOscLength:
         # Oversized (likely unterminated) OSC: abort to bound memory (DoS guard).
         # This byte is valid payload, so reprocess it as normal output instead
@@ -978,10 +980,10 @@ proc processOutput*(grid: TerminalGrid, data: string) =
     of apsStringSeq:
       # Consuming DCS/APC/PM/SOS string until ST (ESC \) or BEL
       if ch == '\x1b':
-        # Possible start of ST (ESC \)
-        if i + 1 < actualData.len and actualData[i + 1] == '\\':
-          i += 1 # Skip the backslash
-        grid.parserState = apsNormal
+        # Defer ST's trailing '\' to apsEscape so it's handled even when the
+        # chunk ends here (peeking i+1 would leak the '\' into normal output).
+        grid.parserState = apsEscape
+        grid.escapeBuffer = ""
       elif ch == '\x07':
         # BEL also terminates string sequences
         grid.parserState = apsNormal

--- a/tests/test_ansi_parser.nim
+++ b/tests/test_ansi_parser.nim
@@ -1026,6 +1026,35 @@ suite "TerminalGrid - OSC sequences":
     check grid.parserState == apsNormal # aborted once the payload crossed the cap
     check grid.escapeBuffer.len == 0
 
+  test "OSC ST split across PTY reads does not leak backslash into output":
+    let grid = newTerminalGrid(20, 3)
+    grid.processOutput("\x1b]2;t\x1b") # chunk ends on ESC of ST
+    grid.processOutput("\\rest")
+    check grid.title == "t"
+    check grid.parserState == apsNormal
+    check grid.cells[0][0].ch == "r"
+    check grid.cells[0][1].ch == "e"
+    check grid.cells[0][2].ch == "s"
+    check grid.cells[0][3].ch == "t"
+
+  test "OSC followed by a new escape in the same chunk starts that escape":
+    let grid = newTerminalGrid(20, 3)
+    grid.processOutput("\x1b]2;t\x1b[31mR")
+    check grid.title == "t"
+    check grid.cells[0][0].ch == "R"
+    check grid.cells[0][0].fg.kind == ckIndexed
+    check grid.cells[0][0].fg.index == 1
+
+  test "DCS ST split across PTY reads does not leak backslash into output":
+    let grid = newTerminalGrid(20, 3)
+    grid.processOutput("\x1bPpayload\x1b") # chunk ends on ESC of ST
+    grid.processOutput("\\rest")
+    check grid.parserState == apsNormal
+    check grid.cells[0][0].ch == "r"
+    check grid.cells[0][1].ch == "e"
+    check grid.cells[0][2].ch == "s"
+    check grid.cells[0][3].ch == "t"
+
 suite "TerminalGrid - CSI sequences":
   test "unterminated CSI past the cap aborts to normal and frees the buffer":
     let grid = newTerminalGrid(20, 3)


### PR DESCRIPTION
…-boundary leak