### PR TITLE
fix(navigation): give a file opened by navigation the shared buffer setup

### DIFF
--- a/src/moepkg/editor_navigation.nim
+++ b/src/moepkg/editor_navigation.nim
@@ -38,8 +38,7 @@ import
   buffer,
   unicode_utils,
   editorconfig_helper,
-  highlight_config,
-  editor_notify
+  highlight_config
 import lsp/protocol/types as lspTypes
 
 const
@@ -106,7 +105,8 @@ proc openFileInActiveWindow*(e: Editor, path: string): Result[TextBuffer, string
   ##
   ## If a buffer already holds this file, switch the active window to it.
   ## Otherwise create a new buffer, load the file, apply EditorConfig and
-  ## reserved-word highlighting, register it, switch to it, and notify the LSP.
+  ## reserved-word highlighting, register it, switch to it and run the shared
+  ## `initLoadedBuffer` setup.
   ##
   ## Shared by the LSP/jump/document-link navigation paths so they all open
   ## files into the *active* window's buffer with identical setup. Unlike the
@@ -130,15 +130,12 @@ proc openFileInActiveWindow*(e: Editor, path: string): Result[TextBuffer, string
   e.addBuffer(newBuffer)
   e.switchToBufferForLsp(e.buffers.high)
 
-  # A file that is not text still opens (every byte is held and saved back
-  # unchanged), but say so.
-  e.notifyUnusualContent(newBuffer)
-
-  # Notify the LSP about the newly opened file and record its synced baseline
-  # so the next didChange delta is computed against the right changeSeq.
-  # Best-effort: openBufferWithLsp is a no-op when LSP is disabled / the buffer
-  # has no path, and logs a degraded notice on failure.
-  e.openBufferWithLsp(newBuffer)
+  # Share the per-buffer setup with every other open path: restore bookmarks,
+  # seed the git-diff gutter, scan conflict markers, warn about content that is
+  # not text and announce the document to the language server. Doing this by
+  # hand here used to leave a file reached by go-to-definition without its
+  # bookmarks, gutter or conflict blocks.
+  e.initLoadedBuffer(newBuffer)
 
   ok(newBuffer)
 

--- a/tests/test_editor_navigation.nim
+++ b/tests/test_editor_navigation.nim
@@ -21,6 +21,8 @@
 
 import std/[unittest, os, strutils, options, importutils, json, tables]
 
+import pkg/results
+
 import ../src/moepkg/[editor, config, config_loader, types, lsp_service]
 import ../src/moepkg/buffer/core
 import ../src/moepkg/editor_navigation
@@ -338,6 +340,67 @@ suite "editor_navigation - handleLspLocations":
 
     check not result
     check e.state.statusMessage.contains("No local file locations found")
+
+suite "editor_navigation - openFileInActiveWindow per-buffer setup":
+  ## Navigation opens (go-to-definition, jump list, document links) create the
+  ## buffer themselves instead of going through the startup/`:e` paths, so they
+  ## used to hand-roll a shortened version of the shared setup. A file reached
+  ## this way came up without its persisted bookmarks, without the git-diff
+  ## gutter request and without conflict blocks.
+
+  const conflictContent =
+    "line before\n" & "<<<<<<< HEAD\n" & "ours\n" & "=======\n" & "theirs\n" &
+    ">>>>>>> feature\n" & "line after\n"
+
+  test "Restores persisted bookmarks for the newly opened file":
+    let e = createTestEditor()
+    e.state.showGitDiff = false
+    e.config.persist.bookmarks = true
+    let testFile = getTempDir() / "moe_nav_bookmark.txt"
+    writeFile(testFile, "a\nb\nc\n")
+    defer:
+      removeFile(testFile)
+    e.savedBookmarks[absolutePath(testFile)] = @[2]
+
+    let opened = e.openFileInActiveWindow(testFile)
+
+    check opened.isOk
+    check opened.get.bookmarks == @[2]
+
+  test "Scans conflict markers on the newly opened file":
+    let e = createTestEditor()
+    e.state.showGitDiff = false
+    let testFile = getTempDir() / "moe_nav_conflict.txt"
+    writeFile(testFile, conflictContent)
+    defer:
+      removeFile(testFile)
+
+    let opened = e.openFileInActiveWindow(testFile)
+
+    check opened.isOk
+    check opened.get.conflictBlocks.len == 1
+
+  test "Leaves an already open buffer untouched":
+    # The early-return branch switches to the existing buffer; it must not
+    # re-run the setup and stomp on state the buffer already carries.
+    let e = createTestEditor()
+    e.state.showGitDiff = false
+    e.config.persist.bookmarks = true
+    let testFile = getTempDir() / "moe_nav_reopen.txt"
+    writeFile(testFile, "a\nb\nc\n")
+    defer:
+      removeFile(testFile)
+
+    let first = e.openFileInActiveWindow(testFile)
+    check first.isOk
+    first.get.bookmarks = @[1]
+    e.savedBookmarks[absolutePath(testFile)] = @[2]
+
+    let second = e.openFileInActiveWindow(testFile)
+
+    check second.isOk
+    check second.get == first.get
+    check second.get.bookmarks == @[1]
 
 suite "editor_navigation - switchToBufferForLsp":
   test "Does nothing for invalid negative index":


### PR DESCRIPTION
`openFileInActiveWindow` creates and registers the buffer itself instead of
going through `loadOrCreateBuffer` / `registerSplitBuffer`, so it hand-rolled a
shortened copy of the shared per-buffer setup: it called `notifyUnusualContent`
and `openBufferWithLsp` but nothing else.

Comparing the four open paths shows only this one is short:

| path | bookmarks | git diff | refreshConflicts |
|---|---|---|---|
| `editor_file.nim` `loadFile` | yes | yes | yes |
| `editor_window.nim` `initLoadedBuffer` | yes | yes | yes |
| `editor_reload.nim` `finishReload` | n/a (existing buffer) | yes | yes |
| `editor_navigation.nim` `openFileInActiveWindow` | **no** | **no** | **no** |

A file reached by go-to-definition, go-to-declaration, the jump list or a
document link therefore came up without its persisted bookmarks, without the
git-diff gutter request and without conflict blocks, so conflict navigation did
nothing on it until the file was reopened another way.

The two hand-written calls are replaced by `initLoadedBuffer`, which
`editor_window` already exports and which this module already imports (the
reverse dependency does not exist, so no cycle). `editor_notify` is no longer
used here and is dropped from the import list.

`invalidateAllLspCaches` is deliberately not added. It exists for a buffer whose
identity changes while the object stays the same (`loadFile`, reload, LSP
restart); this path registers a fresh buffer and switches to it, which is an
ordinary buffer switch and does not invalidate elsewhere either.

## Tests

Three cases in `tests/test_editor_navigation.nim`: bookmarks restored, conflict
markers scanned, and the already-open early return left untouched (it must not
re-run the setup over state the buffer already carries). The first two fail on
the unfixed code (`bookmarks was @[]`, `conflictBlocks.len was 0`); the third
passes both ways and guards the branch the fix must not disturb.

`nimble ptest` 229 files pass, `nph --check` clean.
