### PR TITLE
fix(editor_file): iterate e.buffers in autoSave/autoBackup so backgro…

### DIFF
--- a/src/moepkg/editor_file.nim
+++ b/src/moepkg/editor_file.nim
@@ -19,7 +19,7 @@
 
 ## File operation procedures (load, save, auto-save, auto-backup)
 
-import std/[options, strformat, os, monotimes, times, tables, sets]
+import std/[options, strformat, os, monotimes, times, tables]
 
 import pkg/results
 
@@ -332,19 +332,12 @@ proc autoSave*(e: Editor) =
   if elapsed < threshold:
     return
 
-  # Check all windows for modified buffers and save them
+  # Iterate `e.buffers`, not windows: windows only expose foreground tabs,
+  # so background-tab buffers would silently miss auto save.
   var savedCount = 0
   var savedPaths: seq[string] = @[]
-  var savedBufferIds = initHashSet[BufferId]()
-    # Track already saved buffers to avoid duplicates
 
-  for window in e.windowManager.windows:
-    let buffer = window.buffer
-
-    # Skip if already saved (same buffer in multiple windows)
-    if buffer.id in savedBufferIds:
-      continue
-
+  for buffer in e.buffers:
     # Check if buffer is modified and has a file path
     if buffer.isModified and buffer.filePath.isSome:
       let savePath = buffer.filePath.get
@@ -359,7 +352,6 @@ proc autoSave*(e: Editor) =
       let saveResult = buffer.saveFile(savePath, checkExternalMod = true)
 
       if saveResult.isOk:
-        savedBufferIds.incl(buffer.id)
         savedCount += 1
         savedPaths.add(savePath)
 
@@ -427,26 +419,18 @@ proc autoBackup*(e: Editor) =
   if backupElapsed < backupThreshold:
     return
 
-  # Backup all modified buffers
+  # Iterate `e.buffers`, not windows: windows only expose foreground tabs,
+  # so background-tab buffers would silently miss auto backup.
   var backupCount = 0
   var backupPaths: seq[string] = @[]
-  var backedUpBufferIds = initHashSet[BufferId]()
-    # Track already backed up buffers to avoid duplicates
 
-  for window in e.windowManager.windows:
-    let buffer = window.buffer
-
-    # Skip if already backed up (same buffer in multiple windows)
-    if buffer.id in backedUpBufferIds:
-      continue
-
+  for buffer in e.buffers:
     # Only backup modified buffers with a file path
     if buffer.isModified and buffer.filePath.isSome:
       let backupResult =
         backupBuffer(buffer.filePath, buffer.getFileContent(), e.config.autoBackup)
 
       if backupResult.isOk:
-        backedUpBufferIds.incl(buffer.id)
         backupCount += 1
         backupPaths.add(backupResult.get)
 

--- a/tests/test_editor_file.nim
+++ b/tests/test_editor_file.nim
@@ -680,6 +680,40 @@ suite "Editor - autoSave":
     let content = readFile(testFile)
     check content == "Original"
 
+  test "Auto save saves background-tab buffers":
+    # Regression: iterating windowManager.windows only reaches foreground tabs,
+    # so a modified background-tab buffer would silently lose its edits.
+    var config = newEditorConfig()
+    config.autoSave.enable = true
+    config.autoSave.interval = 1
+    let e = createTestEditorWithConfig(config)
+
+    let fgFile = getTempDir() / "moe_test_autosave_fg.txt"
+    let bgFile = getTempDir() / "moe_test_autosave_bg.txt"
+
+    writeFile(fgFile, "fg-original")
+    writeFile(bgFile, "bg-original")
+    defer:
+      removeFile(fgFile)
+      removeFile(bgFile)
+
+    discard e.loadFile(fgFile)
+    discard e.activeBuffer.insertText(BufferPosition(line: 0, column: 0), "F:")
+
+    # Background buffer: registered in e.buffers but not shown in any window.
+    let bgBuf = newTextBuffer("bg-original", some(bgFile))
+    e.addBuffer(bgBuf)
+    discard bgBuf.insertText(BufferPosition(line: 0, column: 0), "B:")
+    check bgBuf.isModified
+
+    e.state.timing.lastAutoSave = getMonoTime() - initDuration(hours = 1)
+
+    e.autoSave()
+
+    check not e.activeBuffer.isModified
+    check not bgBuf.isModified
+    check readFile(bgFile).startsWith("B:bg-original")
+
 suite "Editor - autoBackup":
   test "Auto backup does nothing when disabled":
     var config = newEditorConfig()
@@ -717,6 +751,53 @@ suite "Editor - autoBackup":
 
     # Should not backup because interval not passed
     e.autoBackup()
+
+  test "Auto backup backs up background-tab buffers":
+    # Regression: iterating windowManager.windows only reaches foreground tabs,
+    # so a modified background-tab buffer would silently miss auto backup.
+    let backupDir = getTempDir() / "moe_test_autobackup_bg_dir"
+    if dirExists(backupDir):
+      removeDir(backupDir)
+    defer:
+      if dirExists(backupDir):
+        removeDir(backupDir)
+
+    var config = newEditorConfig()
+    config.autoBackup.enable = true
+    config.autoBackup.idleTime = 0
+    config.autoBackup.interval = 1
+    config.autoBackup.backupDir = some(backupDir)
+    let e = createTestEditorWithConfig(config)
+
+    let fgFile = getTempDir() / "moe_test_autobackup_fg.txt"
+    let bgFile = getTempDir() / "moe_test_autobackup_bg.txt"
+
+    writeFile(fgFile, "fg-original")
+    writeFile(bgFile, "bg-original")
+    defer:
+      removeFile(fgFile)
+      removeFile(bgFile)
+
+    discard e.loadFile(fgFile)
+    discard e.activeBuffer.insertText(BufferPosition(line: 0, column: 0), "F:")
+
+    # Background buffer: registered in e.buffers but not shown in any window.
+    let bgBuf = newTextBuffer("bg-original", some(bgFile))
+    e.addBuffer(bgBuf)
+    discard bgBuf.insertText(BufferPosition(line: 0, column: 0), "B:")
+
+    e.state.timing.lastInputTime = getMonoTime() - initDuration(hours = 1)
+    e.state.timing.lastAutoBackup = getMonoTime() - initDuration(hours = 1)
+
+    e.autoBackup()
+
+    # Each source file gets its own subdirectory under `backupDir`. Two
+    # subdirectories means both foreground and background buffers were backed
+    # up; before the fix only the foreground buffer would produce one.
+    var subdirCount = 0
+    for _ in walkDir(backupDir):
+      subdirCount += 1
+    check subdirCount == 2
 
 suite "Editor - refreshGitDiff":
   test "Refresh git diff does not crash on non-git file":


### PR DESCRIPTION
…und tabs cannot silently lose unsaved edits