### PR TITLE
Add results imports for none-async modes

### DIFF
--- a/src/moepkg/colorcode.nim
+++ b/src/moepkg/colorcode.nim
@@ -24,7 +24,7 @@
 
 import std/[options, hashes, unicode]
 
-import pkg/celina
+import pkg/[celina, results]
 
 import color
 

--- a/src/moepkg/editor_render_modes.nim
+++ b/src/moepkg/editor_render_modes.nim
@@ -21,7 +21,7 @@
 
 import std/[options, strutils]
 
-import pkg/celina
+import pkg/[celina, results]
 
 import
   types/editor_types,


### PR DESCRIPTION
Without these imports non-async backends break since results types aren't imported.