### PR TITLE
refactor(input): add frontend-neutral GUI boundaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ lasm.log
 moe-debug.log
 
 nimbledeps/
+/deps/
+nim.cfg

--- a/src/moepkg/command_handlers/command_mode_handler.nim
+++ b/src/moepkg/command_handlers/command_mode_handler.nim
@@ -434,7 +434,7 @@ proc handleCommandModeKeyCombo*(e: Editor, keyCombo: KeyCombo): bool =
     e.state.input.commandText =
       e.state.input.commandText[0 ..< bytePos] & keyCombo.char &
       e.state.input.commandText[bytePos ..^ 1]
-    e.state.input.commandCursor += 1
+    e.state.input.commandCursor += keyCombo.char.runeLen
     # Handle completion
     let mgr = e.state.commandCompletionManager
     let hasSpace = ' ' in e.state.input.commandText

--- a/src/moepkg/frontend_input.nim
+++ b/src/moepkg/frontend_input.nim
@@ -20,8 +20,9 @@
 ## Frontend-neutral pointer and scrolling input.
 ##
 ## Coordinates are cells in Moe's rendered grid. A GUI frontend should convert
-## view coordinates before constructing these values. Positive `deltaRows`
-## scrolls toward later buffer rows; negative values scroll toward earlier rows.
+## view coordinates before constructing these values. Positive
+## `deltaPhysicalRows` scrolls toward later buffer lines; negative values scroll
+## toward earlier lines.
 
 import key_bindings/registry
 export registry.KeyModifier
@@ -58,21 +59,21 @@ type
   ScrollInput* = object
     row*: int
     column*: int
-    deltaRows*: int
+    deltaPhysicalRows*: int
     modifiers*: set[KeyModifier]
 
   ScrollOutcome* = object
-    ## Result of applying a semantic row scroll.
+    ## Result of applying a semantic physical-line scroll.
     ##
-    ## A GUI bridge can translate `region` when `viewportRowsMoved != 0`, while
-    ## repainting ordinary cell changes (such as cursor movement) without moving
-    ## the surrounding tab/status rows. Movement fields are signed: positive is
-    ## toward later buffer rows.
+    ## Movement fields are signed physical-line deltas (positive means later
+    ## lines); grid-row conversion under line wrap is the consumer's job.
+    ## `viewportPhysicalRowsMoved` is a pre-layout approximation that may be 0
+    ## or short. It is a repaint hint, not an exact translation amount.
     handled*: bool
     region*: GridRegion
     requestedRows*: int
     appliedRows*: int
-    viewportRowsMoved*: int
+    viewportPhysicalRowsMoved*: int
 
 func initGridRegion*(row, column, rows, columns: int): GridRegion =
   GridRegion(row: row, column: column, rows: max(rows, 0), columns: max(columns, 0))
@@ -94,6 +95,8 @@ func initPointerInput*(
   )
 
 func initScrollInput*(
-    row, column, deltaRows: int, modifiers: set[KeyModifier] = {}
+    row, column, deltaPhysicalRows: int, modifiers: set[KeyModifier] = {}
 ): ScrollInput =
-  ScrollInput(row: row, column: column, deltaRows: deltaRows, modifiers: modifiers)
+  ScrollInput(
+    row: row, column: column, deltaPhysicalRows: deltaPhysicalRows, modifiers: modifiers
+  )

--- a/src/moepkg/frontend_input.nim
+++ b/src/moepkg/frontend_input.nim
@@ -27,6 +27,14 @@ import key_bindings/registry
 export registry.KeyModifier
 
 type
+  GridRegion* = object
+    ## Rectangular region in Moe's rendered cell grid.
+    ## `rows` and `columns` are always non-negative for regions returned by Moe.
+    row*: int
+    column*: int
+    rows*: int
+    columns*: int
+
   PointerButton* = enum
     pbPrimary
     pbMiddle
@@ -52,6 +60,27 @@ type
     column*: int
     deltaRows*: int
     modifiers*: set[KeyModifier]
+
+  ScrollOutcome* = object
+    ## Result of applying a semantic row scroll.
+    ##
+    ## A GUI bridge can translate `region` when `viewportRowsMoved != 0`, while
+    ## repainting ordinary cell changes (such as cursor movement) without moving
+    ## the surrounding tab/status rows. Movement fields are signed: positive is
+    ## toward later buffer rows.
+    handled*: bool
+    region*: GridRegion
+    requestedRows*: int
+    appliedRows*: int
+    viewportRowsMoved*: int
+
+func initGridRegion*(row, column, rows, columns: int): GridRegion =
+  GridRegion(
+    row: row,
+    column: column,
+    rows: max(rows, 0),
+    columns: max(columns, 0),
+  )
 
 func initPointerInput*(
     row, column: int,

--- a/src/moepkg/frontend_input.nim
+++ b/src/moepkg/frontend_input.nim
@@ -1,0 +1,77 @@
+#[###################### GNU General Public License 3.0 ######################]#
+#                                                                              #
+#  Copyright (C) 2017─2026 Shuhei Nogawa                                       #
+#                                                                              #
+#  This program is free software: you can redistribute it and/or modify        #
+#  it under the terms of the GNU General Public License as published by        #
+#  the Free Software Foundation, either version 3 of the License, or           #
+#  (at your option) any later version.                                         #
+#                                                                              #
+#  This program is distributed in the hope that it will be useful,             #
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of              #
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the               #
+#  GNU General Public License for more details.                                #
+#                                                                              #
+#  You should have received a copy of the GNU General Public License           #
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.      #
+#                                                                              #
+#[############################################################################]#
+
+## Frontend-neutral pointer and scrolling input.
+##
+## Coordinates are cells in Moe's rendered grid. A GUI frontend should convert
+## view coordinates before constructing these values. Positive `deltaRows`
+## scrolls toward later buffer rows; negative values scroll toward earlier rows.
+
+import key_bindings/registry
+export registry.KeyModifier
+
+type
+  PointerButton* = enum
+    pbPrimary
+    pbMiddle
+    pbSecondary
+    pbOther
+
+  PointerAction* = enum
+    paPress
+    paRelease
+    paMove
+    paDrag
+
+  PointerInput* = object
+    row*: int
+    column*: int
+    button*: PointerButton
+    action*: PointerAction
+    clickCount*: Natural
+    modifiers*: set[KeyModifier]
+
+  ScrollInput* = object
+    row*: int
+    column*: int
+    deltaRows*: int
+    modifiers*: set[KeyModifier]
+
+func initPointerInput*(
+    row, column: int,
+    button = pbPrimary,
+    action = paPress,
+    clickCount: Natural = 1,
+    modifiers: set[KeyModifier] = {},
+): PointerInput =
+  PointerInput(
+    row: row,
+    column: column,
+    button: button,
+    action: action,
+    clickCount: clickCount,
+    modifiers: modifiers,
+  )
+
+func initScrollInput*(
+    row, column, deltaRows: int, modifiers: set[KeyModifier] = {}
+): ScrollInput =
+  ScrollInput(
+    row: row, column: column, deltaRows: deltaRows, modifiers: modifiers
+  )

--- a/src/moepkg/frontend_input.nim
+++ b/src/moepkg/frontend_input.nim
@@ -75,12 +75,7 @@ type
     viewportRowsMoved*: int
 
 func initGridRegion*(row, column, rows, columns: int): GridRegion =
-  GridRegion(
-    row: row,
-    column: column,
-    rows: max(rows, 0),
-    columns: max(columns, 0),
-  )
+  GridRegion(row: row, column: column, rows: max(rows, 0), columns: max(columns, 0))
 
 func initPointerInput*(
     row, column: int,
@@ -101,6 +96,4 @@ func initPointerInput*(
 func initScrollInput*(
     row, column, deltaRows: int, modifiers: set[KeyModifier] = {}
 ): ScrollInput =
-  ScrollInput(
-    row: row, column: column, deltaRows: deltaRows, modifiers: modifiers
-  )
+  ScrollInput(row: row, column: column, deltaRows: deltaRows, modifiers: modifiers)

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -500,12 +500,12 @@ proc scrollRegion(e: Editor, window: EditorWindow): GridRegion =
   )
 
 proc handleScrollInputCore(e: Editor, input: ScrollInput): ScrollOutcome =
-  ## Apply a frontend-neutral, cell-based vertical scroll and describe the
-  ## affected rendered region for GUI interpolation.
-  result.requestedRows = input.deltaRows
+  ## Apply a frontend-neutral physical-line scroll and describe the affected
+  ## rendered region for GUI repainting.
+  result.requestedRows = input.deltaPhysicalRows
   if not e.config.standard.mouse:
     return
-  if input.deltaRows == 0:
+  if input.deltaPhysicalRows == 0:
     return
   if e.windowManager.windows.len == 0:
     return
@@ -517,12 +517,13 @@ proc handleScrollInputCore(e: Editor, input: ScrollInput): ScrollOutcome =
     let previousIndex = filerState.selectedIndex
     let previousTopLine = window.viewport.topLine
     if filerState.entries.len > 0:
-      filerState.selectedIndex =
-        clamp(filerState.selectedIndex + input.deltaRows, 0, filerState.entries.high)
+      filerState.selectedIndex = clamp(
+        filerState.selectedIndex + input.deltaPhysicalRows, 0, filerState.entries.high
+      )
     result.handled = true
     result.region = e.scrollRegion(window)
     result.appliedRows = filerState.selectedIndex - previousIndex
-    result.viewportRowsMoved = window.viewport.topLine - previousTopLine
+    result.viewportPhysicalRowsMoved = window.viewport.topLine - previousTopLine
     return
 
   # Handle text editing modes.
@@ -535,7 +536,7 @@ proc handleScrollInputCore(e: Editor, input: ScrollInput): ScrollOutcome =
     let curLine = window.cursor.line
     let previousTopLine = window.viewport.topLine
     let maxLine = window.buffer.len - 1
-    let newLine = clamp(curLine + input.deltaRows, 0, maxLine)
+    let newLine = clamp(curLine + input.deltaPhysicalRows, 0, maxLine)
 
     if newLine != curLine:
       window.cursor = BufferPosition(line: newLine, column: window.cursor.column)
@@ -557,11 +558,8 @@ proc handleScrollInputCore(e: Editor, input: ScrollInput): ScrollOutcome =
     result.handled = true
     result.region = e.scrollRegion(window)
     result.appliedRows = newLine - curLine
-    result.viewportRowsMoved = window.viewport.topLine - previousTopLine
+    result.viewportPhysicalRowsMoved = window.viewport.topLine - previousTopLine
     return
-
-  result.handled = true
-  result.region = e.scrollRegion(e.activeWindow)
 
 proc handlePointerInputCore(e: Editor, input: PointerInput): bool =
   ## Apply a frontend-neutral pointer event expressed in rendered grid cells.
@@ -772,8 +770,8 @@ proc handlePointerInput*(e: Editor, input: PointerInput): bool =
   e.handlePointerInputCore(input)
 
 proc handleScrollInput*(e: Editor, input: ScrollInput): ScrollOutcome =
-  ## Handle a vertical scroll expressed as a signed number of grid rows and
-  ## return the movement/region metadata needed for GUI interpolation.
+  ## Handle a vertical scroll expressed as a signed number of physical lines
+  ## and return the movement/region metadata needed for GUI repainting.
   e.prepareForInput(false)
   e.handleScrollInputCore(input)
 

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -478,14 +478,12 @@ proc scrollTargetIndex(e: Editor, input: ScrollInput): int =
   if e.windowManager.windows.len == 0:
     return -1
 
-  result = clamp(
-    e.windowManager.activeWindowIndex, 0, e.windowManager.windows.high
-  )
+  result = clamp(e.windowManager.activeWindowIndex, 0, e.windowManager.windows.high)
   if e.windowManager.windows.len > 1:
     for i, window in e.windowManager.windows:
       let vp = window.viewport
-      if input.column >= vp.x and input.column < vp.x + vp.width and
-          input.row >= vp.y and input.row < vp.y + vp.height:
+      if input.column >= vp.x and input.column < vp.x + vp.width and input.row >= vp.y and
+          input.row < vp.y + vp.height:
         return i
 
 proc scrollRegion(e: Editor, window: EditorWindow): GridRegion =
@@ -498,10 +496,7 @@ proc scrollRegion(e: Editor, window: EditorWindow): GridRegion =
     tabLineOffset = if e.showTabLine: TabLineHeight else: 0
     reservedLines = e.calculateReservedLines(isBottomWindow)
   initGridRegion(
-    vp.y + tabLineOffset,
-    vp.x,
-    vp.height - tabLineOffset - reservedLines,
-    vp.width,
+    vp.y + tabLineOffset, vp.x, vp.height - tabLineOffset - reservedLines, vp.width
   )
 
 proc handleScrollInputCore(e: Editor, input: ScrollInput): ScrollOutcome =
@@ -612,8 +607,8 @@ proc handlePointerInputCore(e: Editor, input: PointerInput): bool =
       for i, window in e.windowManager.windows:
         let vp = window.viewport
         # Check if click is within this window's viewport
-        if input.column >= vp.x and input.column < vp.x + vp.width and
-            input.row >= vp.y and input.row < vp.y + vp.height:
+        if input.column >= vp.x and input.column < vp.x + vp.width and input.row >= vp.y and
+            input.row < vp.y + vp.height:
           let
             # Same reserve the renderer uses, so the hit test cannot claim the
             # shared status/command row nor drop a real text row.
@@ -809,9 +804,7 @@ proc handleMouseEvent*(e: Editor, event: Event): bool =
   of mouse_logic.MouseButton.WheelDown:
     e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, 3, modifiers)).handled
   of mouse_logic.MouseButton.Left:
-    e.handlePointerInputCore(
-      initPointerInput(mouse.y, mouse.x, modifiers = modifiers)
-    )
+    e.handlePointerInputCore(initPointerInput(mouse.y, mouse.x, modifiers = modifiers))
   else:
     false
 

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -473,38 +473,72 @@ proc finalizeCurrentWindowForMouseJump(e: Editor) =
   e.state.previousMode = e.state.mode
   e.state.mode = EditorMode.Normal
 
-proc handleScrollInputCore(e: Editor, input: ScrollInput): bool =
-  ## Apply a frontend-neutral, cell-based vertical scroll.
+proc scrollTargetIndex(e: Editor, input: ScrollInput): int =
+  ## Resolve the window under a cell-coordinate scroll, falling back to active.
+  if e.windowManager.windows.len == 0:
+    return -1
+
+  result = clamp(
+    e.windowManager.activeWindowIndex, 0, e.windowManager.windows.high
+  )
+  if e.windowManager.windows.len > 1:
+    for i, window in e.windowManager.windows:
+      let vp = window.viewport
+      if input.column >= vp.x and input.column < vp.x + vp.width and
+          input.row >= vp.y and input.row < vp.y + vp.height:
+        return i
+
+proc scrollRegion(e: Editor, window: EditorWindow): GridRegion =
+  ## Grid rows belonging to scrollable window content. Tab and bottom/status
+  ## rows are deliberately excluded so a GUI bridge can leave them stationary.
+  let
+    vp = window.viewport
+    maxBottomY = findMaxBottomY(e.windowManager.windows)
+    isBottomWindow = vp.y + vp.height == maxBottomY
+    tabLineOffset = if e.showTabLine: TabLineHeight else: 0
+    reservedLines = e.calculateReservedLines(isBottomWindow)
+  initGridRegion(
+    vp.y + tabLineOffset,
+    vp.x,
+    vp.height - tabLineOffset - reservedLines,
+    vp.width,
+  )
+
+proc handleScrollInputCore(e: Editor, input: ScrollInput): ScrollOutcome =
+  ## Apply a frontend-neutral, cell-based vertical scroll and describe the
+  ## affected rendered region for GUI interpolation.
+  result.requestedRows = input.deltaRows
   if not e.config.standard.mouse:
-    return false
+    return
   if input.deltaRows == 0:
-    return false
+    return
+  if e.windowManager.windows.len == 0:
+    return
 
   # Handle Filer mode scroll.
   if e.state.mode == EditorMode.Filer and e.activeWindow.modeState.kind == mskFiler:
+    let window = e.activeWindow
     let filerState = e.activeWindow.modeState.filer
+    let previousIndex = filerState.selectedIndex
+    let previousTopLine = window.viewport.topLine
     if filerState.entries.len > 0:
       filerState.selectedIndex =
         clamp(filerState.selectedIndex + input.deltaRows, 0, filerState.entries.high)
-    return true
+    result.handled = true
+    result.region = e.scrollRegion(window)
+    result.appliedRows = filerState.selectedIndex - previousIndex
+    result.viewportRowsMoved = window.viewport.topLine - previousTopLine
+    return
 
   # Handle text editing modes.
   if e.state.mode in {
     EditorMode.Normal, EditorMode.Insert, EditorMode.Visual, EditorMode.VisualLine,
     EditorMode.VisualBlock, EditorMode.Replace,
   }:
-    # Determine target window by pointer position.
-    var targetIdx = e.windowManager.activeWindowIndex
-    if e.windowManager.windows.len > 1:
-      for i, window in e.windowManager.windows:
-        let vp = window.viewport
-        if input.column >= vp.x and input.column < vp.x + vp.width and
-            input.row >= vp.y and input.row < vp.y + vp.height:
-          targetIdx = i
-          break
-
+    let targetIdx = e.scrollTargetIndex(input)
     let window = e.windowManager.windows[targetIdx]
     let curLine = window.cursor.line
+    let previousTopLine = window.viewport.topLine
     let maxLine = window.buffer.len - 1
     let newLine = clamp(curLine + input.deltaRows, 0, maxLine)
 
@@ -525,9 +559,14 @@ proc handleScrollInputCore(e: Editor, input: ScrollInput): bool =
         elif newLine >= window.viewport.topLine + viewportHeight:
           window.viewport.resetViewportTop(newLine - viewportHeight + 1)
 
-    return true
+    result.handled = true
+    result.region = e.scrollRegion(window)
+    result.appliedRows = newLine - curLine
+    result.viewportRowsMoved = window.viewport.topLine - previousTopLine
+    return
 
-  return true
+  result.handled = true
+  result.region = e.scrollRegion(e.activeWindow)
 
 proc handlePointerInputCore(e: Editor, input: PointerInput): bool =
   ## Apply a frontend-neutral pointer event expressed in rendered grid cells.
@@ -737,8 +776,9 @@ proc handlePointerInput*(e: Editor, input: PointerInput): bool =
   e.prepareForInput(false)
   e.handlePointerInputCore(input)
 
-proc handleScrollInput*(e: Editor, input: ScrollInput): bool =
-  ## Handle a vertical scroll expressed as a signed number of grid rows.
+proc handleScrollInput*(e: Editor, input: ScrollInput): ScrollOutcome =
+  ## Handle a vertical scroll expressed as a signed number of grid rows and
+  ## return the movement/region metadata needed for GUI interpolation.
   e.prepareForInput(false)
   e.handleScrollInputCore(input)
 
@@ -765,9 +805,9 @@ proc handleMouseEvent*(e: Editor, event: Event): bool =
   let modifiers = celinaMouseModifiers(mouse.modifiers)
   case mouse.button
   of mouse_logic.MouseButton.WheelUp:
-    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, -3, modifiers))
+    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, -3, modifiers)).handled
   of mouse_logic.MouseButton.WheelDown:
-    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, 3, modifiers))
+    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, 3, modifiers)).handled
   of mouse_logic.MouseButton.Left:
     e.handlePointerInputCore(
       initPointerInput(mouse.y, mouse.x, modifiers = modifiers)

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -29,13 +29,13 @@ import
   editor, editor_window_layout, key_bindings, modes, buffer, logger, types, motion,
   quick_run_utils, command_completion, build, render_utils, tab_line, terminal_mode,
   clipboard, git_cache, cursor_util, syntax_checker, background_process, key_router,
-  pending_input, visible_rows, viewer_mode
+  pending_input, visible_rows, viewer_mode, frontend_input
 import
   command_handlers/[
     handler_manager, command_mode_handler, search_mode_handler, insert_commands,
     result_processor,
   ]
-export command_mode_handler, search_mode_handler, cursor_util
+export command_mode_handler, search_mode_handler, cursor_util, frontend_input
 
 # Wire the playback overlay hook so nested key replay routes to the overlay
 # handler when Command / Search overlay is active.
@@ -262,16 +262,12 @@ proc cursorAfterPaste(startPos: BufferPosition, pastedText: string): BufferPosit
       column += 1
   BufferPosition(line: line, column: column)
 
-proc handlePasteEvent*(e: Editor, event: Event): bool =
-  ## Handle paste events from Bracketed Paste Mode
-  ## Inserts pasted text without triggering auto-indentation
-  if event.kind != EventKind.Paste:
-    return true
-
+proc handlePasteText(e: Editor, text: string): bool =
+  ## Insert pasted text without triggering auto-indentation.
   # Normalize CRLF / lone CR to LF up front (matching loadFile) so a stray \r
   # never reaches line content and the cursor advance below counts line breaks
   # correctly. insertText normalizes again defensively for non-paste callers.
-  let pastedText = event.pastedText.normalizeNewlines()
+  let pastedText = text.normalizeNewlines()
   if pastedText.len == 0:
     return true
 
@@ -477,88 +473,70 @@ proc finalizeCurrentWindowForMouseJump(e: Editor) =
   e.state.previousMode = e.state.mode
   e.state.mode = EditorMode.Normal
 
-proc handleMouseEvent(e: Editor, event: Event): bool =
-  ## Handle mouse events for cursor movement
-  ## Returns true if the event was handled, false otherwise
-  if event.kind != EventKind.Mouse:
-    return false
+proc handleScrollInputCore(e: Editor, input: ScrollInput): bool =
+  ## Apply a frontend-neutral, cell-based vertical scroll.
   if not e.config.standard.mouse:
     return false
-
-  let mouse = event.mouse
-
-  # Middle-click paste is intercepted upstream in handleEvent.
-  if mouse.button notin {
-    mouse_logic.MouseButton.Left, mouse_logic.MouseButton.WheelUp,
-    mouse_logic.MouseButton.WheelDown,
-  }:
-    return false
-  if mouse.kind != celina.MouseEventKind.Press:
+  if input.deltaRows == 0:
     return false
 
-  # Handle wheel scroll events
-  if mouse.button in {
-    mouse_logic.MouseButton.WheelUp, mouse_logic.MouseButton.WheelDown
+  # Handle Filer mode scroll.
+  if e.state.mode == EditorMode.Filer and e.activeWindow.modeState.kind == mskFiler:
+    let filerState = e.activeWindow.modeState.filer
+    if filerState.entries.len > 0:
+      filerState.selectedIndex =
+        clamp(filerState.selectedIndex + input.deltaRows, 0, filerState.entries.high)
+    return true
+
+  # Handle text editing modes.
+  if e.state.mode in {
+    EditorMode.Normal, EditorMode.Insert, EditorMode.Visual, EditorMode.VisualLine,
+    EditorMode.VisualBlock, EditorMode.Replace,
   }:
-    const scrollLines = 3
+    # Determine target window by pointer position.
+    var targetIdx = e.windowManager.activeWindowIndex
+    if e.windowManager.windows.len > 1:
+      for i, window in e.windowManager.windows:
+        let vp = window.viewport
+        if input.column >= vp.x and input.column < vp.x + vp.width and
+            input.row >= vp.y and input.row < vp.y + vp.height:
+          targetIdx = i
+          break
 
-    # Handle Filer mode scroll
-    if e.state.mode == EditorMode.Filer and e.activeWindow.modeState.kind == mskFiler:
-      let filerState = e.activeWindow.modeState.filer
-      if filerState.entries.len > 0:
-        if mouse.button == mouse_logic.MouseButton.WheelUp:
-          filerState.selectedIndex = max(0, filerState.selectedIndex - scrollLines)
-        else:
-          filerState.selectedIndex =
-            min(filerState.entries.len - 1, filerState.selectedIndex + scrollLines)
-      return true
+    let window = e.windowManager.windows[targetIdx]
+    let curLine = window.cursor.line
+    let maxLine = window.buffer.len - 1
+    let newLine = clamp(curLine + input.deltaRows, 0, maxLine)
 
-    # Handle text editing modes
-    if e.state.mode in {
-      EditorMode.Normal, EditorMode.Insert, EditorMode.Visual, EditorMode.VisualLine,
-      EditorMode.VisualBlock, EditorMode.Replace,
-    }:
-      # Determine target window by mouse position
-      var targetIdx = e.windowManager.activeWindowIndex
-      if e.windowManager.windows.len > 1:
-        for i, window in e.windowManager.windows:
-          let vp = window.viewport
-          if mouse.x >= vp.x and mouse.x < vp.x + vp.width and mouse.y >= vp.y and
-              mouse.y < vp.y + vp.height:
-            targetIdx = i
-            break
+    if newLine != curLine:
+      window.cursor = BufferPosition(line: newLine, column: window.cursor.column)
+      # Clamp column to line length.
+      let lineLen = window.buffer[newLine].charLen
+      if lineLen > 0:
+        window.cursor.column = min(window.cursor.column, lineLen - 1)
+      else:
+        window.cursor.column = 0
 
-      let window = e.windowManager.windows[targetIdx]
-      let curLine = window.cursor.line
-      let maxLine = window.buffer.len - 1
-      let newLine =
-        if mouse.button == mouse_logic.MouseButton.WheelUp:
-          max(0, curLine - scrollLines)
-        else:
-          min(maxLine, curLine + scrollLines)
-
-      if newLine != curLine:
-        window.cursor = BufferPosition(line: newLine, column: window.cursor.column)
-        # Clamp column to line length
-        let lineLen = window.buffer[newLine].charLen
-        if lineLen > 0:
-          window.cursor.column = min(window.cursor.column, lineLen - 1)
-        else:
-          window.cursor.column = 0
-
-        # Update viewport topLine to keep cursor visible
-        let viewportHeight = window.viewport.height
-        if viewportHeight > 0:
-          if newLine < window.viewport.topLine:
-            window.viewport.resetViewportTop(newLine)
-          elif newLine >= window.viewport.topLine + viewportHeight:
-            window.viewport.resetViewportTop(newLine - viewportHeight + 1)
-
-      return true
+      # Update viewport topLine to keep cursor visible.
+      let viewportHeight = window.viewport.height
+      if viewportHeight > 0:
+        if newLine < window.viewport.topLine:
+          window.viewport.resetViewportTop(newLine)
+        elif newLine >= window.viewport.topLine + viewportHeight:
+          window.viewport.resetViewportTop(newLine - viewportHeight + 1)
 
     return true
 
-  # Handle mouse click in text editing modes
+  return true
+
+proc handlePointerInputCore(e: Editor, input: PointerInput): bool =
+  ## Apply a frontend-neutral pointer event expressed in rendered grid cells.
+  if not e.config.standard.mouse:
+    return false
+  if input.action != paPress or input.button != pbPrimary:
+    return false
+
+  # Handle pointer click in text editing modes.
   if e.state.mode in {
     EditorMode.Normal, EditorMode.Insert, EditorMode.Visual, EditorMode.VisualLine,
     EditorMode.VisualBlock, EditorMode.Replace,
@@ -569,7 +547,8 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
       if e.showTabLine:
         for i, window in e.windowManager.windows:
           let vp = window.viewport
-          if mouse.y == vp.y and mouse.x >= vp.x and mouse.x < vp.x + vp.width:
+          if input.row == vp.y and input.column >= vp.x and
+              input.column < vp.x + vp.width:
             # Resolve this window's per-window tab list to TextBuffer refs.
             var buffersToShow: seq[TextBuffer] = @[]
             for id in window.bufferIds:
@@ -579,7 +558,7 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
             if buffersToShow.len == 0:
               buffersToShow = @[window.buffer]
             let tabIdx =
-              hitTestTabLine(buffersToShow, window.mode, vp.x, vp.width, mouse.x)
+              hitTestTabLine(buffersToShow, window.mode, vp.x, vp.width, input.column)
             if tabIdx >= 0:
               if i != e.windowManager.activeWindowIndex:
                 e.finalizeCurrentWindowForMouseJump()
@@ -594,8 +573,8 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
       for i, window in e.windowManager.windows:
         let vp = window.viewport
         # Check if click is within this window's viewport
-        if mouse.x >= vp.x and mouse.x < vp.x + vp.width and mouse.y >= vp.y and
-            mouse.y < vp.y + vp.height:
+        if input.column >= vp.x and input.column < vp.x + vp.width and
+            input.row >= vp.y and input.row < vp.y + vp.height:
           let
             # Same reserve the renderer uses, so the hit test cannot claim the
             # shared status/command row nor drop a real text row.
@@ -603,8 +582,8 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
             posOpt = screenToBufferPosition(
               vp,
               window.buffer,
-              mouse.x,
-              mouse.y,
+              input.column,
+              input.row,
               e.gutterWidth(window),
               reservedLines,
               e.lineWrap,
@@ -632,7 +611,7 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
 
     # Single window mode
     # Check tab line click first
-    if e.showTabLine and mouse.y == 0:
+    if e.showTabLine and input.row == 0:
       var buffersToShow: seq[TextBuffer] = @[]
       for id in e.activeWindow.bufferIds:
         let bufOpt = e.bufferById(id)
@@ -641,7 +620,7 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
       if buffersToShow.len == 0:
         buffersToShow = @[e.activeBuffer()]
       let tabIdx =
-        hitTestTabLine(buffersToShow, e.state.mode, 0, e.viewport.width, mouse.x)
+        hitTestTabLine(buffersToShow, e.state.mode, 0, e.viewport.width, input.column)
       if tabIdx >= 0:
         e.switchToWindowBuffer(tabIdx)
         return true
@@ -652,11 +631,11 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
       reservedLines = steadyBottomAreaHeight()
       # Account for tab line offset
       tabLineOffset = if e.showTabLine: TabLineHeight else: 0
-      adjustedMouseY = mouse.y - tabLineOffset
+      adjustedMouseY = input.row - tabLineOffset
       posOpt = screenToBufferPosition(
         e.viewport,
         activeBuffer,
-        mouse.x,
+        input.column,
         adjustedMouseY,
         e.gutterWidth(e.activeWindow),
         reservedLines,
@@ -683,7 +662,7 @@ proc handleMouseEvent(e: Editor, event: Event): bool =
       # Same reserve the renderer uses, so the hit test maps to the drawn row.
       maxBottomY = findMaxBottomY(e.windowManager.windows)
       reservedLines = e.steadyReservedLines(vp.y + vp.height == maxBottomY)
-      screenY = mouse.y - vp.y - tabLineOffset
+      screenY = input.row - vp.y - tabLineOffset
 
     # Ignore clicks on tab line or status/command line area
     if screenY >= 0 and screenY < vp.height - tabLineOffset - reservedLines:
@@ -736,16 +715,68 @@ proc prepareForInput(e: Editor, isKeyInput: bool) =
   if isKeyInput and e.state.windowDisplay.scrollAnimation.active:
     cancelScrollAnimation(e.state.windowDisplay.scrollAnimation)
 
-proc prepareForEvent(e: Editor, event: Event) =
-  ## Per-event setup for Celina events.
-  e.prepareForInput(event.kind == EventKind.Key)
-
 proc prepareForKeyCombo(e: Editor) =
   ## Per-input setup for frontend-neutral key handling.
   e.prepareForInput(true)
 
-proc handleQuitEvent(e: Editor): bool =
-  ## Handle Ctrl-C (Quit event from celina). Behaviour depends on the
+proc handlePaste*(e: Editor, text: string): bool =
+  ## Handle pasted text supplied by any frontend.
+  e.prepareForInput(false)
+  e.handlePasteText(text)
+
+proc handlePasteEvent*(e: Editor, event: Event): bool =
+  ## Compatibility adapter for Celina bracketed-paste events.
+  if event.kind != EventKind.Paste:
+    return true
+  e.handlePaste(event.pastedText)
+
+proc handlePointerInput*(e: Editor, input: PointerInput): bool =
+  ## Handle a pointer event whose coordinates are cells in the rendered grid.
+  ## Middle-click paste is intentionally a host policy: GUI frontends should
+  ## obtain the selection text and pass it to `handlePaste`.
+  e.prepareForInput(false)
+  e.handlePointerInputCore(input)
+
+proc handleScrollInput*(e: Editor, input: ScrollInput): bool =
+  ## Handle a vertical scroll expressed as a signed number of grid rows.
+  e.prepareForInput(false)
+  e.handleScrollInputCore(input)
+
+proc celinaMouseModifiers(
+    modifiers: set[celina.KeyModifier]
+): set[key_bindings.KeyModifier] =
+  if celina.KeyModifier.Ctrl in modifiers:
+    result.incl(kmCtrl)
+  if celina.KeyModifier.Alt in modifiers:
+    result.incl(kmAlt)
+  if celina.KeyModifier.Shift in modifiers:
+    result.incl(kmShift)
+
+proc handleMouseEvent*(e: Editor, event: Event): bool =
+  ## Compatibility adapter from Celina mouse events to Moe input values.
+  e.prepareForInput(false)
+  if event.kind != EventKind.Mouse:
+    return false
+
+  let mouse = event.mouse
+  if mouse.kind != celina.MouseEventKind.Press:
+    return false
+
+  let modifiers = celinaMouseModifiers(mouse.modifiers)
+  case mouse.button
+  of mouse_logic.MouseButton.WheelUp:
+    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, -3, modifiers))
+  of mouse_logic.MouseButton.WheelDown:
+    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, 3, modifiers))
+  of mouse_logic.MouseButton.Left:
+    e.handlePointerInputCore(
+      initPointerInput(mouse.y, mouse.x, modifiers = modifiers)
+    )
+  else:
+    false
+
+proc handleInterruptCore(e: Editor): bool =
+  ## Handle Ctrl-C. Behaviour depends on the
   ## current mode/overlay: forward to Terminal PTY, cancel overlays, exit
   ## Insert-Normal, or transition file-edit modes back to Normal.
 
@@ -819,6 +850,11 @@ proc handleQuitEvent(e: Editor): bool =
     adjustCursorAfterInsertExit(e.activeWindow.cursor, lineCharLen)
 
   return true
+
+proc handleInterrupt*(e: Editor): bool =
+  ## Handle a frontend interrupt request, such as Ctrl-C in a terminal.
+  e.prepareForInput(false)
+  e.handleInterruptCore()
 
 proc dismissTempMessagesKeyCombo(e: Editor, keyCombo: KeyCombo): bool =
   ## Dismiss temporary messages (e.g. :jumps output) on any key.
@@ -1100,6 +1136,17 @@ proc handleKeyCombo*(e: Editor, keyCombo: KeyCombo): bool =
 
   return outcome != roQuit
 
+proc handleTextInput*(e: Editor, text: string): bool =
+  ## Handle committed text from a GUI text-input protocol.
+  ##
+  ## This is distinct from a physical key event so frontends can preserve IME,
+  ## dead-key, and composed Unicode input. Special keys and modified shortcuts
+  ## should still be sent through `handleKeyCombo`. `text` may contain more than
+  ## one rune, but paste operations should use `handlePaste`.
+  if text.len == 0:
+    return true
+  e.handleKeyCombo(KeyCombo(isSpecial: false, char: text, modifiers: {}))
+
 proc handleEvent*(e: Editor, event: Event): bool =
   ## Main event handler using the new handler manager system
   if event.kind == EventKind.Key:
@@ -1109,11 +1156,9 @@ proc handleEvent*(e: Editor, event: Event): bool =
       return true
     return e.handleKeyCombo(keyComboOpt.get)
 
-  prepareForEvent(e, event)
-
   # Handle Ctrl-C (Quit event from celina)
   if event.kind == EventKind.Quit:
-    return e.handleQuitEvent()
+    return e.handleInterrupt()
 
   # Handle mouse events first
   if event.kind == EventKind.Mouse:
@@ -1121,6 +1166,7 @@ proc handleEvent*(e: Editor, event: Event): bool =
     # is always enabled and would otherwise block the terminal's native paste.
     if event.mouse.button == mouse_logic.MouseButton.Middle and
         event.mouse.kind == celina.MouseEventKind.Press:
+      e.prepareForInput(false)
       e.middleClickPaste()
       return true
     discard e.handleMouseEvent(event)
@@ -1130,6 +1176,7 @@ proc handleEvent*(e: Editor, event: Event): bool =
   if event.kind == EventKind.Paste:
     return e.handlePasteEvent(event)
 
+  e.prepareForInput(false)
   return true
 
 type

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -1323,6 +1323,39 @@ suite "handleMouseEvent - Mouse Disabled":
     check handled == false
     check e.windowManager.windows[0].cursor.line == 0
 
+suite "frontend-neutral pointer and scroll input":
+  test "signed row delta controls scroll distance":
+    let e = createTestEditorWithBuffer(
+      "line0\nline1\nline2\nline3\nline4\nline5\nline6"
+    )
+    e.windowManager.windows[0].cursor = BufferPosition(line: 1, column: 0)
+
+    check e.handleScrollInput(initScrollInput(2, 10, 4))
+    check e.windowManager.windows[0].cursor.line == 5
+
+    check e.handleScrollInput(initScrollInput(2, 10, -2))
+    check e.windowManager.windows[0].cursor.line == 3
+
+  test "primary press uses rendered grid coordinates":
+    let e = createTestEditorWithBuffer("zero\none\ntwo\nthree")
+    e.state.showTabLine = false
+    e.state.showStatusLine = true
+
+    let handled = e.handlePointerInput(initPointerInput(2, 8))
+
+    check handled
+    check e.cursor.line == 2
+
+  test "non-primary pointer input remains available to the host":
+    let e = createTestEditorWithBuffer("zero\none")
+
+    let handled = e.handlePointerInput(
+      initPointerInput(1, 5, button = pbSecondary)
+    )
+
+    check not handled
+    check e.cursor.line == 0
+
 suite "handleMouseEvent - Wheel Scroll":
   test "WheelDown scrolls cursor down by 3 lines":
     let e = createTestEditorWithBuffer(
@@ -3023,6 +3056,16 @@ suite "handlePasteEvent":
   proc makePasteEvent(text: string): Event =
     Event(kind: EventKind.Paste, pastedText: text)
 
+  test "frontend-neutral paste does not require a Celina event":
+    let e = createTestEditorForPaste("")
+    e.state.mode = EditorMode.Insert
+
+    discard e.handlePaste("café\r\nnext")
+
+    check $e.activeBuffer.getLine(0) == "café"
+    check $e.activeBuffer.getLine(1) == "next"
+    check e.cursor == BufferPosition(line: 1, column: 4)
+
   test "Insert mode with active transaction - paste succeeds":
     let e = createTestEditorForPaste("hello")
     e.state.mode = EditorMode.Insert
@@ -3317,6 +3360,24 @@ suite "handleKeyCombo - frontend-neutral input":
     check e.state.isSearchOverlay
     check e.state.input.search.text == "w"
     check e.state.input.search.cursor == 1
+
+  test "committed GUI text can contain composed Unicode":
+    let e = createTestEditorWithBuffer("")
+    e.state.mode = EditorMode.Insert
+
+    discard e.handleTextInput("é🙂")
+
+    check $e.activeBuffer.getLine(0) == "é🙂"
+    check e.cursor.column == 2
+
+  test "multi-rune text advances the command cursor by runes":
+    let e = createTestEditorWithBuffer("")
+    e.state.enterCommandOverlay()
+
+    discard e.handleTextInput("λx")
+
+    check e.state.input.commandText == ":λx"
+    check e.state.input.commandCursor == 2
 
 suite "Macro recording - Command / Search overlay keys":
   # Regression: overlay dispatch used to bypass macro recording, so `qa:s/foo/bar/<CR>q`

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -1330,11 +1330,87 @@ suite "frontend-neutral pointer and scroll input":
     )
     e.windowManager.windows[0].cursor = BufferPosition(line: 1, column: 0)
 
-    check e.handleScrollInput(initScrollInput(2, 10, 4))
+    let down = e.handleScrollInput(initScrollInput(2, 10, 4))
+    check down.handled
+    check down.requestedRows == 4
+    check down.appliedRows == 4
+    check down.viewportRowsMoved == 0
     check e.windowManager.windows[0].cursor.line == 5
 
-    check e.handleScrollInput(initScrollInput(2, 10, -2))
+    let up = e.handleScrollInput(initScrollInput(2, 10, -2))
+    check up.handled
+    check up.requestedRows == -2
+    check up.appliedRows == -2
+    check up.viewportRowsMoved == 0
     check e.windowManager.windows[0].cursor.line == 3
+
+  test "outcome identifies the scrollable region and viewport movement":
+    let e = createTestEditorWithBuffer(
+      "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14"
+    )
+    e.state.showTabLine = true
+    e.state.showStatusLine = true
+    e.screenSize.width = 40
+    e.windowManager.windows[0].viewport =
+      ViewPort(x: 2, y: 3, width: 40, height: 8, topLine: 0, leftColumn: 0)
+    e.windowManager.windows[0].cursor = BufferPosition(line: 6, column: 0)
+
+    let outcome = e.handleScrollInput(initScrollInput(5, 10, 4))
+
+    check outcome.handled
+    check outcome.region == initGridRegion(4, 2, 6, 40)
+    check outcome.requestedRows == 4
+    check outcome.appliedRows == 4
+    check outcome.viewportRowsMoved == 3
+
+  test "outcome reports the movement actually applied at a buffer edge":
+    let e = createTestEditorWithBuffer("0\n1\n2")
+    e.windowManager.windows[0].cursor = BufferPosition(line: 1, column: 0)
+
+    let outcome = e.handleScrollInput(initScrollInput(2, 10, 8))
+
+    check outcome.handled
+    check outcome.requestedRows == 8
+    check outcome.appliedRows == 1
+    check outcome.viewportRowsMoved == 0
+
+  test "zero row input produces an unhandled outcome":
+    let e = createTestEditorWithBuffer("0\n1\n2")
+
+    let outcome = e.handleScrollInput(initScrollInput(2, 10, 0))
+
+    check not outcome.handled
+    check outcome.requestedRows == 0
+    check outcome.appliedRows == 0
+    check outcome.viewportRowsMoved == 0
+    check outcome.region == GridRegion()
+
+  test "outcome region follows the split window under the pointer":
+    let e = createTestEditorWithBuffer("left0\nleft1\nleft2\nleft3")
+    e.state.showTabLine = false
+    e.state.showStatusLine = true
+    e.screenSize.width = 80
+    e.windowManager.windows[0].viewport =
+      ViewPort(x: 0, y: 0, width: 40, height: 24, topLine: 0, leftColumn: 0)
+    let rightBuffer = newTextBuffer("right0\nright1\nright2\nright3\nright4")
+    let rightWindow = EditorWindow(
+      buffer: rightBuffer,
+      bufferIds: @[rightBuffer.id],
+      viewport:
+        ViewPort(x: 40, y: 0, width: 40, height: 24, topLine: 0, leftColumn: 0),
+      cursor: BufferPosition(line: 0, column: 0),
+      active: false,
+      mode: EditorMode.Normal,
+    )
+    e.windowManager.windows.add(rightWindow)
+
+    let outcome = e.handleScrollInput(initScrollInput(5, 50, 3))
+
+    check outcome.handled
+    check outcome.region == initGridRegion(0, 40, 23, 40)
+    check outcome.appliedRows == 3
+    check e.windowManager.windows[0].cursor.line == 0
+    check e.windowManager.windows[1].cursor.line == 3
 
   test "primary press uses rendered grid coordinates":
     let e = createTestEditorWithBuffer("zero\none\ntwo\nthree")

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -1325,9 +1325,8 @@ suite "handleMouseEvent - Mouse Disabled":
 
 suite "frontend-neutral pointer and scroll input":
   test "signed row delta controls scroll distance":
-    let e = createTestEditorWithBuffer(
-      "line0\nline1\nline2\nline3\nline4\nline5\nline6"
-    )
+    let e =
+      createTestEditorWithBuffer("line0\nline1\nline2\nline3\nline4\nline5\nline6")
     e.windowManager.windows[0].cursor = BufferPosition(line: 1, column: 0)
 
     let down = e.handleScrollInput(initScrollInput(2, 10, 4))
@@ -1345,9 +1344,8 @@ suite "frontend-neutral pointer and scroll input":
     check e.windowManager.windows[0].cursor.line == 3
 
   test "outcome identifies the scrollable region and viewport movement":
-    let e = createTestEditorWithBuffer(
-      "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14"
-    )
+    let e =
+      createTestEditorWithBuffer("0\n1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n13\n14")
     e.state.showTabLine = true
     e.state.showStatusLine = true
     e.screenSize.width = 40
@@ -1396,8 +1394,7 @@ suite "frontend-neutral pointer and scroll input":
     let rightWindow = EditorWindow(
       buffer: rightBuffer,
       bufferIds: @[rightBuffer.id],
-      viewport:
-        ViewPort(x: 40, y: 0, width: 40, height: 24, topLine: 0, leftColumn: 0),
+      viewport: ViewPort(x: 40, y: 0, width: 40, height: 24, topLine: 0, leftColumn: 0),
       cursor: BufferPosition(line: 0, column: 0),
       active: false,
       mode: EditorMode.Normal,
@@ -1425,9 +1422,7 @@ suite "frontend-neutral pointer and scroll input":
   test "non-primary pointer input remains available to the host":
     let e = createTestEditorWithBuffer("zero\none")
 
-    let handled = e.handlePointerInput(
-      initPointerInput(1, 5, button = pbSecondary)
-    )
+    let handled = e.handlePointerInput(initPointerInput(1, 5, button = pbSecondary))
 
     check not handled
     check e.cursor.line == 0

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -1333,14 +1333,14 @@ suite "frontend-neutral pointer and scroll input":
     check down.handled
     check down.requestedRows == 4
     check down.appliedRows == 4
-    check down.viewportRowsMoved == 0
+    check down.viewportPhysicalRowsMoved == 0
     check e.windowManager.windows[0].cursor.line == 5
 
     let up = e.handleScrollInput(initScrollInput(2, 10, -2))
     check up.handled
     check up.requestedRows == -2
     check up.appliedRows == -2
-    check up.viewportRowsMoved == 0
+    check up.viewportPhysicalRowsMoved == 0
     check e.windowManager.windows[0].cursor.line == 3
 
   test "outcome identifies the scrollable region and viewport movement":
@@ -1359,7 +1359,7 @@ suite "frontend-neutral pointer and scroll input":
     check outcome.region == initGridRegion(4, 2, 6, 40)
     check outcome.requestedRows == 4
     check outcome.appliedRows == 4
-    check outcome.viewportRowsMoved == 3
+    check outcome.viewportPhysicalRowsMoved == 3
 
   test "outcome reports the movement actually applied at a buffer edge":
     let e = createTestEditorWithBuffer("0\n1\n2")
@@ -1370,7 +1370,7 @@ suite "frontend-neutral pointer and scroll input":
     check outcome.handled
     check outcome.requestedRows == 8
     check outcome.appliedRows == 1
-    check outcome.viewportRowsMoved == 0
+    check outcome.viewportPhysicalRowsMoved == 0
 
   test "zero row input produces an unhandled outcome":
     let e = createTestEditorWithBuffer("0\n1\n2")
@@ -1380,8 +1380,49 @@ suite "frontend-neutral pointer and scroll input":
     check not outcome.handled
     check outcome.requestedRows == 0
     check outcome.appliedRows == 0
-    check outcome.viewportRowsMoved == 0
+    check outcome.viewportPhysicalRowsMoved == 0
     check outcome.region == GridRegion()
+
+  test "unsupported mode produces an unhandled outcome":
+    let e = createTestEditorWithBuffer("0\n1\n2")
+    e.state.mode = EditorMode.Help
+
+    let outcome = e.handleScrollInput(initScrollInput(2, 10, 1))
+
+    check not outcome.handled
+    check outcome.requestedRows == 1
+    check outcome.appliedRows == 0
+    check outcome.viewportPhysicalRowsMoved == 0
+    check outcome.region == GridRegion()
+
+  test "wrapped text outcome remains physical-line based":
+    let e = createTestEditorWithBuffer("abcdefghij\nnext")
+    e.state.lineWrap = true
+    e.windowManager.windows[0].viewport =
+      ViewPort(x: 0, y: 0, width: 5, height: 2, topLine: 0, leftColumn: 0)
+
+    let outcome = e.handleScrollInput(initScrollInput(0, 0, 1))
+
+    check outcome.handled
+    check outcome.appliedRows == 1
+    check outcome.viewportPhysicalRowsMoved == 0
+    check e.cursor.line == 1
+
+  test "Filer outcome reports selection movement before layout":
+    let e = createTestEditorWithBuffer("")
+    e.state.mode = EditorMode.Filer
+    var filerState =
+      FilerState(currentPath: "/tmp", entries: @[], selectedIndex: 0, showHidden: false)
+    for i in 0 ..< 10:
+      filerState.entries.add(FileEntry(name: "file" & $i, kind: fekFile))
+    e.windowManager.windows[0].modeState = ModeState(kind: mskFiler, filer: filerState)
+
+    let outcome = e.handleScrollInput(initScrollInput(0, 0, 3))
+
+    check outcome.handled
+    check outcome.appliedRows == 3
+    check outcome.viewportPhysicalRowsMoved == 0
+    check e.activeWindow.modeState.filer.selectedIndex == 3
 
   test "outcome region follows the split window under the pointer":
     let e = createTestEditorWithBuffer("left0\nleft1\nleft2\nleft3")


### PR DESCRIPTION
Adds a frontend-neutral pointer/scroll API to Moe while keeping Celina as the terminal compatibility adapter. Scroll handling now returns the actual movement and precise content-grid region, excluding fixed UI such as tab and status lines. This enables GUIs to add scrolling animation.

With this PR GUIs can re-use Celina's Buffer types while still letting the GUI handle mouse input in addition to keyboards. This approach avoids a larger refactor to introduce a rendering bridge which adds a lot of complexity. This could be done in the future, but Celina Buffer seems to provide a good bridge for this currently.