### PR TITLE
Add forced Insert mode option

### DIFF
--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -113,6 +113,7 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 | smartIndent | bool | false | Language-aware extra indent on Enter (Nim: var/let/const/type, trailing or/and/object/tuple/enum, trailing `:` or `=`, unclosed brackets) |
 | ignorecase | bool | true | Enable ignorecase when searching |
 | smartcase | bool | true | Enable smartcase when searching |
+| forceInsertMode | bool | false | Keep editable buffers in Insert mode and disable Normal-mode commands |
 | disableChangeCursor | bool | false | Disable change of the cursor shape |
 | defaultCursor | string (enum: terminalDefault, blinkBlock, blinkIbeam, nonBlinkBlock, nonBlinkIbeam) | terminalDefault | The cursor shape of the terminal emulator you are using |
 | normalModeCursor | string (enum: terminalDefault, blinkBlock, blinkIbeam, nonBlinkBlock, nonBlinkIbeam) | blinkBlock | The cursor shape in Normal mode |

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -113,7 +113,7 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 | smartIndent | bool | false | Language-aware extra indent on Enter (Nim: var/let/const/type, trailing or/and/object/tuple/enum, trailing `:` or `=`, unclosed brackets) |
 | ignorecase | bool | true | Enable ignorecase when searching |
 | smartcase | bool | true | Enable smartcase when searching |
-| forceInsertMode | bool | false | Keep editable buffers in Insert mode and disable Normal-mode commands |
+| forceInsertMode | bool | false | Keep editable buffers in Insert mode; Ctrl-O opens the command line |
 | disableChangeCursor | bool | false | Disable change of the cursor shape |
 | defaultCursor | string (enum: terminalDefault, blinkBlock, blinkIbeam, nonBlinkBlock, nonBlinkIbeam) | terminalDefault | The cursor shape of the terminal emulator you are using |
 | normalModeCursor | string (enum: terminalDefault, blinkBlock, blinkIbeam, nonBlinkBlock, nonBlinkIbeam) | blinkBlock | The cursor shape in Normal mode |

--- a/documents/howtouse.md
+++ b/documents/howtouse.md
@@ -703,6 +703,8 @@ bool, open the enum popup, or start editing an int/float/string/color.
 | `ene` | Create a new empty buffer |
 | `new` | Create a new empty buffer in a horizontally split window |
 | `vnew` | Create a new empty buffer in a vertically split window |
+| `undo` | Undo the last change |
+| `redo` | Redo the last undone change |
 | `delete` | Delete current line and copy to register |
 | `ls` | Display all buffers |
 | `bprev` | Switch to the previous buffer |

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -38,7 +38,7 @@ ignorecase = true                      # Search case insensitive
 
 smartcase = true                       # Smart case search
 
-forceInsertMode = false                # Keep editable buffers in Insert mode and disable Normal-mode commands
+forceInsertMode = false                # Keep editable buffers in Insert mode; Ctrl-O opens the command line
 
 disableChangeCursor = false            # Disable cursor shape changes
 

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -38,6 +38,8 @@ ignorecase = true                      # Search case insensitive
 
 smartcase = true                       # Smart case search
 
+forceInsertMode = false                # Keep editable buffers in Insert mode and disable Normal-mode commands
+
 disableChangeCursor = false            # Disable cursor shape changes
 
 defaultCursor = "terminalDefault"      # Default cursor style - restored on exit

--- a/src/moe.nim
+++ b/src/moe.nim
@@ -333,6 +333,7 @@ proc main() =
         # Apply readonly mode if specified
         if cmdLineConfig.isReadonly:
           editor.activeBuffer().readOnly = true
+          editor.enforceModePolicy()
 
       # Open any additional files (after the first). The auto-split vs no-split
       # decision and the per-file loop live in openAdditionalStartupFiles so the

--- a/src/moepkg/buffer/undo.nim
+++ b/src/moepkg/buffer/undo.nim
@@ -373,6 +373,8 @@ proc undo*(b: TextBuffer, count: int = 1): Result[BufferPosition, string] =
   ## Returns error if nothing to undo or if the undo operation fails
   if b.readOnly:
     return Result[BufferPosition, string].err "Buffer is read-only"
+  if b.inTransaction:
+    return Result[BufferPosition, string].err "Cannot undo during a transaction"
   if b.undoStack.len == 0:
     return Result[BufferPosition, string].err "Nothing to undo"
 
@@ -563,6 +565,8 @@ proc redo*(b: TextBuffer, count: int = 1): Result[BufferPosition, string] =
   ## Returns error if nothing to redo or if the redo operation fails
   if b.readOnly:
     return Result[BufferPosition, string].err "Buffer is read-only"
+  if b.inTransaction:
+    return Result[BufferPosition, string].err "Cannot redo during a transaction"
   if b.redoStack.len == 0:
     return Result[BufferPosition, string].err "Nothing to redo"
 

--- a/src/moepkg/buffer/undo.nim
+++ b/src/moepkg/buffer/undo.nim
@@ -166,7 +166,10 @@ proc beginTransaction*(
 ): Result[(), string] =
   ## Begin a transaction to group multiple changes
   ## If cursorPos is provided, it will be used as the cursor position when undoing
-  ## Returns error if a transaction is already in progress
+  ## Returns error for read-only buffers or if a transaction is already in progress
+  if b.readOnly:
+    return err("Buffer is read-only")
+
   if b.inTransaction:
     let currentDesc =
       if b.currentTransaction.isSome:

--- a/src/moepkg/command_handlers/command_handler.nim
+++ b/src/moepkg/command_handlers/command_handler.nim
@@ -560,6 +560,10 @@ proc handleCommandModeInput*(
     handler.executeSet(cmdResult.option, cmdResult.value)
   of claHelp:
     handler.executeHelp(cmdResult.topic)
+  of claUndo:
+    HandlerResult(kind: hrUndo)
+  of claRedo:
+    HandlerResult(kind: hrRedo)
   of claVSplit:
     handler.executeVSplit(cmdResult.vsplitFilename)
   of claHSplit:

--- a/src/moepkg/command_handlers/handler_manager.nim
+++ b/src/moepkg/command_handlers/handler_manager.nim
@@ -240,21 +240,14 @@ proc handleNormalMode*(
     if r.modeTransition.isSome:
       let targetMode = r.modeTransition.get
       if targetMode == EditorMode.Insert:
-        if not buffer.inTransaction:
-          let transactionResult =
-            buffer.beginTransaction("Insert mode edit", cursorPos = some(state.cursor))
-          if transactionResult.isErr:
-            return HandlerResult(
-              kind: hrError,
-              errorMessage: "Failed to begin transaction: " & transactionResult.error,
-            )
-        # Record insert start position for text tracking
-        # Don't reset if transaction is already active (e.g. returning from insert-normal)
-        if state.editState.insertModeStartPos.isNone:
-          state.editState.insertModeStartPos = some(state.cursor)
-          # Carry the [count]i/a/o/O replay request onto the Insert session.
-          state.editState.insertReplayCount = r.insertReplayCount
-          state.editState.insertReplayLineEntry = r.insertReplayLineEntry
+        let transactionResult = beginInsertModeSession(
+          buffer, state, r.insertReplayCount, r.insertReplayLineEntry
+        )
+        if transactionResult.isErr:
+          return HandlerResult(
+            kind: hrError,
+            errorMessage: "Failed to begin transaction: " & transactionResult.error,
+          )
       elif targetMode == EditorMode.Replace:
         # Reveal a collapsed fold at the cursor so Replace never overtypes text
         # hidden behind a fold marker (mirrors the Insert-mode entry behaviour).

--- a/src/moepkg/command_handlers/handler_manager.nim
+++ b/src/moepkg/command_handlers/handler_manager.nim
@@ -210,6 +210,9 @@ proc applyNormalModePostProcessing(
             )
         return normalResult
 
+  if state.insertNormalMode and normalResult.kind in {hrUndo, hrRedo}:
+    return normalResult
+
   if state.insertNormalMode and
       normalResult.kind notin {hrHandled, hrUnhandled, hrError, hrPlaybackMacro}:
     endInsertNormalSession(buffer, state)
@@ -301,6 +304,10 @@ proc handleNormalMode*(
     )
   of nmrOpenUri:
     return HandlerResult(kind: hrOpenUri, openUri: r.openUri)
+  of nmrUndo:
+    return HandlerResult(kind: hrUndo)
+  of nmrRedo:
+    return HandlerResult(kind: hrRedo)
   of nmrPassthrough:
     # Unreachable: captured by the early return above. Listed to satisfy
     # case exhaustiveness.

--- a/src/moepkg/command_handlers/handler_result.nim
+++ b/src/moepkg/command_handlers/handler_result.nim
@@ -142,6 +142,8 @@ type
     hrLspRestart # Restart LSP server (:lspRestart)
     hrLspFold # LSP folding range (:lspFold)
     hrLspExecuteCommand # LSP execute command (:lspExeCommand)
+    hrUndo # Undo the last change (:undo, :u)
+    hrRedo # Redo the last undone change (:redo)
     hrSubstitute # Search and replace (:s)
     hrDeleteLines # Delete lines (:d, :%d)
     hrReferencesQuit # Close references viewer and return to previous mode
@@ -357,6 +359,8 @@ type
     of hrLspExecuteCommand:
       hrLspCommand*: string
       hrLspCommandArgs*: seq[string]
+    of hrUndo, hrRedo:
+      discard
     of hrSubstitute:
       hrSubstituteCount*: int
     of hrDeleteLines:
@@ -487,7 +491,7 @@ proc group*(k: HandlerResultKind): HandlerResultGroup =
       hrLspRename, hrLspSelectionRange, hrLspDocumentLink, hrConfigQuit,
       hrConfigSaveConfig, hrDebugViewerQuit, hrLogViewerQuit, hrTerminalQuit,
       hrExecCommand, hrFileTreeOpenFile, hrFileTreeQuit, hrOpenUri, hrPlaybackMacro,
-      hrMapAdd, hrMapRemove, hrMapClear, hrMapList:
+      hrMapAdd, hrMapRemove, hrMapClear, hrMapList, hrUndo, hrRedo:
     hrgExitAndResync
 
 proc group*(r: HandlerResult): HandlerResultGroup =

--- a/src/moepkg/command_handlers/insert_handler.nim
+++ b/src/moepkg/command_handlers/insert_handler.nim
@@ -54,6 +54,7 @@ type
     of imrHandled:
       modeTransition*: Option[EditorMode]
       overlayTransition*: Option[OverlayKind]
+      isInterruptExit*: bool
     of imrUnhandled:
       discard
     of imrExecCommand:
@@ -320,13 +321,15 @@ proc handleMotion*(
   return InsertModeResult(kind: imrHandled, modeTransition: none(EditorMode))
 
 proc handleModeSwitch*(
-    handler: InsertModeHandler, targetMode: EditorMode
+    handler: InsertModeHandler, targetMode: EditorMode, isInterruptExit = false
 ): InsertModeResult =
   ## Handle mode switching from insert mode
   # Cancel completion and signature help when leaving insert mode
   handler.completionManager.cancelCompletion()
   handler.signatureHelpManager.hide()
-  return InsertModeResult(kind: imrHandled, modeTransition: some(targetMode))
+  return InsertModeResult(
+    kind: imrHandled, modeTransition: some(targetMode), isInterruptExit: isInterruptExit
+  )
 
 proc charOffsetToBufferPos(
     insertText: string, charOffset: int, startLine, startCol: int
@@ -1379,7 +1382,10 @@ proc handleInsertModeKey*(
     let cmd = route.command
     case cmd.kind
     of ctModeSwitch:
-      return handler.handleModeSwitch(cmd.targetMode)
+      let isInterruptExit =
+        not keyCombo.isSpecial and kmCtrl in keyCombo.modifiers and
+        keyCombo.char.toLowerAscii == "c" and cmd.name == "switch-to-normal"
+      return handler.handleModeSwitch(cmd.targetMode, isInterruptExit)
     of ctOverlaySwitch:
       # Overlay switches not supported in insert mode
       return InsertModeResult(kind: imrUnhandled)

--- a/src/moepkg/command_handlers/mode_dispatchers.nim
+++ b/src/moepkg/command_handlers/mode_dispatchers.nim
@@ -159,7 +159,26 @@ proc replayCountedInsert(buffer: TextBuffer, state: EditorState) =
     cursor = inserted.get.cursor
   state.cursor = cursor
 
-proc finalizeInsertExit(
+proc beginInsertModeSession*(
+    buffer: TextBuffer, state: EditorState, replayCount = 0, replayLineEntry = false
+): Result[void, string] =
+  ## Begin the transaction and tracking shared by all ordinary Insert entries.
+  ## An existing transaction belongs to Insert-Normal or an entry command that
+  ## edited the buffer before returning its mode transition.
+  if not buffer.inTransaction:
+    let transactionResult =
+      buffer.beginTransaction("Insert mode edit", cursorPos = some(state.cursor))
+    if transactionResult.isErr:
+      return err(transactionResult.error)
+
+  if state.editState.insertModeStartPos.isNone:
+    state.editState.insertModeStartPos = some(state.cursor)
+    state.editState.insertReplayCount = replayCount
+    state.editState.insertReplayLineEntry = replayLineEntry
+
+  ok()
+
+proc finalizeInsertExit*(
     buffer: TextBuffer, state: EditorState
 ): Result[string, string] =
   ## Shared leaving-Insert cleanup: snippet/auto-indent teardown, `.`-repeat +
@@ -254,6 +273,15 @@ proc handleInsertMode*(
   of imrHandled:
     # Check if we're leaving Insert mode
     if r.modeTransition.isSome and r.modeTransition.get != EditorMode.Insert:
+      # Forced Insert mode disables Ctrl-o's one-shot Normal command. Keep the
+      # current transaction open so the key is a true no-op.
+      if state.config.standard.forceInsertMode and state.insertNormalMode and
+          r.modeTransition.get == EditorMode.Normal:
+        state.insertNormalMode = false
+        return HandlerResult(
+          kind: hrHandled, modeTransition: none(EditorMode), statusMessage: ""
+        )
+
       # Ctrl-o (insert-normal mode): skip transaction commit/cleanup,
       # keep insert state intact so we can resume after one Normal command
       if state.insertNormalMode:

--- a/src/moepkg/command_handlers/mode_dispatchers.nim
+++ b/src/moepkg/command_handlers/mode_dispatchers.nim
@@ -178,6 +178,50 @@ proc beginInsertModeSession*(
 
   ok()
 
+proc recordLastInsertEdit(transaction: buffer.BufferTransaction, state: EditorState) =
+  let insertedText = extractInsertedText(transaction)
+  if insertedText.len == 0 or state.editState.insertModeStartPos.isNone:
+    return
+
+  if state.editState.substituteContext.isSome:
+    let subCtx = state.editState.substituteContext.get
+    state.editState.lastEditCommand = some(
+      types.LastEditCommand(
+        kind: types.lecSubstitute,
+        substituteText: insertedText,
+        substituteCount: subCtx.deleteCount,
+        substituteKind: subCtx.kind,
+      )
+    )
+  else:
+    state.editState.lastEditCommand = some(
+      types.LastEditCommand(
+        kind: types.lecInsertText,
+        insertedText: insertedText,
+        insertPosition: state.editState.insertModeStartPos.get,
+      )
+    )
+
+proc commitInsertModeBoundary*(
+    buffer: TextBuffer, state: EditorState
+): Result[void, string] =
+  ## Commit one Insert-mode undo group without leaving Insert mode. Unlike an
+  ## Escape or Ctrl-C exit, this keeps snippet and auto-indent state active.
+  if buffer.currentTransaction.isSome:
+    recordLastInsertEdit(buffer.currentTransaction.get, state)
+
+  state.editState.insertModeStartPos = none(BufferPosition)
+  state.editState.insertReplayCount = 0
+  state.editState.insertReplayLineEntry = false
+  state.editState.substituteContext = none(types.SubstituteContext)
+
+  if buffer.inTransaction:
+    let transactionResult = buffer.commitTransaction()
+    if transactionResult.isErr:
+      return err("Failed to commit transaction: " & transactionResult.error)
+
+  ok()
+
 proc finalizeInsertExit*(
     buffer: TextBuffer, state: EditorState
 ): Result[string, string] =
@@ -221,33 +265,14 @@ proc finalizeInsertExit*(
             break
       state.editState.visualBlockInsertContext = none(types.VisualBlockInsertContext)
 
-    if insertedText.len > 0:
-      if state.editState.substituteContext.isSome:
-        let subCtx = state.editState.substituteContext.get
-        state.editState.lastEditCommand = some(
-          types.LastEditCommand(
-            kind: types.lecSubstitute,
-            substituteText: insertedText,
-            substituteCount: subCtx.deleteCount,
-            substituteKind: subCtx.kind,
-          )
-        )
-      else:
-        state.editState.lastEditCommand = some(
-          types.LastEditCommand(
-            kind: types.lecInsertText,
-            insertedText: insertedText,
-            insertPosition: state.editState.insertModeStartPos.get,
-          )
-        )
-
+    recordLastInsertEdit(transaction, state)
     # Replay before commit so [count]i repeats share the same undo group.
     replayCountedInsert(buffer, state)
 
-    state.editState.insertModeStartPos = none(BufferPosition)
-    state.editState.insertReplayCount = 0
-    state.editState.insertReplayLineEntry = false
-    state.editState.substituteContext = none(types.SubstituteContext)
+  state.editState.insertModeStartPos = none(BufferPosition)
+  state.editState.insertReplayCount = 0
+  state.editState.insertReplayLineEntry = false
+  state.editState.substituteContext = none(types.SubstituteContext)
 
   if buffer.inTransaction:
     let transactionResult = buffer.commitTransaction()
@@ -262,6 +287,17 @@ proc finalizeInsertExit*(
 
   ok("")
 
+proc finalizeInsertInterrupt*(
+    buffer: TextBuffer, state: EditorState
+): Result[void, string] =
+  ## Finish Insert mode for Ctrl-C without Escape-only count replay or visual
+  ## block replication. The typed text is still recorded for dot-repeat.
+  state.snippetSession.active = false
+  clearAutoIndentIfUnedited(buffer, state)
+
+  state.editState.visualBlockInsertContext = none(types.VisualBlockInsertContext)
+  commitInsertModeBoundary(buffer, state)
+
 proc handleInsertMode*(
     manager: HandlerManager, editor: Editor, keyCombo: KeyCombo
 ): HandlerResult =
@@ -273,13 +309,15 @@ proc handleInsertMode*(
   of imrHandled:
     # Check if we're leaving Insert mode
     if r.modeTransition.isSome and r.modeTransition.get != EditorMode.Insert:
-      # Forced Insert mode disables Ctrl-o's one-shot Normal command. Keep the
-      # current transaction open so the key is a true no-op.
+      # Forced Insert mode uses Ctrl-o as its built-in route to Command mode.
       if state.config.standard.forceInsertMode and state.insertNormalMode and
           r.modeTransition.get == EditorMode.Normal:
         state.insertNormalMode = false
         return HandlerResult(
-          kind: hrHandled, modeTransition: none(EditorMode), statusMessage: ""
+          kind: hrHandled,
+          modeTransition: none(EditorMode),
+          overlayTransition: some(OverlayKind.okCommand),
+          statusMessage: "",
         )
 
       # Ctrl-o (insert-normal mode): skip transaction commit/cleanup,
@@ -300,7 +338,10 @@ proc handleInsertMode*(
           if finalizeResult.isErr: finalizeResult.error else: finalizeResult.get,
       )
     return HandlerResult(
-      kind: hrHandled, modeTransition: r.modeTransition, statusMessage: ""
+      kind: hrHandled,
+      modeTransition: r.modeTransition,
+      overlayTransition: r.overlayTransition,
+      statusMessage: "",
     )
   of imrUnhandled:
     return HandlerResult(kind: hrUnhandled)

--- a/src/moepkg/command_handlers/mode_dispatchers.nim
+++ b/src/moepkg/command_handlers/mode_dispatchers.nim
@@ -327,6 +327,16 @@ proc handleInsertMode*(
           kind: hrHandled, modeTransition: r.modeTransition, statusMessage: ""
         )
 
+      # Resolve the keybinding before applying Ctrl-C's interrupt semantics so
+      # :iunmap and Insert-mode remaps remain authoritative.
+      if r.isInterruptExit:
+        let interruptResult = finalizeInsertInterrupt(buffer, state)
+        return HandlerResult(
+          kind: hrHandled,
+          modeTransition: r.modeTransition,
+          statusMessage: if interruptResult.isErr: interruptResult.error else: "",
+        )
+
       let finalizeResult = finalizeInsertExit(buffer, state)
       # Even on failure, allow mode transition so user isn't stuck in Insert
       # mode. A committed replication warning (ok with a message) surfaces the

--- a/src/moepkg/command_handlers/normal_handler.nim
+++ b/src/moepkg/command_handlers/normal_handler.nim
@@ -43,6 +43,8 @@ type
     nmrExecCommand # Signal to handler_manager to execute a Command mode command
     nmrJumpToBuffer # Signal to handler_manager to jump to buffer and position
     nmrOpenUri # Signal to handler_manager to open URI/file under cursor
+    nmrUndo # Signal to handler_manager to close an Insert-Normal boundary first
+    nmrRedo # Signal to handler_manager to close an Insert-Normal boundary first
     nmrPassthrough
       # Trivial 1:1 forward to a HandlerResult — payload is the canonical
       # PassthroughKind from command_passthrough.nim.
@@ -72,6 +74,8 @@ type
       nmrJumpColumn*: int # Target column number
     of nmrOpenUri:
       openUri*: string
+    of nmrUndo, nmrRedo:
+      discard
     of nmrPassthrough:
       passthroughKind*: PassthroughKind
 
@@ -728,6 +732,8 @@ proc handleNormalModeKey*(
       return handler.handleInsertModeEntry(buffer, state, "open-above", cmd.count)
     # dd, yy, cc are handled by operator doubling in command_registry
     of "edit.undo":
+      if state.insertNormalMode and buffer.inTransaction:
+        return NormalModeResult(kind: nmrUndo)
       let r = buffer.undo()
       if r.isOk:
         state.cursor = r.value
@@ -745,6 +751,8 @@ proc handleNormalModeKey*(
       else:
         return NormalModeResult(kind: nmrError, errorMessage: r.error)
     of "edit.redo":
+      if state.insertNormalMode and buffer.inTransaction:
+        return NormalModeResult(kind: nmrRedo)
       let r = buffer.redo()
       if r.isOk:
         state.cursor = r.value

--- a/src/moepkg/command_handlers/result_processor.nim
+++ b/src/moepkg/command_handlers/result_processor.nim
@@ -29,7 +29,7 @@ import
   ../[
     editor, modes, buffer, logger, types, filer, filetree, lsp_service, primitives,
     syntax_checker, cursor_util, quick_run_utils, command_completion, key_bindings,
-    key_router, lsp_integration,
+    key_router, lsp_integration, command_registry,
   ]
 import
   backup_ops, config_ops, debug_ops, editor_ops, file_ops, handler_result,
@@ -88,6 +88,56 @@ proc modeSwitchEntry(mode: EditorMode): Option[HandlerResult] =
     some(HandlerResult(kind: hrEnterFileTree, enterFileTreePath: none(string)))
   else:
     none(HandlerResult)
+
+proc processHistoryResult(e: Editor, r: HandlerResult, activeBuffer: TextBuffer): bool =
+  ## Execute undo/redo at a committed Insert boundary. Buffer history rejects
+  ## open transactions, so commands such as forced-Insert `Ctrl-o :undo` first
+  ## turn the current typing group into an ordinary undo entry.
+  let
+    wasInsertNormal = e.state.insertNormalMode
+    resumeInsert = e.state.mode == EditorMode.Insert or wasInsertNormal
+
+  var boundaryResult = Result[void, string].ok()
+  if activeBuffer.inTransaction:
+    boundaryResult =
+      if e.state.editState.visualBlockInsertContext.isSome:
+        let finalizeResult = finalizeInsertExit(activeBuffer, e.state)
+        if finalizeResult.isErr:
+          Result[void, string].err(finalizeResult.error)
+        else:
+          Result[void, string].ok()
+      else:
+        commitInsertModeBoundary(activeBuffer, e.state)
+
+  if boundaryResult.isErr:
+    e.state.statusMessage = boundaryResult.error
+  else:
+    let ctx = CommandContext(
+      buffer: activeBuffer,
+      state: e.state,
+      viewport: e.viewport,
+      motionController: e.motionController,
+      keyBindingRegistry: e.keyBindingRegistry,
+    )
+    let commandId =
+      if r.kind == hrUndo:
+        builtin(bcEditUndo)
+      else:
+        builtin(bcEditRedo)
+    let historyResult = e.commandRegistry.execute(ctx, commandId)
+    if historyResult.isErr:
+      e.state.statusMessage = historyResult.error
+
+  if resumeInsert and not activeBuffer.readOnly and not activeBuffer.inTransaction:
+    let beginResult = beginInsertModeSession(activeBuffer, e.state)
+    if beginResult.isErr:
+      e.state.statusMessage = "Failed to begin transaction: " & beginResult.error
+
+  if wasInsertNormal:
+    e.state.insertNormalMode = false
+    e.setMode(EditorMode.Insert)
+
+  true
 
 proc processResult*(e: Editor, r: HandlerResult, activeBuffer: TextBuffer): bool =
   ## Apply the editor-level side effects implied by `r`. Returns true to
@@ -163,6 +213,8 @@ proc processResult*(e: Editor, r: HandlerResult, activeBuffer: TextBuffer): bool
     return true # Unified: ops-moved kinds keep their own status message
   of hrSetBoolOption, hrSetIntOption, hrSetFloatOption:
     return e.processSetOptionResult(r)
+  of hrUndo, hrRedo:
+    return e.processHistoryResult(r, activeBuffer)
   of hrClearSearchHighlight, hrStripWhitespace, hrShellCommand, hrBackground, hrMan,
       hrSubstitute, hrDeleteLines, hrBuild:
     return e.processMiscResult(r, activeBuffer)

--- a/src/moepkg/command_handlers/result_processor.nim
+++ b/src/moepkg/command_handlers/result_processor.nim
@@ -232,7 +232,7 @@ proc processResultEpilogue(
   let modeTransition = r.getModeTransition()
   if modeTransition.isSome:
     let oldMode = e.state.mode
-    let newMode = modeTransition.get
+    let newMode = e.effectiveMode(modeTransition.get)
 
     # Replay a `mode_switch`-named viewer's real entry result so it never
     # goes live without its state — but only if not already live (Escape back
@@ -490,8 +490,11 @@ proc runNestedKeyCombo*(
     let expand = checkRuntimeKeySeqMapping(manager, e, keyCombo)
     if expand.isSome:
       return expand.get
-  let r = manager.handleKeyCombo(e, keyCombo)
-  processReplayedResult(e, r, e.activeBuffer)
+  let
+    r = manager.handleKeyCombo(e, keyCombo)
+    outcome = processReplayedResult(e, r, e.activeBuffer)
+  e.enforceModePolicy()
+  outcome
 
 proc outcomeToHandlerResult(e: Editor, outcome: ReplayOutcome): HandlerResult =
   ## Fold a ReplayOutcome into the HandlerResult shape test-facing wrappers

--- a/src/moepkg/command_handlers/visual_commands.nim
+++ b/src/moepkg/command_handlers/visual_commands.nim
@@ -328,6 +328,8 @@ proc visualDelete*(buffer: TextBuffer, state: EditorState) =
         checkVisualEdit(state, buffer.deleteRange(selStart, selEnd))
         state.cursor = selStart
     if txr.isErr:
+      if state.statusMessage.len == 0:
+        state.statusMessage = txr.error
       state.visualSelection.active = false
       state.mode = state.previousMode
       return
@@ -371,6 +373,8 @@ proc visualIndent*(buffer: TextBuffer, state: EditorState, count: int = 1) =
       state.cursor.line = startLine
       state.cursor.column = 0
     if txr.isErr:
+      if state.statusMessage.len == 0:
+        state.statusMessage = txr.error
       state.visualSelection.active = false
       state.mode = state.previousMode
       return
@@ -400,6 +404,8 @@ proc visualDedent*(buffer: TextBuffer, state: EditorState, count: int = 1) =
       state.cursor.line = startLine
       state.cursor.column = 0
     if txr.isErr:
+      if state.statusMessage.len == 0:
+        state.statusMessage = txr.error
       state.visualSelection.active = false
       state.mode = state.previousMode
       return
@@ -464,6 +470,8 @@ proc applyVisualTextTransform(
 
     state.cursor = selStart
   if txr.isErr:
+    if state.statusMessage.len == 0:
+      state.statusMessage = txr.error
     state.visualSelection.active = false
     state.mode = state.previousMode
     return
@@ -774,6 +782,8 @@ proc visualChange*(buffer: TextBuffer, state: EditorState) =
 
         state.cursor = selStart
     if txr.isErr:
+      if state.statusMessage.len == 0:
+        state.statusMessage = txr.error
       state.visualSelection.active = false
       state.mode = state.previousMode
       return
@@ -981,6 +991,8 @@ proc visualSurround*(buffer: TextBuffer, state: EditorState, ch: string) =
 
       state.cursor = selStart
     if txr.isErr:
+      if state.statusMessage.len == 0:
+        state.statusMessage = txr.error
       state.visualSelection.active = false
       state.mode = state.previousMode
       return

--- a/src/moepkg/command_line/executor.nim
+++ b/src/moepkg/command_line/executor.nim
@@ -81,6 +81,10 @@ proc execute*(parser: CommandLineParser, cmd: ParsedCommand): CommandLineResult 
     )
   of claEnew:
     return CommandLineResult(kind: claEnew)
+  of claUndo:
+    return CommandLineResult(kind: claUndo)
+  of claRedo:
+    return CommandLineResult(kind: claRedo)
   of claGoto:
     if cmd.args.len > 0:
       try:

--- a/src/moepkg/command_line/types.nim
+++ b/src/moepkg/command_line/types.nim
@@ -37,6 +37,8 @@ type
     claEnew # :ene, :enew (new empty buffer)
     claSet # :set
     claHelp # :help, :h
+    claUndo # :undo, :u
+    claRedo # :redo
     claSubstitute # :s
     claDeleteLines # :d, :%d (delete lines)
     claGoto # :123 (go to line 123)
@@ -143,7 +145,7 @@ type
     of claEdit:
       editFilename*: Option[string]
       forceEdit*: bool # true for :e!
-    of claEnew:
+    of claEnew, claUndo, claRedo:
       discard
     of claGoto:
       lineNumber*: int

--- a/src/moepkg/command_line_commands.nim
+++ b/src/moepkg/command_line_commands.nim
@@ -321,6 +321,29 @@ const CommandLineCommandTable*: seq[CommandLineCommandSpec] = @[
     action: some(claVnew),
     isCanonicalLong: true,
   ),
+  # Edit history
+  CommandLineCommandSpec(
+    name: "u",
+    completionDescription: "Undo the last change",
+    helpEntries: @[],
+    action: some(claUndo),
+    isCanonicalLong: false,
+  ),
+  CommandLineCommandSpec(
+    name: "undo",
+    completionDescription: "Undo the last change",
+    helpEntries: @[HelpEntry(syntax: "undo", description: "Undo the last change")],
+    action: some(claUndo),
+    isCanonicalLong: true,
+  ),
+  CommandLineCommandSpec(
+    name: "redo",
+    completionDescription: "Redo the last undone change",
+    helpEntries:
+      @[HelpEntry(syntax: "redo", description: "Redo the last undone change")],
+    action: some(claRedo),
+    isCanonicalLong: true,
+  ),
   # Substitute / delete lines
   CommandLineCommandSpec(
     name: "s",

--- a/src/moepkg/command_registry/edit.nim
+++ b/src/moepkg/command_registry/edit.nim
@@ -512,6 +512,7 @@ proc handleSubstituteChar*(ctx: CommandContext, count: int = 1): Result[(), stri
     let transactionResult = ctx.buffer.beginTransaction("Substitute")
     if transactionResult.isErr:
       return err("Failed to begin transaction: " & transactionResult.error)
+    ctx.state.editState.insertModeStartPos = some(ctx.cursor)
     ctx.state.statusMessage = "-- INSERT --"
     return Result[(), string].ok ()
 
@@ -542,6 +543,7 @@ proc handleSubstituteChar*(ctx: CommandContext, count: int = 1): Result[(), stri
   ctx.state.mode = EditorMode.Insert
 
   # Record substitute context so Insert mode exit can properly record the command
+  ctx.state.editState.insertModeStartPos = some(ctx.cursor)
   ctx.state.editState.substituteContext =
     some(SubstituteContext(kind: skChar, deleteCount: charsToDelete))
 
@@ -623,6 +625,7 @@ proc handleSubstituteLine*(ctx: CommandContext, count: int = 1): Result[(), stri
 
   # Record substitute context so Insert mode exit can properly record the command
   let lineCount = endLine - startLine + 1
+  ctx.state.editState.insertModeStartPos = some(ctx.cursor)
   ctx.state.editState.substituteContext =
     some(SubstituteContext(kind: skLine, deleteCount: lineCount))
 

--- a/src/moepkg/config.nim
+++ b/src/moepkg/config.nim
@@ -81,6 +81,7 @@ proc newEditorConfig*(): EditorConfig =
       smartIndent: false,
       ignorecase: true,
       smartcase: true,
+      forceInsertMode: false,
       disableChangeCursor: false,
       defaultCursor: ctTerminalDefault,
       normalModeCursor: ctBlinkBlock,

--- a/src/moepkg/editor.nim
+++ b/src/moepkg/editor.nim
@@ -39,6 +39,7 @@ import
   editor_display,
   editor_substitute,
   editor_buffers,
+  editor_mode,
   viewer_mode,
   editor_reload,
   editor_config_reload,
@@ -59,7 +60,7 @@ export
   editor_selection, editor_selectionrange, editor_documentsymbol, editor_documentlink,
   editor_signaturehelp, editor_hover, editor_callhierarchy, editor_navigation,
   editor_render, editor_display, editor_substitute, editor_buffers, editor_reload,
-  editor_config_reload, editor_frame
+  editor_config_reload, editor_frame, editor_mode
 
 proc addCommandAlias*(
     e: Editor, alias: string, action: CommandLineAction

--- a/src/moepkg/editor_buffers.nim
+++ b/src/moepkg/editor_buffers.nim
@@ -27,6 +27,7 @@ import pkg/results
 
 import
   types/editor_types,
+  editor_mode,
   editor_window,
   editor_window_state,
   git_cache,
@@ -158,6 +159,7 @@ proc activateBufferInWindow(e: Editor, targetBuffer: TextBuffer) =
 
   # syncActiveWindow also updates state.windowDisplay.currentBufferId for the Jump List anchor.
   e.syncActiveWindow()
+  e.enforceModePolicy()
   e.setActiveWindowScreenCursor(e.activeWindow)
 
 proc switchToBufferByIndex*(e: Editor, index: int) =
@@ -685,6 +687,7 @@ proc openAdditionalStartupFiles*(
         logError("moe", fmt"Failed to split for {filePath}: {splitResult.error}")
       elif readonly:
         e.activeBuffer().readOnly = true
+        e.enforceModePolicy()
     else:
       let bufResult = e.loadOrCreateBuffer(filePath)
       if bufResult.isErr:

--- a/src/moepkg/editor_config_reload.nim
+++ b/src/moepkg/editor_config_reload.nim
@@ -29,6 +29,7 @@ import
   types/editor_types,
   editor_lsp,
   editor_init,
+  editor_mode,
   git_cache,
   color,
   highlight,
@@ -122,6 +123,7 @@ proc applyConfigSettings*(e: Editor, newConfig: EditorConfig) =
   # Store the new config; state.config aliases the same ref.
   e.config = newConfig
   e.state.config = newConfig
+  e.enforceModePolicy()
 
   # Re-apply [Lsp.<lang>] entries so live reload / :lspRestart pick up server
   # command/args/trace/rust-analyzer edits. Already-running workers keep

--- a/src/moepkg/editor_file.nim
+++ b/src/moepkg/editor_file.nim
@@ -32,6 +32,7 @@ import
   search_utils,
   editorconfig_helper,
   editor_codelens,
+  editor_mode,
   highlight,
   highlight_config,
   persist,
@@ -355,6 +356,12 @@ proc saveFile*(
     logError("editor", "Save failed: File was modified externally: " & savePath)
     return err(ExternalModErrorMsg)
 
+  let insertBoundaryResult = e.commitForcedInsertBoundary(restart = false)
+  if insertBoundaryResult.isErr:
+    return err(insertBoundaryResult.error)
+  defer:
+    e.enforceModePolicy()
+
   # Trim trailing whitespace if EditorConfig says so; reverted on save failure.
   let didTrimRes = trimTrailingWhitespaceTracked(activeBuffer)
   if didTrimRes.isErr:
@@ -401,6 +408,13 @@ proc saveAllBuffers*(e: Editor, force: bool = false): SaveAllBuffersResult =
   ## When `force` is false, buffers whose underlying file was changed externally
   ## are skipped and reported via `skippedExternal`. When true, those changes
   ## are overwritten.
+  let insertBoundaryResult = e.commitForcedInsertBoundary(restart = false)
+  if insertBoundaryResult.isErr:
+    result.failures.add((path: "", error: insertBoundaryResult.error))
+    return
+  defer:
+    e.enforceModePolicy()
+
   for buffer in e.buffers:
     if not buffer.isModified:
       continue
@@ -480,6 +494,15 @@ proc autoSave*(e: Editor) =
 
   if elapsed < threshold:
     return
+
+  let insertBoundaryResult = e.commitForcedInsertBoundary(restart = false)
+  if insertBoundaryResult.isErr:
+    logError(
+      "editor", "Auto save insert boundary failed: " & insertBoundaryResult.error
+    )
+    return
+  defer:
+    e.enforceModePolicy()
 
   # Iterate `e.buffers`, not windows: windows only expose foreground tabs,
   # so background-tab buffers would silently miss auto save.

--- a/src/moepkg/editor_frame.nim
+++ b/src/moepkg/editor_frame.nim
@@ -31,6 +31,7 @@ import
   types/editor_types,
   editor_reload,
   editor_config_reload,
+  editor_mode,
   editor_file,
   editor_lsp,
   editor_codelens,
@@ -353,6 +354,7 @@ proc tick*(e: Editor) =
   e.tickLsp()
   e.tickFileAndConfig()
   e.tickGitAndDebug()
+  e.tickForcedInsertBoundary()
   e.tickAutoSave()
   e.tickNotifications()
 

--- a/src/moepkg/editor_mode.nim
+++ b/src/moepkg/editor_mode.nim
@@ -17,37 +17,33 @@
 #                                                                              #
 #[############################################################################]#
 
-## Behavioral coverage for the frontend embedding facade.
+## Configuration-driven editor mode policy.
 
-import std/unittest
+import pkg/results
 
-import ../src/moepkg/frontend
+import types/editor_types
+import command_handlers/mode_dispatchers
 
-suite "frontend embedding facade":
-  test "constructs and queries an editor through one import":
-    let e = newEditor(newEditorConfig())
+func forceInsertMode(e: Editor): bool =
+  not e.isNil and not e.config.isNil and e.config.standard.forceInsertMode
 
-    e.setFrontendGitStatusEnabled(true)
-    let status: FrontendStatus = e.frontendStatus
+func effectiveMode*(e: Editor, requestedMode: EditorMode): EditorMode =
+  ## Resolve a requested mode through the configured editing policy.
+  if e.forceInsertMode and requestedMode == EditorMode.Normal:
+    EditorMode.Insert
+  else:
+    requestedMode
 
-    check status.modeLabel == "NORMAL"
-    check e.frontendGitStatusEnabled
+proc enforceModePolicy*(e: Editor) =
+  ## Keep an editable window in a valid Insert session when Normal mode is
+  ## disabled. Special and Visual modes remain available.
+  if not e.forceInsertMode or e.currentMode notin {EditorMode.Normal, EditorMode.Insert}:
+    return
 
-  test "exposes frontend-neutral input values and handlers":
-    let
-      e = newEditor(newEditorConfig())
-      pointer = PointerInput(
-        row: 2, column: 3, button: pbPrimary, action: paPress, clickCount: 1
-      )
+  let transactionResult = beginInsertModeSession(e.activeBuffer, e.state)
+  if transactionResult.isErr:
+    e.state.statusMessage = "Failed to begin transaction: " & transactionResult.error
+    return
 
-    check pointer.row == 2
-    check pointer.column == 3
-    check e.handleTextInput("")
-
-  test "can disable Normal mode through the public config":
-    let config = newEditorConfig()
-    config.standard.forceInsertMode = true
-    let e = newEditor(config)
-
-    check e.frontendStatus.modeLabel == "INSERT"
-    check e.handleTextInput("x")
+  if e.currentMode == EditorMode.Normal:
+    e.setMode(EditorMode.Insert)

--- a/src/moepkg/editor_mode.nim
+++ b/src/moepkg/editor_mode.nim
@@ -19,25 +19,49 @@
 
 ## Configuration-driven editor mode policy.
 
+import std/[monotimes, options, times]
+
 import pkg/results
 
-import types/editor_types
+import types/editor_types, buffer
 import command_handlers/mode_dispatchers
 
 func forceInsertMode(e: Editor): bool =
   not e.isNil and not e.config.isNil and e.config.standard.forceInsertMode
 
+func canForceInsertMode(e: Editor): bool =
+  e.forceInsertMode and e.state.overlay.isNone and not e.activeBuffer.readOnly
+
 func effectiveMode*(e: Editor, requestedMode: EditorMode): EditorMode =
   ## Resolve a requested mode through the configured editing policy.
-  if e.forceInsertMode and requestedMode == EditorMode.Normal:
+  if e.canForceInsertMode and requestedMode == EditorMode.Normal:
     EditorMode.Insert
   else:
     requestedMode
 
+proc clearInsertSessionTracking(e: Editor) =
+  e.state.editState.insertModeStartPos = none(BufferPosition)
+  e.state.editState.insertReplayCount = 0
+  e.state.editState.insertReplayLineEntry = false
+  e.state.editState.visualBlockInsertContext = none(types.VisualBlockInsertContext)
+  e.state.editState.substituteContext = none(types.SubstituteContext)
+
 proc enforceModePolicy*(e: Editor) =
-  ## Keep an editable window in a valid Insert session when Normal mode is
-  ## disabled. Special and Visual modes remain available.
-  if not e.forceInsertMode or e.currentMode notin {EditorMode.Normal, EditorMode.Insert}:
+  ## Keep an editable window in a valid Insert session when Normal mode is disabled.
+  if not e.forceInsertMode or e.state.overlay.isSome:
+    return
+
+  if e.activeBuffer.readOnly:
+    if e.currentMode == EditorMode.Insert:
+      if e.activeBuffer.inTransaction:
+        let commitResult = e.activeBuffer.commitTransaction()
+        if commitResult.isErr:
+          e.state.statusMessage = "Failed to commit transaction: " & commitResult.error
+      e.clearInsertSessionTracking()
+      e.setMode(EditorMode.Normal)
+    return
+
+  if e.currentMode notin {EditorMode.Normal, EditorMode.Insert}:
     return
 
   let transactionResult = beginInsertModeSession(e.activeBuffer, e.state)
@@ -47,3 +71,48 @@ proc enforceModePolicy*(e: Editor) =
 
   if e.currentMode == EditorMode.Normal:
     e.setMode(EditorMode.Insert)
+
+proc commitForcedInsertBoundary*(
+    e: Editor, restart: bool = true
+): Result[void, string] =
+  ## Commit the active forced-Insert transaction for undo/save boundaries.
+  if not e.forceInsertMode or e.currentMode != EditorMode.Insert or
+      e.activeBuffer.readOnly:
+    return ok()
+
+  let commitResult =
+    if e.state.editState.visualBlockInsertContext.isSome:
+      let finalizeResult = finalizeInsertExit(e.activeBuffer, e.state)
+      if finalizeResult.isErr:
+        err(finalizeResult.error)
+      else:
+        ok()
+    else:
+      commitInsertModeBoundary(e.activeBuffer, e.state)
+  if commitResult.isErr:
+    return err(commitResult.error)
+
+  if restart:
+    let beginResult = beginInsertModeSession(e.activeBuffer, e.state)
+    if beginResult.isErr:
+      return err("Failed to begin transaction: " & beginResult.error)
+
+  ok()
+
+proc tickForcedInsertBoundary*(e: Editor) =
+  ## End a typing undo group after a short idle period, then keep Insert active.
+  const UndoIdleMilliseconds = 500
+
+  if not e.canForceInsertMode or e.currentMode != EditorMode.Insert or
+      not e.activeBuffer.inTransaction or e.activeBuffer.currentTransaction.isNone or
+      e.activeBuffer.currentTransaction.get.changes.len == 0 or
+      e.state.editState.visualBlockInsertContext.isSome:
+    return
+
+  let idle = getMonoTime() - e.state.timing.lastInputTime
+  if idle.inMilliseconds < UndoIdleMilliseconds:
+    return
+
+  let boundaryResult = e.commitForcedInsertBoundary()
+  if boundaryResult.isErr:
+    e.state.statusMessage = boundaryResult.error

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -214,7 +214,7 @@ proc handleRecentFileModeKeyCombo(e: Editor, keyCombo: KeyCombo): bool =
       hrCallHierarchyRequestIncoming, hrCallHierarchyRequestOutgoing, hrEnterTerminal,
       hrTerminalQuit, hrExecCommand, hrOnlyWindow, hrEnterFileTree, hrFileTreeOpenFile,
       hrFileTreeQuit, hrOpenUri, hrCquit, hrConflictNext, hrConflictPrev, hrMapAdd,
-      hrMapRemove, hrMapClear, hrMapList, hrPlaybackMacro:
+      hrMapRemove, hrMapClear, hrMapList, hrPlaybackMacro, hrUndo, hrRedo:
     discard # Not expected from RecentFile mode handler
 
   # Route overlay/mode transitions through processResult so a viewer target
@@ -1360,12 +1360,6 @@ proc handleKeyCombo*(e: Editor, keyCombo: KeyCombo): bool =
   let popupResult = e.handlePopupKeyCombo(keyCombo)
   if popupResult.isSome:
     return popupResult.get
-
-  # GUI frontends may deliver Ctrl-C as a KeyCombo rather than an interrupt
-  # event. Route both forms through the same non-Escape Insert cleanup.
-  if e.state.mode == EditorMode.Insert and not keyCombo.isSpecial and
-      kmCtrl in keyCombo.modifiers and keyCombo.char.toLowerAscii == "c":
-    return e.handleInterruptCore()
 
   # In Normal mode, Escape cancels pending multi-key state
   if e.handleEscapeCancellationKeyCombo(keyCombo):

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -1084,14 +1084,12 @@ proc handleInterruptCore(e: Editor): bool =
     # Other file edit modes (Insert, Visual, Replace, etc.): switch to Normal mode
     let activeBuffer = e.activeBuffer()
 
-    # Finalize the complete Insert session so replay/snippet/block state cannot
-    # leak across Ctrl-C. Replace mode only owns a transaction and history.
+    # Ctrl-C records the insert for dot-repeat, but does not run Escape-only
+    # counted-insert replay or visual-block replication.
     if e.state.mode == EditorMode.Insert:
-      let finalizeResult = finalizeInsertExit(activeBuffer, e.state)
+      let finalizeResult = finalizeInsertInterrupt(activeBuffer, e.state)
       if finalizeResult.isErr:
         e.state.statusMessage = finalizeResult.error
-      elif finalizeResult.get.len > 0:
-        e.state.statusMessage = finalizeResult.get
     elif e.state.mode == EditorMode.Replace:
       if activeBuffer.inTransaction:
         clearAutoIndentIfUnedited(activeBuffer, e.state)
@@ -1100,6 +1098,7 @@ proc handleInterruptCore(e: Editor): bool =
           logError "handler", "Failed to commit transaction: " & commitResult.error
           e.state.statusMessage = "Failed to commit transaction: " & commitResult.error
       e.state.editState.replaceHistory = @[]
+      e.state.editState.substituteContext = none(types.SubstituteContext)
 
     e.state.previousMode = e.state.mode
     e.setMode(EditorMode.Normal)
@@ -1354,12 +1353,19 @@ proc handleKeyCombo*(e: Editor, keyCombo: KeyCombo): bool =
   # Handle overlay modes (Command, Search, Rename) + Debug mode
   let overlayResult = e.handleOverlayKeyCombo(keyCombo)
   if overlayResult.isSome:
+    e.enforceModePolicy()
     return overlayResult.get
 
   # Handle LSP popups (CodeLens picker, Hover popup); some keys fall through
   let popupResult = e.handlePopupKeyCombo(keyCombo)
   if popupResult.isSome:
     return popupResult.get
+
+  # GUI frontends may deliver Ctrl-C as a KeyCombo rather than an interrupt
+  # event. Route both forms through the same non-Escape Insert cleanup.
+  if e.state.mode == EditorMode.Insert and not keyCombo.isSpecial and
+      kmCtrl in keyCombo.modifiers and keyCombo.char.toLowerAscii == "c":
+    return e.handleInterruptCore()
 
   # In Normal mode, Escape cancels pending multi-key state
   if e.handleEscapeCancellationKeyCombo(keyCombo):
@@ -1526,6 +1532,7 @@ proc runBuildAsync(
         if splitResult.isErr:
           editor.notify("Failed to open output window: " & splitResult.error, nlError)
         else:
+          editor.enforceModePolicy()
           if editor.config.notification.screenNotifications and
               editor.config.notification.buildOnSaveScreenNotify:
             editor.notify("Build completed: " & info.path)
@@ -1567,6 +1574,7 @@ proc runQuickRunAsync(
           if splitResult.isErr:
             editor.notify("Failed to open output window: " & splitResult.error, nlError)
           else:
+            editor.enforceModePolicy()
             if editor.config.notification.screenNotifications and
                 editor.config.notification.quickRunScreenNotify:
               editor.notify("QuickRun completed: " & qrProcess.filePath)

--- a/src/moepkg/handler.nim
+++ b/src/moepkg/handler.nim
@@ -944,6 +944,7 @@ proc prepareForInput(e: Editor, isKeyInput: bool) =
   # Clear status message from previous event cycle:
   # messages persist for one render frame, then clear on next input)
   e.state.statusMessage = ""
+  e.enforceModePolicy()
 
   # Update last input time for auto backup idle detection
   e.updateInputTime()
@@ -978,7 +979,8 @@ proc handlePointerInput*(e: Editor, input: PointerInput): bool =
   ## Middle-click paste is intentionally a host policy: GUI frontends should
   ## obtain the selection text and pass it to `handlePaste`.
   e.prepareForInput(false)
-  e.handlePointerInputCore(input)
+  result = e.handlePointerInputCore(input)
+  e.enforceModePolicy()
 
 proc handleScrollInput*(e: Editor, input: ScrollInput): ScrollOutcome =
   ## Handle a vertical scroll expressed as a signed number of physical lines
@@ -1009,13 +1011,18 @@ proc handleMouseEvent*(e: Editor, event: Event): bool =
   let modifiers = celinaMouseModifiers(mouse.modifiers)
   case mouse.button
   of mouse_logic.MouseButton.WheelUp:
-    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, -3, modifiers)).handled
+    result =
+      e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, -3, modifiers)).handled
   of mouse_logic.MouseButton.WheelDown:
-    e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, 3, modifiers)).handled
+    result =
+      e.handleScrollInputCore(initScrollInput(mouse.y, mouse.x, 3, modifiers)).handled
   of mouse_logic.MouseButton.Left:
-    e.handlePointerInputCore(initPointerInput(mouse.y, mouse.x, modifiers = modifiers))
+    result = e.handlePointerInputCore(
+      initPointerInput(mouse.y, mouse.x, modifiers = modifiers)
+    )
   else:
-    false
+    result = false
+  e.enforceModePolicy()
 
 proc handleInterruptCore(e: Editor): bool =
   ## Handle Ctrl-C. Behaviour depends on the
@@ -1077,25 +1084,32 @@ proc handleInterruptCore(e: Editor): bool =
     # Other file edit modes (Insert, Visual, Replace, etc.): switch to Normal mode
     let activeBuffer = e.activeBuffer()
 
-    # Commit transaction when leaving Insert or Replace mode
-    if e.state.mode in {EditorMode.Insert, EditorMode.Replace}:
+    # Finalize the complete Insert session so replay/snippet/block state cannot
+    # leak across Ctrl-C. Replace mode only owns a transaction and history.
+    if e.state.mode == EditorMode.Insert:
+      let finalizeResult = finalizeInsertExit(activeBuffer, e.state)
+      if finalizeResult.isErr:
+        e.state.statusMessage = finalizeResult.error
+      elif finalizeResult.get.len > 0:
+        e.state.statusMessage = finalizeResult.get
+    elif e.state.mode == EditorMode.Replace:
       if activeBuffer.inTransaction:
         clearAutoIndentIfUnedited(activeBuffer, e.state)
         let commitResult = activeBuffer.commitTransaction()
         if commitResult.isErr:
           logError "handler", "Failed to commit transaction: " & commitResult.error
           e.state.statusMessage = "Failed to commit transaction: " & commitResult.error
-      # Clear insert mode tracking state
-      e.state.editState.insertModeStartPos = none(BufferPosition)
-      e.state.editState.substituteContext = none(types.SubstituteContext)
       e.state.editState.replaceHistory = @[]
 
     e.state.previousMode = e.state.mode
     e.setMode(EditorMode.Normal)
+    e.enforceModePolicy()
 
-    # Adjust cursor: move one position left when exiting Insert mode
-    let lineCharLen = activeBuffer.getLine(e.activeWindow.cursor.line).charLen
-    adjustCursorAfterInsertExit(e.activeWindow.cursor, lineCharLen)
+    # Adjust the cursor only when the transition really entered Normal mode.
+    # Forced Insert mode redirects it into a fresh Insert session instead.
+    if e.state.mode == EditorMode.Normal:
+      let lineCharLen = activeBuffer.getLine(e.activeWindow.cursor.line).charLen
+      adjustCursorAfterInsertExit(e.activeWindow.cursor, lineCharLen)
 
   return true
 

--- a/src/moepkg/help_generator.nim
+++ b/src/moepkg/help_generator.nim
@@ -852,6 +852,7 @@ proc renderCommandModeHead*(): string {.compileTime.} =
       helpEntriesFor("bg") & helpEntriesFor("man"),
     helpEntriesFor("e") & helpEntriesFor("ene") & helpEntriesFor("new") &
       helpEntriesFor("vnew"),
+    helpEntriesFor("undo") & helpEntriesFor("redo"),
     @[CommandLineSpecialHelp.substitute] & helpEntriesFor("delete") &
       @[CommandLineSpecialHelp.deleteAll, CommandLineSpecialHelp.deleteRange],
     helpEntriesFor("ls") & helpEntriesFor("bprev") & helpEntriesFor("bnext") &

--- a/src/moepkg/help_markdown.nim
+++ b/src/moepkg/help_markdown.nim
@@ -57,8 +57,9 @@ const
   ## divergence is intentional — TUI help groups by action, the markdown
   ## doc groups by user-discoverability (basic → forced → window-scoped).
   CommandModeHeadNames = @[
-    "bg", "man", "e", "ene", "new", "vnew", "delete", "ls", "bprev", "bnext", "bfirst",
-    "blast", "bd", "vs", "sp", "only", "theme", "noh", "stripwhitespace",
+    "bg", "man", "e", "ene", "new", "vnew", "undo", "redo", "delete", "ls", "bprev",
+    "bnext", "bfirst", "blast", "bd", "vs", "sp", "only", "theme", "noh",
+    "stripwhitespace",
   ]
 
   CommandModeTailNames = @[

--- a/src/moepkg/types/config_types.nim
+++ b/src/moepkg/types/config_types.nim
@@ -128,6 +128,11 @@ type
     .}: bool
     ignorecase* {.cfg, cfgDocDescription: "Enable ignorecase when searching".}: bool
     smartcase* {.cfg, cfgDocDescription: "Enable smartcase when searching".}: bool
+    forceInsertMode* {.
+      cfg,
+      cfgDocDescription:
+        "Keep editable buffers in Insert mode and disable Normal-mode commands"
+    .}: bool
     disableChangeCursor* {.
       cfg, cfgDocDescription: "Disable change of the cursor shape"
     .}: bool

--- a/src/moepkg/types/config_types.nim
+++ b/src/moepkg/types/config_types.nim
@@ -131,7 +131,7 @@ type
     forceInsertMode* {.
       cfg,
       cfgDocDescription:
-        "Keep editable buffers in Insert mode and disable Normal-mode commands"
+        "Keep editable buffers in Insert mode; Ctrl-O opens the command line"
     .}: bool
     disableChangeCursor* {.
       cfg, cfgDocDescription: "Disable change of the cursor shape"

--- a/tests/test_buffer_undo_redo.nim
+++ b/tests/test_buffer_undo_redo.nim
@@ -1802,3 +1802,39 @@ suite "Buffer - readOnly guard on undo/redo":
     let rr = b.redo()
     check rr.isErr
     check rr.error == "Buffer is read-only"
+
+suite "Buffer - transaction guard on undo/redo":
+  test "undo rejects an open transaction without changing history or text":
+    let b = newTextBuffer("abc")
+    discard b.insertText(BufferPosition(line: 0, column: 3), "d")
+    check b.beginTransaction("typing").isOk
+    discard b.insertText(BufferPosition(line: 0, column: 4), "e")
+    let undoLenBefore = b.undoStack.len
+    let redoLenBefore = b.redoStack.len
+
+    let r = b.undo()
+
+    check r.isErr
+    check r.error == "Cannot undo during a transaction"
+    check b.getLine(0) == "abcde"
+    check b.inTransaction
+    check b.undoStack.len == undoLenBefore
+    check b.redoStack.len == redoLenBefore
+
+  test "redo rejects an open transaction without changing history or text":
+    let b = newTextBuffer("abc")
+    discard b.insertText(BufferPosition(line: 0, column: 3), "d")
+    check b.undo().isOk
+    check b.beginTransaction("typing").isOk
+    discard b.insertText(BufferPosition(line: 0, column: 3), "e")
+    let undoLenBefore = b.undoStack.len
+    let redoLenBefore = b.redoStack.len
+
+    let r = b.redo()
+
+    check r.isErr
+    check r.error == "Cannot redo during a transaction"
+    check b.getLine(0) == "abce"
+    check b.inTransaction
+    check b.undoStack.len == undoLenBefore
+    check b.redoStack.len == redoLenBefore

--- a/tests/test_buffer_undo_redo.nim
+++ b/tests/test_buffer_undo_redo.nim
@@ -1571,23 +1571,22 @@ suite "Buffer - Transaction Partial Failure Recovery":
       startSeq: baselineSeq,
       endSeq: baselineSeq + 2,
       kind: ckTransaction,
-      transactionChanges:
-        @[
-          BufferChange(
-            startSeq: baselineSeq,
-            endSeq: baselineSeq + 1,
-            kind: ckInsertLine,
-            insertLineIdx: 999,
-            insertLineText: "x",
-          ),
-          BufferChange(
-            startSeq: baselineSeq + 1,
-            endSeq: baselineSeq + 2,
-            kind: ckInsertText,
-            insertPos: BufferPosition(line: 0, column: 0),
-            insertText: "X",
-          ),
-        ],
+      transactionChanges: @[
+        BufferChange(
+          startSeq: baselineSeq,
+          endSeq: baselineSeq + 1,
+          kind: ckInsertLine,
+          insertLineIdx: 999,
+          insertLineText: "x",
+        ),
+        BufferChange(
+          startSeq: baselineSeq + 1,
+          endSeq: baselineSeq + 2,
+          kind: ckInsertText,
+          insertPos: BufferPosition(line: 0, column: 0),
+          insertText: "X",
+        ),
+      ],
       transactionDescription: "test",
     )
     b.undoStack.addLast(txn)
@@ -1613,23 +1612,22 @@ suite "Buffer - Transaction Partial Failure Recovery":
       startSeq: baselineSeq,
       endSeq: baselineSeq + 2,
       kind: ckTransaction,
-      transactionChanges:
-        @[
-          BufferChange(
-            startSeq: baselineSeq,
-            endSeq: baselineSeq + 1,
-            kind: ckInsertText,
-            insertPos: BufferPosition(line: 0, column: 0),
-            insertText: "X",
-          ),
-          BufferChange(
-            startSeq: baselineSeq + 1,
-            endSeq: baselineSeq + 2,
-            kind: ckInsertLine,
-            insertLineIdx: 999,
-            insertLineText: "x",
-          ),
-        ],
+      transactionChanges: @[
+        BufferChange(
+          startSeq: baselineSeq,
+          endSeq: baselineSeq + 1,
+          kind: ckInsertText,
+          insertPos: BufferPosition(line: 0, column: 0),
+          insertText: "X",
+        ),
+        BufferChange(
+          startSeq: baselineSeq + 1,
+          endSeq: baselineSeq + 2,
+          kind: ckInsertLine,
+          insertLineIdx: 999,
+          insertLineText: "x",
+        ),
+      ],
       transactionDescription: "test",
     )
     b.redoStack.addLast(txn)

--- a/tests/test_buffer_undo_redo.nim
+++ b/tests/test_buffer_undo_redo.nim
@@ -1571,22 +1571,23 @@ suite "Buffer - Transaction Partial Failure Recovery":
       startSeq: baselineSeq,
       endSeq: baselineSeq + 2,
       kind: ckTransaction,
-      transactionChanges: @[
-        BufferChange(
-          startSeq: baselineSeq,
-          endSeq: baselineSeq + 1,
-          kind: ckInsertLine,
-          insertLineIdx: 999,
-          insertLineText: "x",
-        ),
-        BufferChange(
-          startSeq: baselineSeq + 1,
-          endSeq: baselineSeq + 2,
-          kind: ckInsertText,
-          insertPos: BufferPosition(line: 0, column: 0),
-          insertText: "X",
-        ),
-      ],
+      transactionChanges:
+        @[
+          BufferChange(
+            startSeq: baselineSeq,
+            endSeq: baselineSeq + 1,
+            kind: ckInsertLine,
+            insertLineIdx: 999,
+            insertLineText: "x",
+          ),
+          BufferChange(
+            startSeq: baselineSeq + 1,
+            endSeq: baselineSeq + 2,
+            kind: ckInsertText,
+            insertPos: BufferPosition(line: 0, column: 0),
+            insertText: "X",
+          ),
+        ],
       transactionDescription: "test",
     )
     b.undoStack.addLast(txn)
@@ -1612,22 +1613,23 @@ suite "Buffer - Transaction Partial Failure Recovery":
       startSeq: baselineSeq,
       endSeq: baselineSeq + 2,
       kind: ckTransaction,
-      transactionChanges: @[
-        BufferChange(
-          startSeq: baselineSeq,
-          endSeq: baselineSeq + 1,
-          kind: ckInsertText,
-          insertPos: BufferPosition(line: 0, column: 0),
-          insertText: "X",
-        ),
-        BufferChange(
-          startSeq: baselineSeq + 1,
-          endSeq: baselineSeq + 2,
-          kind: ckInsertLine,
-          insertLineIdx: 999,
-          insertLineText: "x",
-        ),
-      ],
+      transactionChanges:
+        @[
+          BufferChange(
+            startSeq: baselineSeq,
+            endSeq: baselineSeq + 1,
+            kind: ckInsertText,
+            insertPos: BufferPosition(line: 0, column: 0),
+            insertText: "X",
+          ),
+          BufferChange(
+            startSeq: baselineSeq + 1,
+            endSeq: baselineSeq + 2,
+            kind: ckInsertLine,
+            insertLineIdx: 999,
+            insertLineText: "x",
+          ),
+        ],
       transactionDescription: "test",
     )
     b.redoStack.addLast(txn)
@@ -1748,6 +1750,16 @@ suite "Buffer - readOnly guard on undo/redo":
   # replay history without checking the flag — so a buffer set readOnly AFTER
   # edits were recorded could still be mutated through the history stacks. The
   # guards below complete "readOnly rejects on every mutation path".
+  test "beginTransaction on a readOnly buffer returns err":
+    let b = newTextBuffer("hello")
+    b.readOnly = true
+
+    let r = b.beginTransaction("insert")
+
+    check r.isErr
+    check r.error == "Buffer is read-only"
+    check not b.inTransaction
+
   test "undo on a readOnly buffer returns err and leaves content unchanged":
     let b = newTextBuffer("hello")
     discard b.insertText(BufferPosition(line: 0, column: 5), "!")

--- a/tests/test_command_handler.nim
+++ b/tests/test_command_handler.nim
@@ -1565,6 +1565,14 @@ suite "CommandModeHandler - handleCommandModeInput":
     let result = handler.handleCommandModeInput(buffer, ":help")
     check result.kind == hrEnterHelpViewer
 
+  test "Handle :undo and :redo commands":
+    let handler = setupHandler()
+    let buffer = setupBuffer()
+
+    check handler.handleCommandModeInput(buffer, ":u").kind == hrUndo
+    check handler.handleCommandModeInput(buffer, ":undo").kind == hrUndo
+    check handler.handleCommandModeInput(buffer, ":redo").kind == hrRedo
+
   test "Handle :vs command":
     let handler = setupHandler()
     let buffer = setupBuffer()

--- a/tests/test_config.nim
+++ b/tests/test_config.nim
@@ -91,6 +91,7 @@ suite "Config - newEditorConfig defaults":
     check config.standard.colorMode == cm256color
     check config.standard.mouse == false
     check config.standard.lineWrap == true
+    check config.standard.forceInsertMode == false
     check config.standard.relativeNumber == false
     check config.standard.scrollbar == false
     check config.standard.scrollbarWidth == 1

--- a/tests/test_config_loader.nim
+++ b/tests/test_config_loader.nim
@@ -87,6 +87,7 @@ autoCloseParen = true
 autoIndent = true
 ignorecase = true
 smartcase = true
+forceInsertMode = false
 disableChangeCursor = false
 defaultCursor = "terminalDefault"
 normalModeCursor = "blinkBlock"
@@ -126,6 +127,7 @@ timeoutlen = 1000
     config.standard.autoIndent = false
     config.standard.ignorecase = false
     config.standard.smartcase = false
+    config.standard.forceInsertMode = true
     config.standard.disableChangeCursor = true
     config.standard.liveReloadOfConf = true
     config.standard.incrementalSearch = false
@@ -159,6 +161,7 @@ timeoutlen = 1000
     check loaded.standard.autoIndent == false
     check loaded.standard.ignorecase == false
     check loaded.standard.smartcase == false
+    check loaded.standard.forceInsertMode == true
     check loaded.standard.disableChangeCursor == true
     check loaded.standard.liveReloadOfConf == true
     check loaded.standard.incrementalSearch == false

--- a/tests/test_editor_config_reload.nim
+++ b/tests/test_editor_config_reload.nim
@@ -100,6 +100,18 @@ suite "editor_config_reload - applyConfigSettings":
     e.applyConfigSettings(newConfig)
     check e.config.standard.number == false
 
+  test "enabling forced Insert mode leaves Normal mode":
+    let e = createTestEditor()
+    check e.state.mode == EditorMode.Normal
+    check not e.activeBuffer.inTransaction
+    let newConfig = newEditorConfig()
+    newConfig.standard.forceInsertMode = true
+
+    e.applyConfigSettings(newConfig)
+
+    check e.state.mode == EditorMode.Insert
+    check e.activeBuffer.inTransaction
+
   test "disables LSP servers at runtime":
     let e = createTestEditor()
     e.lsp.setEnabled(true)

--- a/tests/test_editor_config_reload.nim
+++ b/tests/test_editor_config_reload.nim
@@ -112,6 +112,18 @@ suite "editor_config_reload - applyConfigSettings":
     check e.state.mode == EditorMode.Insert
     check e.activeBuffer.inTransaction
 
+  test "enabling forced Insert mode preserves an active overlay":
+    let e = createTestEditor()
+    e.state.enterCommandOverlay()
+    let newConfig = newEditorConfig()
+    newConfig.standard.forceInsertMode = true
+
+    e.applyConfigSettings(newConfig)
+
+    check e.state.mode == EditorMode.Normal
+    check e.state.isCommandOverlay
+    check not e.activeBuffer.inTransaction
+
   test "disables LSP servers at runtime":
     let e = createTestEditor()
     e.lsp.setEnabled(true)

--- a/tests/test_editor_file.nim
+++ b/tests/test_editor_file.nim
@@ -442,7 +442,52 @@ suite "Editor - multi-file startup (no auto-split)":
     # returned extra buffers, not the active one.
     check not e.activeBuffer.readOnly
 
+  test "forced Insert mode stays Normal after activating an extra -R buffer":
+    let config = newEditorConfig()
+    config.standard.forceInsertMode = true
+    config.startUpFileOpen.autoSplit = false
+    let e = createTestEditorWithConfig(config)
+    let
+      fileA = getTempDir() / "moe_test_multi_force_ro_a.txt"
+      fileB = getTempDir() / "moe_test_multi_force_ro_b.txt"
+    writeFile(fileA, "A")
+    writeFile(fileB, "B")
+    defer:
+      removeFile(fileA)
+      removeFile(fileB)
+    check e.loadFile(fileA).isOk
+    e.openAdditionalStartupFiles(@[fileA, fileB], readonly = true)
+    let extraBuffer = e.buffers[e.findBufferByPath(fileB)]
+
+    check e.activateBuffer(extraBuffer.id)
+
+    check e.activeBuffer.readOnly
+    check e.state.mode == EditorMode.Normal
+    check not e.activeBuffer.inTransaction
+
 suite "Editor - multi-file startup (auto-split)":
+  test "forced Insert mode leaves an auto-split -R buffer in Normal mode":
+    let config = newEditorConfig()
+    config.standard.forceInsertMode = true
+    config.startUpFileOpen.autoSplit = true
+    config.startUpFileOpen.splitType = stHorizontal
+    let e = createTestEditorWithConfig(config)
+    let
+      fileA = getTempDir() / "moe_test_split_force_ro_a.txt"
+      fileB = getTempDir() / "moe_test_split_force_ro_b.txt"
+    writeFile(fileA, "A")
+    writeFile(fileB, "B")
+    defer:
+      removeFile(fileA)
+      removeFile(fileB)
+    check e.loadFile(fileA).isOk
+
+    e.openAdditionalStartupFiles(@[fileA, fileB], readonly = true)
+
+    check e.activeBuffer.readOnly
+    check e.state.mode == EditorMode.Normal
+    check not e.activeBuffer.inTransaction
+
   test "Each extra file opens in its own split window":
     # With auto-split every extra path opens in a new split window (and its own
     # buffer), unlike the no-split path which only registers buffers in the
@@ -499,6 +544,25 @@ suite "Editor - multi-file startup (auto-split)":
     check e.findBufferByPath(fileC) >= 0
 
 suite "Editor - saveFile":
+  test "forced Insert mode commits before trimming and resumes after save":
+    let config = newEditorConfig()
+    config.standard.forceInsertMode = true
+    let e = createTestEditorWithConfig(config)
+    let testFile = getTempDir() / "moe_test_forced_insert_trim.txt"
+    writeFile(testFile, "hello   \n")
+    defer:
+      removeFile(testFile)
+    check e.loadFile(testFile).isOk
+    e.activeBuffer.editorConfig =
+      some(BufferEditorConfig(trimTrailingWhitespace: some(true)))
+    check e.activeBuffer.insertText(BufferPosition(line: 0, column: 0), "x").isOk
+
+    let saveResult = e.saveFile()
+
+    check saveResult.isOk
+    check readFile(testFile) == "xhello\n"
+    check e.activeBuffer.inTransaction
+
   test "Save file to existing path":
     let e = createTestEditor()
     let testFile = getTempDir() / "moe_test_save.txt"
@@ -1003,6 +1067,27 @@ suite "Editor - updateInputTime":
     check afterTime > beforeTime
 
 suite "Editor - autoSave":
+  test "forced Insert mode commits before auto-save trimming":
+    let config = newEditorConfig()
+    config.standard.forceInsertMode = true
+    config.autoSave.enable = true
+    config.autoSave.interval = 1
+    let e = createTestEditorWithConfig(config)
+    let testFile = getTempDir() / "moe_test_forced_insert_autosave_trim.txt"
+    writeFile(testFile, "hello   \n")
+    defer:
+      removeFile(testFile)
+    check e.loadFile(testFile).isOk
+    e.activeBuffer.editorConfig =
+      some(BufferEditorConfig(trimTrailingWhitespace: some(true)))
+    check e.activeBuffer.insertText(BufferPosition(line: 0, column: 0), "x").isOk
+    e.state.timing.lastAutoSave = getMonoTime() - initDuration(hours = 1)
+
+    e.autoSave()
+
+    check readFile(testFile) == "xhello\n"
+    check e.activeBuffer.inTransaction
+
   test "Auto save does nothing when disabled":
     var config = newEditorConfig()
     config.autoSave.enable = false

--- a/tests/test_editor_frame.nim
+++ b/tests/test_editor_frame.nim
@@ -773,17 +773,16 @@ suite "updateForFrame - split buffer re-parse budget":
     e.addBuffer(buf)
 
     # Simulate an LSP publishDiagnostics that sets the flag with no flight.
-    buf.diagnostics =
-      @[
-        BufferDiagnostic(
-          startLine: 10,
-          startCol: 0,
-          endLine: 10,
-          endCol: 5,
-          severity: bdsError,
-          message: "test error",
-        )
-      ]
+    buf.diagnostics = @[
+      BufferDiagnostic(
+        startLine: 10,
+        startCol: 0,
+        endLine: 10,
+        endCol: 5,
+        severity: bdsError,
+        message: "test error",
+      )
+    ]
     buf.diagnosticsDirty = true
     buf.highlightNeedsUpdate = true
     check buf.incrementalHighlight.pendingReparse == nil

--- a/tests/test_editor_frame.nim
+++ b/tests/test_editor_frame.nim
@@ -19,7 +19,7 @@
 
 ## Tests for editor_frame.nim
 
-import std/[unittest, options, os, tables, monotimes]
+import std/[unittest, options, os, tables, monotimes, times]
 
 import pkg/celina
 
@@ -28,6 +28,22 @@ import std/strutils
 import ../src/moepkg/[types, editor, config, message_log, editor_notify]
 import ../src/moepkg/[highlight, editor_frame, editor_window]
 import ../src/moepkg/buffer {.all.}
+
+suite "tick - forced Insert mode boundaries":
+  test "commits an idle edit group and starts the next one":
+    let config = newEditorConfig()
+    config.standard.forceInsertMode = true
+    let e = newEditor(config)
+    check e.activeBuffer.insertText(BufferPosition(line: 0, column: 0), "hello").isOk
+    e.cursor = BufferPosition(line: 0, column: 5)
+    e.state.timing.lastInputTime = getMonoTime() - initDuration(milliseconds = 600)
+
+    e.tick()
+
+    check e.activeBuffer.undoStack.len == 1
+    check e.activeBuffer.inTransaction
+    check e.activeBuffer.currentTransaction.get.changes.len == 0
+    check e.state.editState.insertModeStartPos == some(e.cursor)
 
 suite "tick - frontend Git status subscription":
   test "does not maintain Git status without a display or frontend consumer":
@@ -757,16 +773,17 @@ suite "updateForFrame - split buffer re-parse budget":
     e.addBuffer(buf)
 
     # Simulate an LSP publishDiagnostics that sets the flag with no flight.
-    buf.diagnostics = @[
-      BufferDiagnostic(
-        startLine: 10,
-        startCol: 0,
-        endLine: 10,
-        endCol: 5,
-        severity: bdsError,
-        message: "test error",
-      )
-    ]
+    buf.diagnostics =
+      @[
+        BufferDiagnostic(
+          startLine: 10,
+          startCol: 0,
+          endLine: 10,
+          endCol: 5,
+          severity: bdsError,
+          message: "test error",
+        )
+      ]
     buf.diagnosticsDirty = true
     buf.highlightNeedsUpdate = true
     check buf.incrementalHighlight.pendingReparse == nil

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -4065,8 +4065,10 @@ suite "handleKeyCombo - frontend-neutral input":
 suite "forced Insert mode":
   let
     escapeKey = KeyCombo(isSpecial: true, special: skEscape, fnNum: 0, modifiers: {})
+    enterKey = KeyCombo(isSpecial: true, special: skEnter, fnNum: 0, modifiers: {})
     ctrlCKey = KeyCombo(isSpecial: false, char: "c", modifiers: {key_bindings.kmCtrl})
     ctrlOKey = KeyCombo(isSpecial: false, char: "o", modifiers: {key_bindings.kmCtrl})
+    ctrlRKey = KeyCombo(isSpecial: false, char: "r", modifiers: {key_bindings.kmCtrl})
 
   proc charKey(c: string): KeyCombo =
     KeyCombo(isSpecial: false, char: c, modifiers: {})
@@ -4120,6 +4122,20 @@ suite "forced Insert mode":
     check e.activeBuffer.undoStack.len == 1
     check e.activeBuffer.currentTransaction.get.changes.len == 0
 
+  test "an Insert Ctrl-C remap runs without leaving Insert mode":
+    let e = createTestEditorWithBuffer("")
+    check e.keyBindingRegistry.addRuntimeMapping(
+      EditorMode.Insert, "C-c", "insert-newline"
+    ).len == 0
+    e.typeKeys("i")
+
+    check e.handleKeyCombo(ctrlCKey)
+
+    check e.state.mode == EditorMode.Insert
+    check e.activeBuffer.len == 2
+    check e.cursor == BufferPosition(line: 1, column: 0)
+    check e.activeBuffer.inTransaction
+
   test "Ctrl-O opens the command line without exposing Normal mode":
     let e = createForcedInsertEditor()
 
@@ -4132,6 +4148,49 @@ suite "forced Insert mode":
 
     check e.handleTextInput("w")
     check e.state.input.commandText == ":w"
+
+  test "Ctrl-O undo and redo commit the current typing group":
+    let e = createForcedInsertEditor()
+    check e.handleTextInput("abc")
+    check e.handleKeyCombo(escapeKey)
+    check e.handleTextInput("de")
+
+    check e.handleKeyCombo(ctrlOKey)
+    check e.handleTextInput("undo")
+    check e.handleKeyCombo(enterKey)
+
+    check $e.activeBuffer.getLine(0) == "abc"
+    check e.state.mode == EditorMode.Insert
+    check e.activeBuffer.inTransaction
+
+    check e.handleKeyCombo(ctrlOKey)
+    check e.handleTextInput("redo")
+    check e.handleKeyCombo(enterKey)
+
+    check $e.activeBuffer.getLine(0) == "abcde"
+    check e.state.mode == EditorMode.Insert
+    check e.activeBuffer.inTransaction
+
+  test "ordinary Ctrl-O u commits before undo and resumes Insert mode":
+    let e = createTestEditorWithBuffer("")
+    e.typeKeys("i")
+    check e.handleTextInput("abc")
+
+    check e.handleKeyCombo(ctrlOKey)
+    check e.handleKeyCombo(charKey("u"))
+
+    check $e.activeBuffer.getLine(0) == ""
+    check e.state.mode == EditorMode.Insert
+    check not e.state.insertNormalMode
+    check e.activeBuffer.inTransaction
+
+    check e.handleKeyCombo(ctrlOKey)
+    check e.handleKeyCombo(ctrlRKey)
+
+    check $e.activeBuffer.getLine(0) == "abc"
+    check e.state.mode == EditorMode.Insert
+    check not e.state.insertNormalMode
+    check e.activeBuffer.inTransaction
 
   test "Ctrl-C does not replay a counted Insert command":
     let e = createTestEditorWithBuffer("")

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -1005,21 +1005,34 @@ proc runDetachedScenario(e: Editor): Future[void] {.async: (raises: [Exception])
   await sleepAsync(10)
   await e.handlePendingAsyncOperations(FrontendHooks())
 
+proc waitForOutputSplit(e: Editor): Future[bool] {.async: (raises: [Exception]).} =
+  for _ in 0 ..< 200:
+    if e.windowManager.windows.len > 1:
+      return true
+    await sleepAsync(10)
+  return false
+
 suite "handlePendingAsyncOperations drains ops queued from async tasks":
-  test "build op drains on tick":
+  test "build output remains Normal when forced Insert mode is enabled":
     let config = newEditorConfig()
+    config.standard.forceInsertMode = true
     let editor = newEditor(config)
     editor.state.pending.add PendingAsyncOp(
       kind: paoBuild,
-      build: (path: "/tmp/x.nim", language: 0, customCmd: "", workspaceRoot: ""),
+      build: (path: "/tmp/x.nim", language: 0, customCmd: "echo hi", workspaceRoot: ""),
     )
 
     waitFor editor.handlePendingAsyncOperations(FrontendHooks())
 
     check editor.state.pending.len == 0
+    check waitFor waitForOutputSplit(editor)
+    check editor.activeBuffer.readOnly
+    check editor.state.mode == EditorMode.Normal
+    check not editor.activeBuffer.inTransaction
 
-  test "quickRun op drains on tick":
+  test "QuickRun output remains Normal when forced Insert mode is enabled":
     let config = newEditorConfig()
+    config.standard.forceInsertMode = true
     let editor = newEditor(config)
     editor.state.pending.add PendingAsyncOp(
       kind: paoQuickRun,
@@ -1029,6 +1042,10 @@ suite "handlePendingAsyncOperations drains ops queued from async tasks":
     waitFor editor.handlePendingAsyncOperations(FrontendHooks())
 
     check editor.state.pending.len == 0
+    check waitFor waitForOutputSplit(editor)
+    check editor.activeBuffer.readOnly
+    check editor.state.mode == EditorMode.Normal
+    check not editor.activeBuffer.inTransaction
 
   test "syntaxCheck op drains on tick":
     let config = newEditorConfig()
@@ -4048,7 +4065,15 @@ suite "handleKeyCombo - frontend-neutral input":
 suite "forced Insert mode":
   let
     escapeKey = KeyCombo(isSpecial: true, special: skEscape, fnNum: 0, modifiers: {})
+    ctrlCKey = KeyCombo(isSpecial: false, char: "c", modifiers: {key_bindings.kmCtrl})
     ctrlOKey = KeyCombo(isSpecial: false, char: "o", modifiers: {key_bindings.kmCtrl})
+
+  proc charKey(c: string): KeyCombo =
+    KeyCombo(isSpecial: false, char: c, modifiers: {})
+
+  proc typeKeys(e: Editor, keys: string) =
+    for key in keys:
+      check e.handleKeyCombo(charKey($key))
 
   proc createForcedInsertEditor(): Editor =
     let config = newEditorConfig()
@@ -4087,7 +4112,7 @@ suite "forced Insert mode":
     let e = createForcedInsertEditor()
     check e.handleTextInput("a")
 
-    check e.handleInterrupt()
+    check e.handleKeyCombo(ctrlCKey)
 
     check e.state.mode == EditorMode.Insert
     check e.cursor == BufferPosition(line: 0, column: 1)
@@ -4095,16 +4120,81 @@ suite "forced Insert mode":
     check e.activeBuffer.undoStack.len == 1
     check e.activeBuffer.currentTransaction.get.changes.len == 0
 
-  test "Ctrl-O cannot expose a one-shot Normal command":
+  test "Ctrl-O opens the command line without exposing Normal mode":
     let e = createForcedInsertEditor()
 
     check e.handleKeyCombo(ctrlOKey)
     check e.state.mode == EditorMode.Insert
     check not e.state.insertNormalMode
+    check e.state.isCommandOverlay
+    check e.state.input.commandText == ":"
     check e.activeBuffer.inTransaction
 
-    check e.handleTextInput("x")
+    check e.handleTextInput("w")
+    check e.state.input.commandText == ":w"
+
+  test "Ctrl-C does not replay a counted Insert command":
+    let e = createTestEditorWithBuffer("")
+
+    e.typeKeys("3ix")
+    check e.handleKeyCombo(ctrlCKey)
+
+    check e.state.mode == EditorMode.Normal
     check $e.activeBuffer.getLine(0) == "x"
+
+  test "Ctrl-C does not replicate a visual block insertion":
+    let e = createTestEditorWithBuffer("aaa\nbbb\nccc")
+    e.state.mode = EditorMode.Insert
+    check e.activeBuffer.beginTransaction("visual block insert").isOk
+    e.state.editState.insertModeStartPos = some(e.cursor)
+    e.state.editState.visualBlockInsertContext = some(
+      VisualBlockInsertContext(
+        kind: vbiInsert, startLine: 0, endLine: 2, insertColumn: 0
+      )
+    )
+
+    check e.handleTextInput("X")
+    check e.handleKeyCombo(ctrlCKey)
+
+    check $e.activeBuffer.getLine(0) == "Xaaa"
+    check $e.activeBuffer.getLine(1) == "bbb"
+    check $e.activeBuffer.getLine(2) == "ccc"
+    check e.state.editState.visualBlockInsertContext.isNone
+
+  test "Ctrl-C after substitute does not corrupt the next dot repeat":
+    let e = createTestEditorWithBuffer("old")
+
+    e.typeKeys("ccN")
+    check e.handleKeyCombo(ctrlCKey)
+    e.typeKeys("iQ")
+    check e.handleKeyCombo(escapeKey)
+    e.typeKeys(".")
+
+    check $e.activeBuffer.getLine(0) == "QQN"
+
+  test "Ctrl-C after Replace clears the prior substitute context":
+    let e = createTestEditorWithBuffer("old")
+
+    e.typeKeys("ccN")
+    check e.handleKeyCombo(escapeKey)
+    e.typeKeys("Ry")
+    check e.handleKeyCombo(ctrlCKey)
+    e.typeKeys("iQ")
+    check e.handleKeyCombo(escapeKey)
+    e.typeKeys(".")
+
+    check e.state.editState.substituteContext.isNone
+    check $e.activeBuffer.getLine(0) == "yQQ"
+
+  test "marking the first -R buffer leaves it in Normal mode":
+    let e = createForcedInsertEditor()
+    # main applies -R after loading the first path into the initial buffer.
+    e.activeBuffer.readOnly = true
+
+    e.enforceModePolicy()
+
+    check e.state.mode == EditorMode.Normal
+    check not e.activeBuffer.inTransaction
 
   test "policy restores a directly assigned Normal mode":
     let e = createForcedInsertEditor()

--- a/tests/test_handler.nim
+++ b/tests/test_handler.nim
@@ -4045,6 +4045,76 @@ suite "handleKeyCombo - frontend-neutral input":
     check e.state.input.commandText == ":λx"
     check e.state.input.commandCursor == 2
 
+suite "forced Insert mode":
+  let
+    escapeKey = KeyCombo(isSpecial: true, special: skEscape, fnNum: 0, modifiers: {})
+    ctrlOKey = KeyCombo(isSpecial: false, char: "o", modifiers: {key_bindings.kmCtrl})
+
+  proc createForcedInsertEditor(): Editor =
+    let config = newEditorConfig()
+    config.standard.forceInsertMode = true
+    newEditor(config)
+
+  test "editor starts with a valid Insert session":
+    let e = createForcedInsertEditor()
+
+    check e.state.mode == EditorMode.Insert
+    check e.activeBuffer.inTransaction
+    check e.state.editState.insertModeStartPos ==
+      some(BufferPosition(line: 0, column: 0))
+
+  test "committed GUI text inserts without a Normal-mode command":
+    let e = createForcedInsertEditor()
+
+    check e.handleTextInput("hello")
+
+    check $e.activeBuffer.getLine(0) == "hello"
+    check e.cursor == BufferPosition(line: 0, column: 5)
+    check e.state.mode == EditorMode.Insert
+
+  test "Escape commits the edit boundary and remains in Insert mode":
+    let e = createForcedInsertEditor()
+    check e.handleTextInput("a")
+
+    check e.handleKeyCombo(escapeKey)
+
+    check e.state.mode == EditorMode.Insert
+    check e.activeBuffer.inTransaction
+    check e.activeBuffer.undoStack.len == 1
+    check e.activeBuffer.currentTransaction.get.changes.len == 0
+
+  test "Ctrl-C commits the edit boundary and remains in Insert mode":
+    let e = createForcedInsertEditor()
+    check e.handleTextInput("a")
+
+    check e.handleInterrupt()
+
+    check e.state.mode == EditorMode.Insert
+    check e.cursor == BufferPosition(line: 0, column: 1)
+    check e.activeBuffer.inTransaction
+    check e.activeBuffer.undoStack.len == 1
+    check e.activeBuffer.currentTransaction.get.changes.len == 0
+
+  test "Ctrl-O cannot expose a one-shot Normal command":
+    let e = createForcedInsertEditor()
+
+    check e.handleKeyCombo(ctrlOKey)
+    check e.state.mode == EditorMode.Insert
+    check not e.state.insertNormalMode
+    check e.activeBuffer.inTransaction
+
+    check e.handleTextInput("x")
+    check $e.activeBuffer.getLine(0) == "x"
+
+  test "policy restores a directly assigned Normal mode":
+    let e = createForcedInsertEditor()
+
+    e.setMode(EditorMode.Normal)
+    e.enforceModePolicy()
+
+    check e.state.mode == EditorMode.Insert
+    check e.activeBuffer.inTransaction
+
 suite "Macro recording - Command / Search overlay keys":
   # Regression: overlay dispatch used to bypass macro recording, so `qa:s/foo/bar/<CR>q`
   # would capture only ":" and lose the rest of the command line (same for `/pattern<CR>`).
@@ -4188,6 +4258,23 @@ proc addSecondWindow(e: Editor, buf2: TextBuffer, vpx: int = 40) =
   e.windowManager.windows.add(win2)
 
 suite "handleMouseEvent - Cross-window jump finalizes stale state":
+  test "Forced Insert mode survives a jump to a Normal-mode window":
+    let e = createTestEditorWithBuffer("aaa\nbbb\nccc")
+    e.config.standard.forceInsertMode = true
+    e.state.config.standard.forceInsertMode = true
+    e.enforceModePolicy()
+    e.state.showTabLine = false
+    e.state.showStatusLine = true
+    let buf2 = newTextBuffer("xxx\nyyy\nzzz")
+    e.addSecondWindow(buf2)
+
+    let handled = e.handleMouseEvent(makeLeftClickEvent(50, 1))
+
+    check handled
+    check e.windowManager.activeWindowIndex == 1
+    check e.state.mode == EditorMode.Insert
+    check buf2.inTransaction
+
   test "Insert-mode transaction on old buffer is committed":
     # Without the finalize hook, bufA's open transaction leaks past the jump.
     let e = createTestEditorWithBuffer("aaa\nbbb\nccc")


### PR DESCRIPTION
## Summary

- add Standard.forceInsertMode for GUI-style editing without Normal-mode commands
- keep editable windows in a valid Insert session across Escape, Ctrl-C, replay, config reload, and window changes
- reuse Moe's Insert transaction lifecycle and preserve Visual and special modes
- document the option and cover config, frontend, input, replay, and mouse behavior

## Tests

- atlas-run build
- 218/218 eligible Atlas test programs passed (known macOS/environment-dependent cases excluded)
- focused config, frontend, handler, config-reload, runtime-keymapping, macro-replay, and docs-sync tests passed
- nph check passed for changed formatter-clean Nim files