### PR TITLE
Add Ctrl-E and Ctrl-Y line scrolling shortcuts

### DIFF
--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -87,6 +87,8 @@
 | <kbd>**Ctrl**</kbd> <kbd>**f**</kbd> | Page Down |
 | <kbd>**Ctrl**</kbd> <kbd>**u**</kbd> | Half Page Up |
 | <kbd>**Ctrl**</kbd> <kbd>**d**</kbd> | Half Page Down |
+| <kbd>**Ctrl**</kbd> <kbd>**e**</kbd> | Scroll one line down |
+| <kbd>**Ctrl**</kbd> <kbd>**y**</kbd> | Scroll one line up |
 | <kbd>**%**</kbd> | Move to matching pair of paren |
 | <kbd>**d**</kbd> <kbd>**$**</kbd> OR <kbd>**D**</kbd> | Delete until the end of the line |
 | <kbd>**C**</kbd> | Change until the end of the line |

--- a/src/moepkg/command_registry/core.nim
+++ b/src/moepkg/command_registry/core.nim
@@ -53,6 +53,8 @@ type
     bcScrollCursorTop = "scroll.cursor.top"
     bcScrollCursorCenter = "scroll.cursor.center"
     bcScrollCursorBottom = "scroll.cursor.bottom"
+    bcScrollLineDown = "scroll.line.down"
+    bcScrollLineUp = "scroll.line.up"
     # Mode switching commands
     bcModeNormal = "mode.normal"
     bcModeInsert = "mode.insert"

--- a/src/moepkg/command_registry/motion_scroll.nim
+++ b/src/moepkg/command_registry/motion_scroll.nim
@@ -23,7 +23,7 @@ import std/options
 
 import pkg/results
 
-import ../[types, motion, modes, render_utils]
+import ../[types, motion, modes, render_utils, visible_rows]
 import ../buffer/[core, fold]
 
 import core
@@ -126,37 +126,121 @@ proc scrollVisibleHeight(ctx: CommandContext): int =
       steadyBottomAreaHeight()
   max(1, ctx.motionController.viewportManager.viewport.height - reservedLines)
 
-proc handleScrollLines(
-    ctx: CommandContext, args: seq[string], direction: int
-): Result[(), string] =
+proc scrollRowLayout(ctx: CommandContext): RowLayout =
+  let
+    viewport = ctx.motionController.viewportManager.viewport
+    viewportOffset = viewportOffsetFor(ctx.buffer, ctx.state)
+  initRowLayout(
+    ctx.buffer,
+    ctx.motionController.viewportManager.wrapCountCache,
+    ctx.state.lineWrap,
+    wrapWidthFor(viewport.width, viewportOffset),
+    ctx.state.tabStop,
+  )
+
+func scrollPositionAbove(a, b: tuple[line, offset: int]): bool {.inline.} =
+  a.line < b.line or (a.line == b.line and a.offset < b.offset)
+
+proc maxScrollTop(
+    ctx: CommandContext, layout: RowLayout, visibleHeight: int
+): tuple[line, offset: int] =
+  let
+    lastLine = ctx.buffer.len - 1
+    collapsedFold = ctx.buffer.foldState.getCollapsedFoldAt(lastLine)
+    bottomLine = if collapsedFold.isSome: collapsedFold.get.startLine else: lastLine
+    bottomOffset =
+      if collapsedFold.isSome:
+        0
+      else:
+        layout.lineRows(bottomLine) - 1
+  layout.walkBackRows(bottomLine, bottomOffset, visibleHeight - 1)
+
+proc moveCursorToRow(ctx: CommandContext, layout: RowLayout, row: VisibleRow) =
+  let
+    viewport = ctx.motionController.viewportManager.viewport
+    (_, cursorCellX) =
+      layout.cursorCell(ctx.cursor.line, ctx.cursor.column, viewport.leftColumn)
+  ctx.cursor.line = row.line
+  ctx.cursor.column =
+    if row.fold.isSome:
+      0
+    else:
+      layout.cellToColumn(row.line, row.wrapSeg, cursorCellX, viewport.leftColumn)
+
+proc keepCursorInScrolledViewport(
+    ctx: CommandContext, layout: RowLayout, visibleHeight: int
+) =
+  let
+    viewport = ctx.motionController.viewportManager.viewport
+    (cursorOffset, _) =
+      layout.cursorCell(ctx.cursor.line, ctx.cursor.column, viewport.leftColumn)
+    cursorPosition = (line: ctx.cursor.line, offset: cursorOffset)
+    topPosition = (line: viewport.topLine, offset: viewport.topWrapOffset)
+
+  if scrollPositionAbove(cursorPosition, topPosition):
+    let topRow = layout.rowAt(viewport.topLine, viewport.topWrapOffset, 0)
+    if topRow.isSome:
+      ctx.moveCursorToRow(layout, topRow.get)
+  else:
+    let cursorRow =
+      layout.rowOfLine(
+        viewport.topLine, viewport.topWrapOffset, ctx.cursor.line, visibleHeight
+      ) + cursorOffset
+    if cursorRow >= visibleHeight:
+      let bottomRow =
+        layout.rowAt(viewport.topLine, viewport.topWrapOffset, visibleHeight - 1)
+      if bottomRow.isSome:
+        ctx.moveCursorToRow(layout, bottomRow.get)
+
+proc handleScrollLineDown*(ctx: CommandContext, args: seq[string]): Result[(), string] =
+  ## Scroll the viewport down by screen rows (Ctrl-E).
   let
     count = parseCount(args)
     visibleHeight = ctx.scrollVisibleHeight()
+    layout = ctx.scrollRowLayout()
     viewport = ctx.motionController.viewportManager.viewport
-    maxTopLine = max(0, ctx.buffer.len - visibleHeight)
-    targetTopLine = clamp(viewport.topLine + direction * count, 0, maxTopLine)
-    targetCursorLine = clamp(
-      ctx.cursor.line,
-      targetTopLine,
-      min(ctx.buffer.len - 1, targetTopLine + visibleHeight - 1),
-    )
+    maxTop = ctx.maxScrollTop(layout, visibleHeight)
+    currentTop =
+      if scrollPositionAbove(
+        maxTop, (line: viewport.topLine, offset: viewport.topWrapOffset)
+      ):
+        maxTop
+      else:
+        (line: viewport.topLine, offset: viewport.topWrapOffset)
+    row = layout.rowAt(currentTop.line, currentTop.offset, count)
+    candidate =
+      if row.isSome:
+        (line: row.get.line, offset: row.get.wrapSeg)
+      else:
+        maxTop
+    targetTop = if scrollPositionAbove(maxTop, candidate): maxTop else: candidate
 
-  viewport.resetViewportTop(targetTopLine)
-  if targetCursorLine != ctx.cursor.line:
-    let cursor = ctx.motionController.cursorManager.clampPosition(
-      CursorPosition(x: ctx.cursor.column, y: targetCursorLine), ctx.buffer
-    )
-    ctx.cursor = BufferPosition(line: cursor.y, column: cursor.x)
+  viewport.restoreViewportTop(targetTop.line, targetTop.offset)
+  ctx.keepCursorInScrolledViewport(layout, visibleHeight)
 
   return ok(())
 
-proc handleScrollLineDown*(ctx: CommandContext, args: seq[string]): Result[(), string] =
-  ## Scroll the viewport down by buffer lines (Ctrl-E).
-  ctx.handleScrollLines(args, 1)
-
 proc handleScrollLineUp*(ctx: CommandContext, args: seq[string]): Result[(), string] =
-  ## Scroll the viewport up by buffer lines (Ctrl-Y).
-  ctx.handleScrollLines(args, -1)
+  ## Scroll the viewport up by screen rows (Ctrl-Y).
+  let
+    count = parseCount(args)
+    visibleHeight = ctx.scrollVisibleHeight()
+    layout = ctx.scrollRowLayout()
+    viewport = ctx.motionController.viewportManager.viewport
+    maxTop = ctx.maxScrollTop(layout, visibleHeight)
+    currentTop =
+      if scrollPositionAbove(
+        maxTop, (line: viewport.topLine, offset: viewport.topWrapOffset)
+      ):
+        maxTop
+      else:
+        (line: viewport.topLine, offset: viewport.topWrapOffset)
+    targetTop = layout.walkBackRows(currentTop.line, currentTop.offset, count)
+
+  viewport.restoreViewportTop(targetTop.line, targetTop.offset)
+  ctx.keepCursorInScrolledViewport(layout, visibleHeight)
+
+  return ok(())
 
 ## Fold commands
 

--- a/src/moepkg/command_registry/motion_scroll.nim
+++ b/src/moepkg/command_registry/motion_scroll.nim
@@ -194,6 +194,8 @@ proc keepCursorInScrolledViewport(
 
 proc handleScrollLineDown*(ctx: CommandContext, args: seq[string]): Result[(), string] =
   ## Scroll the viewport down by screen rows (Ctrl-E).
+  ## Wrapped segments and collapsed folds each count as visible rows; the cursor
+  ## moves only when scrolling would leave it outside the viewport.
   let
     count = parseCount(args)
     visibleHeight = ctx.scrollVisibleHeight()
@@ -222,6 +224,8 @@ proc handleScrollLineDown*(ctx: CommandContext, args: seq[string]): Result[(), s
 
 proc handleScrollLineUp*(ctx: CommandContext, args: seq[string]): Result[(), string] =
   ## Scroll the viewport up by screen rows (Ctrl-Y).
+  ## Wrapped segments and collapsed folds each count as visible rows; the cursor
+  ## moves only when scrolling would leave it outside the viewport.
   let
     count = parseCount(args)
     visibleHeight = ctx.scrollVisibleHeight()

--- a/src/moepkg/command_registry/motion_scroll.nim
+++ b/src/moepkg/command_registry/motion_scroll.nim
@@ -118,6 +118,46 @@ proc handleScrollCursorBottom*(
 
   return ok(())
 
+proc scrollVisibleHeight(ctx: CommandContext): int =
+  let reservedLines =
+    if ctx.state.windowDisplay.viewportReservedLines >= 0:
+      ctx.state.windowDisplay.viewportReservedLines
+    else:
+      steadyBottomAreaHeight()
+  max(1, ctx.motionController.viewportManager.viewport.height - reservedLines)
+
+proc handleScrollLines(
+    ctx: CommandContext, args: seq[string], direction: int
+): Result[(), string] =
+  let
+    count = parseCount(args)
+    visibleHeight = ctx.scrollVisibleHeight()
+    viewport = ctx.motionController.viewportManager.viewport
+    maxTopLine = max(0, ctx.buffer.len - visibleHeight)
+    targetTopLine = clamp(viewport.topLine + direction * count, 0, maxTopLine)
+    targetCursorLine = clamp(
+      ctx.cursor.line,
+      targetTopLine,
+      min(ctx.buffer.len - 1, targetTopLine + visibleHeight - 1),
+    )
+
+  viewport.resetViewportTop(targetTopLine)
+  if targetCursorLine != ctx.cursor.line:
+    let cursor = ctx.motionController.cursorManager.clampPosition(
+      CursorPosition(x: ctx.cursor.column, y: targetCursorLine), ctx.buffer
+    )
+    ctx.cursor = BufferPosition(line: cursor.y, column: cursor.x)
+
+  return ok(())
+
+proc handleScrollLineDown*(ctx: CommandContext, args: seq[string]): Result[(), string] =
+  ## Scroll the viewport down by buffer lines (Ctrl-E).
+  ctx.handleScrollLines(args, 1)
+
+proc handleScrollLineUp*(ctx: CommandContext, args: seq[string]): Result[(), string] =
+  ## Scroll the viewport up by buffer lines (Ctrl-Y).
+  ctx.handleScrollLines(args, -1)
+
 ## Fold commands
 
 proc handleFoldOpen*(ctx: CommandContext, args: seq[string]): Result[(), string] =
@@ -337,6 +377,24 @@ proc registerMotionAndScrollCommands*(registry: CommandRegistry) =
     handleScrollCursorBottom,
     0,
     0,
+  )
+
+  registry.register(
+    builtin(bcScrollLineDown),
+    "Scroll Line Down",
+    "Scroll viewport one line down (Ctrl-E)",
+    handleScrollLineDown,
+    0,
+    1,
+  )
+
+  registry.register(
+    builtin(bcScrollLineUp),
+    "Scroll Line Up",
+    "Scroll viewport one line up (Ctrl-Y)",
+    handleScrollLineUp,
+    0,
+    1,
   )
 
   # Fold commands

--- a/src/moepkg/help_generator.nim
+++ b/src/moepkg/help_generator.nim
@@ -100,6 +100,8 @@ const NormalModeCommands*: HelpGroup = HelpGroup(
     HelpEntry(syntax: "Ctrl-f", description: "Page Down"),
     HelpEntry(syntax: "Ctrl-u", description: "Half Page Up"),
     HelpEntry(syntax: "Ctrl-d", description: "Half Page Down"),
+    HelpEntry(syntax: "Ctrl-e", description: "Scroll one line down"),
+    HelpEntry(syntax: "Ctrl-y", description: "Scroll one line up"),
     HelpEntry(syntax: "%", description: "Move to matching pair of paren"),
     HelpEntry(syntax: "d$ or D", description: "Delete until the end of the line"),
     HelpEntry(syntax: "C", description: "Change until the end of the line"),

--- a/src/moepkg/key_bindings/commands.nim
+++ b/src/moepkg/key_bindings/commands.nim
@@ -223,6 +223,8 @@ const CustomCommands: seq[tuple[name, desc, commandId: string]] = @[
   ("scroll-cursor-top", "Scroll cursor to top of screen", "scroll.cursor.top"),
   ("scroll-cursor-center", "Scroll cursor to center of screen", "scroll.cursor.center"),
   ("scroll-cursor-bottom", "Scroll cursor to bottom of screen", "scroll.cursor.bottom"),
+  ("scroll-line-down", "Scroll viewport one line down", "scroll.line.down"),
+  ("scroll-line-up", "Scroll viewport one line up", "scroll.line.up"),
   ("fold-open", "Open fold at cursor", "fold.open"),
   ("fold-close", "Close fold at cursor", "fold.close"),
   ("fold-toggle", "Toggle fold at cursor", "fold.toggle"),

--- a/src/moepkg/key_bindings/normal_bindings.nim
+++ b/src/moepkg/key_bindings/normal_bindings.nim
@@ -39,6 +39,8 @@ const NormalBindings: seq[tuple[key, cmd: string]] = @[
   ("C-u", "half-page-up"),
   ("C-d", "half-page-down"),
   ("C-f", "page-down"),
+  ("C-e", "scroll-line-down"),
+  ("C-y", "scroll-line-up"),
   # Edit history
   ("u", "undo"),
   ("C-r", "redo"),

--- a/tests/test_command_registry.nim
+++ b/tests/test_command_registry.nim
@@ -351,6 +351,8 @@ suite "CommandRegistry - BuiltinCommandId":
     check $bcScrollCursorTop == "scroll.cursor.top"
     check $bcScrollCursorCenter == "scroll.cursor.center"
     check $bcScrollCursorBottom == "scroll.cursor.bottom"
+    check $bcScrollLineDown == "scroll.line.down"
+    check $bcScrollLineUp == "scroll.line.up"
 
   test "fold commands have correct string values":
     check $bcFoldOpen == "fold.open"
@@ -432,6 +434,8 @@ suite "CommandRegistry - registerBuiltinCommands":
     check registry.findCommand(builtin(bcScrollCursorTop)).isSome
     check registry.findCommand(builtin(bcScrollCursorCenter)).isSome
     check registry.findCommand(builtin(bcScrollCursorBottom)).isSome
+    check registry.findCommand(builtin(bcScrollLineDown)).isSome
+    check registry.findCommand(builtin(bcScrollLineUp)).isSome
 
   test "registers all fold commands":
     let registry = newCommandRegistry()

--- a/tests/test_command_registry_integration.nim
+++ b/tests/test_command_registry_integration.nim
@@ -2050,6 +2050,72 @@ suite "Handler - Scroll operations":
 
     check registry.execute(ctx, builtin(bcScrollCursorBottom)).isOk
 
+  test "scroll line down keeps a visible cursor in place (Ctrl-E)":
+    let buffer = newTextBuffer("0\n1\n2\n3\n4\n5\n6\n7\n8\n9")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 2, column: 0)
+    ctx.motionController.viewportManager.viewport.height = 5
+    ctx.state.windowDisplay.viewportReservedLines = 0
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineDown)).isOk
+    check ctx.motionController.viewportManager.viewport.topLine == 1
+    check ctx.cursor.line == 2
+
+  test "scroll line down moves cursor when it leaves the viewport (Ctrl-E)":
+    let buffer = newTextBuffer("0\n1\n2\n3\n4\n5\n6\n7\n8\n9")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 0, column: 0)
+    ctx.motionController.viewportManager.viewport.height = 5
+    ctx.state.windowDisplay.viewportReservedLines = 0
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineDown)).isOk
+    check ctx.motionController.viewportManager.viewport.topLine == 1
+    check ctx.cursor.line == 1
+
+  test "scroll line up keeps a visible cursor in place (Ctrl-Y)":
+    let buffer = newTextBuffer("0\n1\n2\n3\n4\n5\n6\n7\n8\n9")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 5, column: 0)
+    ctx.motionController.viewportManager.viewport.topLine = 4
+    ctx.motionController.viewportManager.viewport.height = 5
+    ctx.state.windowDisplay.viewportReservedLines = 0
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineUp)).isOk
+    check ctx.motionController.viewportManager.viewport.topLine == 3
+    check ctx.cursor.line == 5
+
+  test "scroll line up moves cursor when it leaves the viewport (Ctrl-Y)":
+    let buffer = newTextBuffer("0\n1\n2\n3\n4\n5\n6\n7\n8\n9")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 8, column: 0)
+    ctx.motionController.viewportManager.viewport.topLine = 4
+    ctx.motionController.viewportManager.viewport.height = 5
+    ctx.state.windowDisplay.viewportReservedLines = 0
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineUp)).isOk
+    check ctx.motionController.viewportManager.viewport.topLine == 3
+    check ctx.cursor.line == 7
+
+  test "scroll line commands accept a count and clamp at buffer edges":
+    let buffer = newTextBuffer("0\n1\n2\n3\n4\n5\n6\n7\n8\n9")
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 2, column: 0)
+    ctx.motionController.viewportManager.viewport.height = 5
+    ctx.state.windowDisplay.viewportReservedLines = 0
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineDown), @["20"]).isOk
+    check ctx.motionController.viewportManager.viewport.topLine == 5
+    check ctx.cursor.line == 5
+
+    check registry.execute(ctx, builtin(bcScrollLineUp), @["20"]).isOk
+    check ctx.motionController.viewportManager.viewport.topLine == 0
+    check ctx.cursor.line == 4
+
 suite "Handler - Visual mode operations":
   test "visual delete":
     let buffer = newTextBuffer("hello world")

--- a/tests/test_command_registry_integration.nim
+++ b/tests/test_command_registry_integration.nim
@@ -2116,6 +2116,73 @@ suite "Handler - Scroll operations":
     check ctx.motionController.viewportManager.viewport.topLine == 0
     check ctx.cursor.line == 4
 
+  test "scroll line down keeps a visible cursor out of a collapsed fold (Ctrl-E)":
+    # Screen shows 0, 1, [fold 2..90], 91, 92 -- the cursor is already visible,
+    # so scrolling by one row must not move it at all.
+    var lines: seq[string] = @[]
+    for i in 0 ..< 100:
+      lines.add($i)
+    let buffer = newTextBuffer(lines.join("\n"))
+    check buffer.foldState.addFold(2, 90, collapsed = true)
+
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 92, column: 0)
+    ctx.motionController.viewportManager.viewport.topLine = 0
+    ctx.motionController.viewportManager.viewport.height = 7
+    ctx.state.windowDisplay.viewportReservedLines = 2
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineDown)).isOk
+    check ctx.cursor.line == 92
+
+  test "scroll line down steps over a collapsed fold in one press (Ctrl-E)":
+    # A collapsed fold occupies a single screen row, so three presses from the
+    # top reach line 91: 0 -> 1 -> [fold] -> 91.
+    var lines: seq[string] = @[]
+    for i in 0 ..< 100:
+      lines.add($i)
+    let buffer = newTextBuffer(lines.join("\n"))
+    check buffer.foldState.addFold(2, 90, collapsed = true)
+
+    let ctx = createTestContext(buffer)
+    ctx.cursor = BufferPosition(line: 92, column: 0)
+    let viewport = ctx.motionController.viewportManager.viewport
+    viewport.topLine = 0
+    viewport.height = 7
+    ctx.state.windowDisplay.viewportReservedLines = 2
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineDown)).isOk
+    check viewport.topLine == 1
+    check registry.execute(ctx, builtin(bcScrollLineDown)).isOk
+    check viewport.topLine == 2
+    check registry.execute(ctx, builtin(bcScrollLineDown)).isOk
+    check viewport.topLine == 91
+
+  test "scroll line down never moves the top backwards under lineWrap (Ctrl-E)":
+    # 10 lines of 30 columns at width 10 wrap to 3 rows each, so the top may
+    # legitimately sit below `buffer.len - visibleHeight` on a wrap segment.
+    var lines: seq[string] = @[]
+    for i in 0 ..< 10:
+      lines.add("x".repeat(30))
+    let buffer = newTextBuffer(lines.join("\n"))
+
+    let ctx = createTestContext(buffer)
+    ctx.state.config.standard.lineWrap = true
+    ctx.cursor = BufferPosition(line: 9, column: 0)
+    let viewport = ctx.motionController.viewportManager.viewport
+    viewport.topLine = 4
+    viewport.topWrapOffset = 2
+    viewport.width = 10
+    viewport.height = 8
+    ctx.state.windowDisplay.viewportReservedLines = 2
+    let registry = createTestRegistry()
+
+    check registry.execute(ctx, builtin(bcScrollLineDown)).isOk
+    check (
+      viewport.topLine > 4 or (viewport.topLine == 4 and viewport.topWrapOffset >= 2)
+    )
+
 suite "Handler - Visual mode operations":
   test "visual delete":
     let buffer = newTextBuffer("hello world")

--- a/tests/test_key_bindings.nim
+++ b/tests/test_key_bindings.nim
@@ -1441,6 +1441,10 @@ suite "Default bindings coverage":
       registry.findSingleBinding(EditorMode.Normal, toKeyCombo('u', ctrl = true))
     let ctrlD =
       registry.findSingleBinding(EditorMode.Normal, toKeyCombo('d', ctrl = true))
+    let ctrlE =
+      registry.findSingleBinding(EditorMode.Normal, toKeyCombo('e', ctrl = true))
+    let ctrlY =
+      registry.findSingleBinding(EditorMode.Normal, toKeyCombo('y', ctrl = true))
 
     check ctrlB.isSome
     check ctrlB.get.name == "page-up"
@@ -1450,6 +1454,10 @@ suite "Default bindings coverage":
     check ctrlU.get.name == "half-page-up"
     check ctrlD.isSome
     check ctrlD.get.name == "half-page-down"
+    check ctrlE.isSome
+    check ctrlE.get.name == "scroll-line-down"
+    check ctrlY.isSome
+    check ctrlY.get.name == "scroll-line-up"
 
   test "Word motion bindings":
     let registry = newKeyBindingRegistry()


### PR DESCRIPTION
## Summary

- add Normal-mode Ctrl-E and Ctrl-Y bindings for scrolling the viewport down/up by screen rows
- preserve the cursor while visible and move it only when it leaves the viewport
- use Moe’s shared row layout so wrapped lines and collapsed folds scroll consistently with rendering
- support numeric counts and document both shortcuts

## Testing

- exact nph v0.7.0 formatting check
- command registry, key binding, binding drift, and help synchronization tests
- focused scrolling, count, collapsed-fold, and line-wrap regression tests
- debug and release builds