### PR TITLE
Add :x and :xit commands with write-if-modified semantics

### DIFF
--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -1222,7 +1222,7 @@ Built-in aliases can be overridden.
 Example:
 ```toml
 [CommandAliases]
-x = { command = "quit" }
+qq = { command = "quit" }
 ww = { command = "saveall", description = "Save all buffers" }
 fmt = { command = "lspformat", description = "Format code with LSP" }
 ```

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -37,12 +37,14 @@
 | <kbd>**:**</kbd> <kbd>**w**</kbd> | Write file |
 | <kbd>**:**</kbd> <kbd>**q**</kbd> | Quit |
 | <kbd>**:**</kbd> <kbd>**w**</kbd> <kbd>**q**</kbd> | Write and quit |
+| <kbd>**:**</kbd> <kbd>**x**</kbd> OR <kbd>**:**</kbd> <kbd>**x**</kbd> <kbd>**i**</kbd> <kbd>**t**</kbd> | Write if modified and quit |
 | <kbd>**:**</kbd> <kbd>**q**</kbd> <kbd>**!**</kbd> | Force quit |
 | <kbd>**:**</kbd> <kbd>**q**</kbd> <kbd>**a**</kbd> | Quit all windows |
 | <kbd>**:**</kbd> <kbd>**w**</kbd> <kbd>**q**</kbd> <kbd>**a**</kbd> | Write and quit all windows |
 | <kbd>**:**</kbd> <kbd>**q**</kbd> <kbd>**a**</kbd> <kbd>**!**</kbd> | Force quit all windows |
 | <kbd>**:**</kbd> <kbd>**w**</kbd> <kbd>**!**</kbd> | Force write |
 | <kbd>**:**</kbd> <kbd>**w**</kbd> <kbd>**q**</kbd> <kbd>**!**</kbd> | Force write and quit window |
+| <kbd>**:**</kbd> <kbd>**x**</kbd> <kbd>**!**</kbd> | Force write if modified and quit |
 | <kbd>**:**</kbd> <kbd>**w**</kbd> <kbd>**q**</kbd> <kbd>**a**</kbd> <kbd>**!**</kbd> | Force write and quit all windows |
 | <kbd>**:**</kbd> <kbd>**c**</kbd> <kbd>**q**</kbd> | Quit with non-zero exit code |
 <!-- AUTO-GEN:end Exiting -->

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -609,10 +609,10 @@ rustAnalyzerDebugSingle = true         # rust-analyzer specific: debug single
 # [CommandAliases]
 # Define custom command aliases for built-in editor commands.
 # Each key is the alias name, value is a table with "command" and optional "description".
-# Usage: :x => quit, :ww => saveall
+# Usage: :qq => quit, :ww => saveall
 # Built-in aliases (from loadDefaultConfig) can be overridden.
 #
-# x = { command = "quit" }
+# qq = { command = "quit" }
 # ww = { command = "saveall", description = "Save all buffers" }
 # fmt = { command = "lspformat", description = "Format code with LSP" }
 

--- a/src/moepkg/command_handlers/command_handler.nim
+++ b/src/moepkg/command_handlers/command_handler.nim
@@ -102,10 +102,21 @@ proc executeSaveAndQuit*(
     filename: Option[string],
     force: bool,
 ): HandlerResult =
-  ## Execute save and quit command (:wq, :x)
+  ## Execute save and quit command (:wq)
   HandlerResult(
     kind: hrSaveAndQuit, saveAndQuitFilename: filename, forceQuitAfterSave: force
   )
+
+proc executeSaveIfModifiedAndQuit*(
+    handler: CommandModeHandler,
+    buffer: TextBuffer,
+    filename: Option[string],
+    force: bool,
+): HandlerResult =
+  ## Execute :x/:xit, writing only when the buffer is modified.
+  if not buffer.isModified:
+    return HandlerResult(kind: hrQuit)
+  handler.executeSaveAndQuit(buffer, filename, force)
 
 proc executeSaveAllAndQuit*(handler: CommandModeHandler, force: bool): HandlerResult =
   ## Execute save all and quit command (:wqa, :xa, :wqa!)
@@ -523,6 +534,10 @@ proc handleCommandModeInput*(
     handler.executeSaveAll(cmdResult.forceSaveAll)
   of claSaveAndQuit:
     handler.executeSaveAndQuit(
+      buffer, cmdResult.saveFilename, cmdResult.forceSaveAndQuit
+    )
+  of claSaveIfModifiedAndQuit:
+    handler.executeSaveIfModifiedAndQuit(
       buffer, cmdResult.saveFilename, cmdResult.forceSaveAndQuit
     )
   of claSaveAllAndQuit:

--- a/src/moepkg/command_line.nim
+++ b/src/moepkg/command_line.nim
@@ -42,8 +42,12 @@ proc parseAndExecute*(parser: CommandLineParser, input: string): CommandLineResu
 
 proc isQuitCommand*(cmdResult: CommandLineResult): bool =
   ## Check if the result is a quit command
-  cmdResult.kind in {claQuit, claQuitAll, claSaveAndQuit, claSaveAllAndQuit, claCquit}
+  cmdResult.kind in {
+    claQuit, claQuitAll, claSaveAndQuit, claSaveIfModifiedAndQuit, claSaveAllAndQuit,
+    claCquit,
+  }
 
 proc isSaveCommand*(cmdResult: CommandLineResult): bool =
-  ## Check if the result requires saving
-  cmdResult.kind in {claSave, claSaveAll, claSaveAndQuit, claSaveAllAndQuit}
+  ## Check if the result belongs to the save-command family.
+  cmdResult.kind in
+    {claSave, claSaveAll, claSaveAndQuit, claSaveIfModifiedAndQuit, claSaveAllAndQuit}

--- a/src/moepkg/command_line/executor.nim
+++ b/src/moepkg/command_line/executor.nim
@@ -55,6 +55,16 @@ proc execute*(parser: CommandLineParser, cmd: ParsedCommand): CommandLineResult 
           none(string),
       forceSaveAndQuit: "force" in cmd.flags,
     )
+  of claSaveIfModifiedAndQuit:
+    return CommandLineResult(
+      kind: claSaveIfModifiedAndQuit,
+      saveFilename:
+        if cmd.args.len > 0:
+          some(cmd.args[0])
+        else:
+          none(string),
+      forceSaveAndQuit: "force" in cmd.flags,
+    )
   of claSaveAllAndQuit:
     return CommandLineResult(
       kind: claSaveAllAndQuit, forceSaveAllAndQuit: "force" in cmd.flags

--- a/src/moepkg/command_line/types.nim
+++ b/src/moepkg/command_line/types.nim
@@ -30,7 +30,8 @@ type
     claQuitAll # :qa (quit all)
     claSave # :w
     claSaveAll # :wa (write all)
-    claSaveAndQuit # :wq, :x
+    claSaveAndQuit # :wq
+    claSaveIfModifiedAndQuit # :x, :xit
     claSaveAllAndQuit # :wqa, :xa (save all and quit)
     claEdit # :e
     claEnew # :ene, :enew (new empty buffer)
@@ -134,9 +135,9 @@ type
       forceSave*: bool # true for :w!
     of claSaveAll:
       forceSaveAll*: bool # true for :wa!
-    of claSaveAndQuit:
+    of claSaveAndQuit, claSaveIfModifiedAndQuit:
       saveFilename*: Option[string]
-      forceSaveAndQuit*: bool # true for :wq!
+      forceSaveAndQuit*: bool # true for :wq! or :x!
     of claSaveAllAndQuit:
       forceSaveAllAndQuit*: bool # true for :wqa!
     of claEdit:

--- a/src/moepkg/command_line_commands.nim
+++ b/src/moepkg/command_line_commands.nim
@@ -208,6 +208,31 @@ const CommandLineCommandTable*: seq[CommandLineCommandSpec] = @[
     isCanonicalLong: false,
   ),
   CommandLineCommandSpec(
+    name: "x",
+    completionDescription: "Write if modified and quit",
+    helpEntries:
+      @[HelpEntry(syntax: ":x or :xit", description: "Write if modified and quit")],
+    action: some(claSaveIfModifiedAndQuit),
+    isCanonicalLong: false,
+    keymapBaseDescription: "Save if modified and quit",
+  ),
+  CommandLineCommandSpec(
+    name: "xit",
+    completionDescription: "Write if modified and quit",
+    helpEntries: @[],
+    action: some(claSaveIfModifiedAndQuit),
+    isCanonicalLong: true,
+    keymapBaseDescription: "Save if modified and quit",
+  ),
+  CommandLineCommandSpec(
+    name: "x!",
+    completionDescription: "",
+    helpEntries:
+      @[HelpEntry(syntax: ":x!", description: "Force write if modified and quit")],
+    action: none(CommandLineAction),
+    isCanonicalLong: false,
+  ),
+  CommandLineCommandSpec(
     name: "wqa",
     completionDescription: "Write and quit all windows",
     helpEntries: @[HelpEntry(syntax: ":wqa", description: "Write and quit all windows")],

--- a/src/moepkg/help_generator.nim
+++ b/src/moepkg/help_generator.nim
@@ -701,7 +701,7 @@ const DebugModeCommands*: HelpGroup = HelpGroup(
 )
 
 const ExitingHelpNames =
-  @["w", "q", "wq", "q!", "qa", "qa!", "wqa", "wqa!", "w!", "wq!", "cq"]
+  @["w", "q", "wq", "x", "q!", "qa", "qa!", "wqa", "wqa!", "w!", "wq!", "x!", "cq"]
 
 proc boolSetHead(spec: SetOptionSpec): string =
   result = "set " & spec.longName & " / set no" & spec.longName

--- a/src/moepkg/help_markdown.nim
+++ b/src/moepkg/help_markdown.nim
@@ -51,7 +51,7 @@ const
   CommandTableHeader = "| Command | Description |\n|:---|:---|\n"
 
   ExitingHelpNames =
-    @["w", "q", "wq", "q!", "qa", "wqa", "qa!", "w!", "wq!", "wqa!", "cq"]
+    @["w", "q", "wq", "x", "q!", "qa", "wqa", "qa!", "w!", "wq!", "x!", "wqa!", "cq"]
   ## Hand-curated order matching the existing howtouse.md row sequence.
   ## `help_generator.nim` ships a slightly different list for TUI help; the
   ## divergence is intentional — TUI help groups by action, the markdown

--- a/tests/test_command_config.nim
+++ b/tests/test_command_config.nim
@@ -114,6 +114,9 @@ suite "CommandConfig - canonicalCommandName":
     check name.isSome
     check resolveCommandName(name.get) == some(claSaveAndQuit)
 
+  test "Maps the semantic save-if-modified action to :xit":
+    check canonicalCommandName(claSaveIfModifiedAndQuit) == some("xit")
+
 suite "CommandConfig - addShellCommand":
   test "Adds a shell command":
     let config = newCommandConfig()
@@ -298,6 +301,8 @@ suite "CommandConfig - applyToParser":
     check parser.aliases["q"] == claQuit
     check parser.aliases["w"] == claSave
     check parser.aliases["wq"] == claSaveAndQuit
+    check parser.aliases["x"] == claSaveIfModifiedAndQuit
+    check parser.aliases["xit"] == claSaveIfModifiedAndQuit
 
   test "Applies shell commands to parser":
     let config = newCommandConfig()
@@ -363,6 +368,7 @@ suite "resolveCommandName":
     check resolveCommandName("quit") == some(claQuit)
     check resolveCommandName("save") == some(claSave)
     check resolveCommandName("saveandquit") == some(claSaveAndQuit)
+    check resolveCommandName("xit") == some(claSaveIfModifiedAndQuit)
     check resolveCommandName("terminal") == some(claTerminal)
 
   test "Case-insensitive resolution":

--- a/tests/test_command_handler.nim
+++ b/tests/test_command_handler.nim
@@ -167,6 +167,36 @@ suite "CommandModeHandler - executeSaveAndQuit":
     check result.saveAndQuitFilename.get == "test.txt"
     check result.forceQuitAfterSave == true
 
+suite "CommandModeHandler - executeSaveIfModifiedAndQuit":
+  test "Clean buffer quits without entering the save path":
+    let handler = setupHandler()
+    let buffer = setupBuffer(@["Hello"])
+
+    let result =
+      handler.executeSaveIfModifiedAndQuit(buffer, none(string), force = false)
+
+    check result.kind == hrQuit
+
+  test "Modified buffer uses the existing save-and-quit path":
+    let handler = setupHandler()
+    let buffer = setupBuffer(@["Hello"])
+    discard buffer.insertText(BufferPosition(line: 0, column: 5), "!")
+
+    let result =
+      handler.executeSaveIfModifiedAndQuit(buffer, some("test.txt"), force = true)
+
+    check result.kind == hrSaveAndQuit
+    check result.saveAndQuitFilename == some("test.txt")
+    check result.forceQuitAfterSave == true
+
+  test "Clean :wq still enters the save path":
+    let handler = setupHandler()
+    let buffer = setupBuffer(@["Hello"])
+
+    let result = handler.executeSaveAndQuit(buffer, none(string), force = false)
+
+    check result.kind == hrSaveAndQuit
+
 suite "CommandModeHandler - executeQuitAll":
   test "Quit all with unmodified buffer":
     let handler = setupHandler()
@@ -1393,6 +1423,22 @@ suite "CommandModeHandler - handleCommandModeInput":
     let buffer = setupBuffer()
 
     let result = handler.handleCommandModeInput(buffer, ":wq")
+    check result.kind == hrSaveAndQuit
+
+  test "Handle :x and :xit on a clean buffer":
+    let handler = setupHandler()
+    let buffer = setupBuffer()
+
+    check handler.handleCommandModeInput(buffer, ":x").kind == hrQuit
+    check handler.handleCommandModeInput(buffer, ":xit").kind == hrQuit
+
+  test "Handle :x on a modified buffer":
+    let handler = setupHandler()
+    let buffer = setupBuffer(@["Hello"])
+    discard buffer.insertText(BufferPosition(line: 0, column: 5), "!")
+
+    let result = handler.handleCommandModeInput(buffer, ":x")
+
     check result.kind == hrSaveAndQuit
 
   test "Handle :wa command":

--- a/tests/test_command_line.nim
+++ b/tests/test_command_line.nim
@@ -266,7 +266,8 @@ suite "CommandLine - parseCommandLine":
     parser.addAlias("w", claSave)
     parser.addAlias("wa", claSaveAll)
     parser.addAlias("wq", claSaveAndQuit)
-    parser.addAlias("x", claSaveAndQuit)
+    parser.addAlias("x", claSaveIfModifiedAndQuit)
+    parser.addAlias("xit", claSaveIfModifiedAndQuit)
     parser.addAlias("wqa", claSaveAllAndQuit)
     parser.addAlias("e", claEdit)
     parser.addAlias("ene", claEnew)
@@ -409,6 +410,8 @@ suite "CommandLine - execute":
     parser.addAlias("qa", claQuitAll)
     parser.addAlias("w", claSave)
     parser.addAlias("wq", claSaveAndQuit)
+    parser.addAlias("x", claSaveIfModifiedAndQuit)
+    parser.addAlias("xit", claSaveIfModifiedAndQuit)
     parser.addAlias("e", claEdit)
     parser.addAlias("enew", claEnew)
     parser.addAlias("set", claSet)
@@ -453,6 +456,24 @@ suite "CommandLine - execute":
     let result = parser.parseAndExecute(":wq")
     check result.kind == claSaveAndQuit
     check result.forceSaveAndQuit == false
+
+  test "Execute :x":
+    let result = parser.parseAndExecute(":x")
+    check result.kind == claSaveIfModifiedAndQuit
+    check result.saveFilename.isNone
+    check result.forceSaveAndQuit == false
+
+  test "Execute :xit":
+    let result = parser.parseAndExecute(":xit")
+    check result.kind == claSaveIfModifiedAndQuit
+    check result.saveFilename.isNone
+    check result.forceSaveAndQuit == false
+
+  test "Execute :x!filename (bang glued to filename)":
+    let result = parser.parseAndExecute(":x!out.txt")
+    check result.kind == claSaveIfModifiedAndQuit
+    check result.saveFilename == some("out.txt")
+    check result.forceSaveAndQuit == true
 
   test "Execute :e with filename":
     let result = parser.parseAndExecute(":e test.nim")
@@ -635,6 +656,7 @@ suite "CommandLine - isQuitCommand and isSaveCommand":
     check isQuitCommand(CommandLineResult(kind: claQuit)) == true
     check isQuitCommand(CommandLineResult(kind: claQuitAll)) == true
     check isQuitCommand(CommandLineResult(kind: claSaveAndQuit)) == true
+    check isQuitCommand(CommandLineResult(kind: claSaveIfModifiedAndQuit)) == true
     check isQuitCommand(CommandLineResult(kind: claSaveAllAndQuit)) == true
     check isQuitCommand(CommandLineResult(kind: claCquit)) == true
 
@@ -647,6 +669,7 @@ suite "CommandLine - isQuitCommand and isSaveCommand":
     check isSaveCommand(CommandLineResult(kind: claSave)) == true
     check isSaveCommand(CommandLineResult(kind: claSaveAll)) == true
     check isSaveCommand(CommandLineResult(kind: claSaveAndQuit)) == true
+    check isSaveCommand(CommandLineResult(kind: claSaveIfModifiedAndQuit)) == true
     check isSaveCommand(CommandLineResult(kind: claSaveAllAndQuit)) == true
 
   test "isSaveCommand returns false for non-save commands":

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -2302,6 +2302,31 @@ suite "handleCommandModeEvent - all command mode commands execute":
     check not e.state.isCommandOverlay
     check e.state.input.commandText == ""
 
+  test ":x on a clean unnamed buffer quits without trying to save":
+    let e = createTestEditorWithBuffer("hello")
+    e.activeBuffer.markSaved()
+    e.state.enterCommandOverlay()
+    e.state.input.commandText = ":x"
+
+    let cont = handleCommandModeEvent(e, makeEnterEvent())
+
+    # A save attempt would fail for this unnamed buffer and return true.
+    check cont == false
+
+  test ":x on a modified unnamed buffer preserves save failure behavior":
+    let e = createTestEditorWithBuffer("hello")
+    e.activeBuffer.markSaved()
+    discard e.activeBuffer.insertText(BufferPosition(line: 0, column: 5), "!")
+    e.state.enterCommandOverlay()
+    e.state.input.commandText = ":x"
+
+    let cont = handleCommandModeEvent(e, makeEnterEvent())
+
+    check cont == true
+    check e.activeBuffer.isModified
+    check not e.state.isCommandOverlay
+    check e.state.input.commandText == ""
+
   test ":b 0 switch to buffer":
     let e = createTestEditorWithBuffer("hello")
     e.state.enterCommandOverlay()

--- a/tests/test_help_viewer.nim
+++ b/tests/test_help_viewer.nim
@@ -568,13 +568,14 @@ suite "HelpViewer - Mode sections (snapshot)":
   ## or column-width changes in the underlying `*Commands` tables fail the
   ## build. Update literals deliberately when content is intentionally changed.
 
-  test "# Exiting section is aligned to width 5":
+  test "# Exiting section is aligned to width 10":
     let state = newHelpViewerState()
     check state.items.contains("# Exiting")
-    check state.items.contains(":w    - Write file")
-    check state.items.contains(":q    - Quit")
-    check state.items.contains(":wqa! - Force write and quit all windows")
-    check state.items.contains(":cq   - Quit with non-zero exit code")
+    check state.items.contains(":w         - Write file")
+    check state.items.contains(":q         - Quit")
+    check state.items.contains(":x or :xit - Write if modified and quit")
+    check state.items.contains(":wqa!      - Force write and quit all windows")
+    check state.items.contains(":cq        - Quit with non-zero exit code")
 
   test "# Changing modes section is aligned to width 6":
     let state = newHelpViewerState()


### PR DESCRIPTION
## Summary
Using :x is intentional: it writes the file only when the buffer changed. If nothing changed, it exits without touching the file, _preserving its mtime and avoiding false rebuilds or file-watcher events._

- add Vim-compatible `:x` and `:xit` commands
- write the current buffer only when it is modified, then use the existing save-and-quit lifecycle
- keep `:wq` unconditional and unchanged
- expose the new commands through parsing, completion, runtime key mapping, TUI help, and generated Markdown documentation

## Behavior

| Command | Clean buffer | Modified buffer |
| --- | --- | --- |
| `:x` / `:xit` | quit without writing | write, then quit |
| `:x!` | quit without writing | force write, then quit |
| `:wq` | write, then quit | write, then quit |

Optional filenames and the force flag are preserved when `:x` does enter the existing save-and-quit path.

## Implementation

This introduces a dedicated semantic `claSaveIfModifiedAndQuit` command-line action, while keeping `x` and `xit` as its external aliases. The command handler checks `TextBuffer.isModified`: clean buffers return through the existing application-exit result, while modified buffers reuse `executeSaveAndQuit`. This deliberately does not change the current window/application lifecycle or the behavior of the all-buffer commands.

## Testing

- targeted parser, configuration, command-table, handler, editor integration, completion, runtime key mapping, help, and documentation-sync tests pass
- release build compiles successfully
- `nph ./` passes
- full runner: 222/223 test files pass; the remaining existing flaky `tests/test_terminal_handler.nim` PTY shell-exit timing test failed on rerun and does not touch changed code
