### PR TITLE
feat(highlight): add optional Matter syntax backend

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,9 +69,9 @@ jobs:
         uses: actions/cache@v6
         with:
           path: ~/.nimble
-          key: ${{ runner.os }}-nimble-v2-${{ hashFiles('*.nimble') }}
+          key: ${{ runner.os }}-${{ matrix.nim-version }}-nimble-v3-${{ hashFiles('nimble.lock', 'moe.nimble') }}
           restore-keys: |
-            ${{ runner.os }}-nimble-v2-
+            ${{ runner.os }}-${{ matrix.nim-version }}-nimble-v3-
 
       - uses: jiro4989/setup-nim-action@v2
         with:
@@ -85,5 +85,11 @@ jobs:
           use-nightlies: true
           repo-token: ${{ secrets.GITHUB_TOKEN }}
         if: matrix.nim-version == 'devel'
+
+      # Nim 2.0.10 bundles Nimble 0.16.1, whose lockfile installer fails for
+      # revision-pinned packages when their generated path contains '#'.
+      - name: Update Nimble for revision-pinned dependencies
+        if: matrix.nim-version == '2.0.10'
+        run: nimble install 'nimble@0.24.1' -y
 
       - run: nimble build -y

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -192,4 +192,5 @@ jobs:
         nim c -r -d:moe.matter -d:matterTimeLimitMs=0 -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlight_matter.nim
         nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_matter_highlight_edges.nim
         nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlight.nim
+        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlighter_api.nim
         nim c -d:release -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" src/moe.nim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -159,3 +159,37 @@ jobs:
         # whole job a silent no-op. Fail loudly instead.
         command -v lasm
         xvfb-run env XDG_SESSION_TYPE=x11 nim c -r tests/test_lsp_e2e_lasm.nim
+
+  matter:
+    name: Matter syntax backend
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      TERM: xterm-256color
+    steps:
+    - uses: actions/checkout@v7
+    - uses: jiro4989/setup-nim-action@v2
+      with:
+        nim-version: 2.2.10
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Install dependencies
+      run: |
+        nimble install -d -y
+        nimble setup
+    # Matter 0.3.0's Nimble package omits its grammar archives. Use the exact
+    # locked source revision for build-time assets, never a moving branch.
+    - name: Fetch Matter grammar assets
+      uses: actions/checkout@v7
+      with:
+        repository: elcritch/matter
+        ref: 8db6f03d1028c42693c3a586ba3625e1b48e9589
+        path: deps/matter-assets
+        persist-credentials: false
+    - name: Build and test Matter backend
+      run: |
+        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_matter_backend.nim
+        # Disable wall-clock interruption for full-vs-incremental equivalence.
+        nim c -r -d:moe.matter -d:matterTimeLimitMs=0 -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlight_matter.nim
+        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_matter_highlight_edges.nim
+        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlight.nim
+        nim c -d:release -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" src/moe.nim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -196,21 +196,12 @@ jobs:
       run: |
         nimble install -d -y
         nimble setup
-    # Matter 0.3.0's Nimble package omits its grammar archives. Use the exact
-    # locked source revision for build-time assets, never a moving branch.
-    - name: Fetch Matter grammar assets
-      uses: actions/checkout@v7
-      with:
-        repository: elcritch/matter
-        ref: 8db6f03d1028c42693c3a586ba3625e1b48e9589
-        path: deps/matter-assets
-        persist-credentials: false
     - name: Build and test Matter backend
       run: |
-        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_matter_backend.nim
+        nim c -r -d:moe.matter tests/test_matter_backend.nim
         # Disable wall-clock interruption for full-vs-incremental equivalence.
-        nim c -r -d:moe.matter -d:matterTimeLimitMs=0 -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlight_matter.nim
-        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_matter_highlight_edges.nim
-        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlight.nim
-        nim c -r -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" tests/test_highlighter_api.nim
-        nim c -d:release -d:moe.matter -d:matterGrammarRoot="$PWD/deps/matter-assets" src/moe.nim
+        nim c -r -d:moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim
+        nim c -r -d:moe.matter tests/test_matter_highlight_edges.nim
+        nim c -r -d:moe.matter tests/test_highlight.nim
+        nim c -r -d:moe.matter tests/test_highlighter_api.nim
+        nim c -d:release -d:moe.matter src/moe.nim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -192,6 +192,8 @@ jobs:
       with:
         nim-version: 2.2.10
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Update Nimble for revision-pinned dependencies
+      run: nimble install 'nimble@0.24.1' -y
     - name: Install dependencies
       run: |
         nimble install -d -y

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -196,8 +196,8 @@ jobs:
       run: nimble install 'nimble@0.24.1' -y
     - name: Install dependencies
       run: |
-        nimble install -d -y
-        nimble setup
+        nimble --parser:declarative --features:matter install -d -y
+        nimble --parser:declarative --features:matter setup
     - name: Build and test Matter backend
       run: |
         nim c -r -d:moe.matter tests/test_matter_backend.nim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -206,4 +206,5 @@ jobs:
         nim c -r -d:features.moe.matter tests/test_matter_highlight_edges.nim
         nim c -r -d:features.moe.matter tests/test_highlight.nim
         nim c -r -d:features.moe.matter tests/test_highlighter_api.nim
+        nim c -r -d:features.moe.matter tests/test_config_loader.nim
         nim c -d:release -d:features.moe.matter src/moe.nim

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -200,8 +200,8 @@ jobs:
       run: |
         nim c -r -d:moe.matter tests/test_matter_backend.nim
         # Disable wall-clock interruption for full-vs-incremental equivalence.
-        nim c -r -d:moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim
-        nim c -r -d:moe.matter tests/test_matter_highlight_edges.nim
-        nim c -r -d:moe.matter tests/test_highlight.nim
-        nim c -r -d:moe.matter tests/test_highlighter_api.nim
-        nim c -d:release -d:moe.matter src/moe.nim
+        nim c -r -d:features.moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim
+        nim c -r -d:features.moe.matter tests/test_matter_highlight_edges.nim
+        nim c -r -d:features.moe.matter tests/test_highlight.nim
+        nim c -r -d:features.moe.matter tests/test_highlighter_api.nim
+        nim c -d:release -d:features.moe.matter src/moe.nim

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -195,6 +195,7 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 <!-- AUTO-GEN:start Highlight -->
 | Name | Type | Default Value | Description |
 |:---|:---|:---|:---|
+| backend | string (enum: builtin, matter) | builtin | Syntax highlighting backend (builtin or matter) |
 | currentLine | bool | true | Highlight the current line background |
 | currentColumn | bool | false | Highlight the current column background |
 | reservedWord | string array | ["TODO", "WIP", "NOTE"] | Highlight any words |

--- a/documents/configfile.md
+++ b/documents/configfile.md
@@ -196,6 +196,7 @@ You can use the example -> https://github.com/fox0430/moe/blob/develop/example
 | Name | Type | Default Value | Description |
 |:---|:---|:---|:---|
 | backend | string (enum: builtin, matter) | builtin | Syntax highlighting backend (builtin or matter) |
+| matterGrammarFiles | string array | [] | TextMate grammar files, resolved inside Moe's configuration directory |
 | currentLine | bool | true | Highlight the current line background |
 | currentColumn | bool | false | Highlight the current column background |
 | reservedWord | string array | ["TODO", "WIP", "NOTE"] | Highlight any words |

--- a/documents/developer.md
+++ b/documents/developer.md
@@ -149,6 +149,60 @@ nimble gendocs         # Both config and howtouse
 nimble genhowtouse     # Just documents/howtouse.md
 ```
 
+## Optional Matter syntax backend
+
+Build with `-d:moe.matter` to include the TextMate-grammar backend. Grammar
+archives are embedded into the executable at compile time; an Atlas checkout
+keeps Matter's `data/grammars` directory available automatically:
+
+```sh
+atlas install
+nim c -d:release -d:moe.matter --out:moe src/moe.nim
+```
+
+Matter 0.3.0's Nimble installation omits the archives. When building with
+Nimble, provide a full checkout of the same pinned source revision for assets:
+
+```sh
+nimble install -d -y
+nimble setup
+git clone --branch v0.3.0 --depth 1 https://github.com/elcritch/matter deps/matter-assets
+git -C deps/matter-assets rev-parse HEAD
+# Expected: 8db6f03d1028c42693c3a586ba3625e1b48e9589
+nim c -d:release -d:moe.matter \
+  -d:matterGrammarRoot="$PWD/deps/matter-assets" --out:moe src/moe.nim
+```
+
+Select the backend in `moerc.toml`; `builtin` remains the default:
+
+```toml
+[Highlight]
+backend = "matter" # or "builtin"
+```
+
+The existing `[Standard] syntax` toggle enables/disables rendering for either
+backend. Reloading config switches existing buffers and invalidates their syntax
+caches. A binary compiled without `-d:moe.matter` uses builtin highlighting even
+if the config requests Matter. Diff and Log always retain Moe's builtin lexer.
+
+Matter shares Moe's progressive-load and budgeted incremental paths, per-line
+length cap, reserved-word colours, and URI/LSP/diagnostic overlays. Tokenization
+has a soft 20ms per-line limit: a timeout or grammar error makes that line and
+following lines plain until a reparse starts from an earlier successful state
+or the backend is reset. This avoids caching a partial multiline state. Debug
+builds and expensive grammars (notably C++) may reach this limit more often.
+Debug logging records these failures; see the logging section above.
+Build with `-d:matterTimeLimitMs=N` to adjust the soft deadline (`0` disables it).
+
+The executable does not read grammar files or access the network at runtime.
+Embedded archives retain each package's license and provenance. When distributing
+a Matter-enabled build, retain these notices and include Matter's
+`data/grammars/NOTICES.md` from the pinned source with accompanying materials.
+
+Run the optional tests with `nim c -r -d:moe.matter tests/test_matter_backend.nim`
+and `nim c -r -d:moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim`
+(add the grammar-root define above for a Nimble-only dependency installation).
+
 ## Contributing
 
 Bug reports, feature requests, and pull requests are welcome. Before opening a PR:

--- a/documents/developer.md
+++ b/documents/developer.md
@@ -151,39 +151,48 @@ nimble genhowtouse     # Just documents/howtouse.md
 
 ## Optional Matter syntax backend
 
-Build with `-d:moe.matter` to include the TextMate-grammar backend. Grammar
-archives are embedded into the executable at compile time; an Atlas checkout
-keeps Matter's `data/grammars` directory available automatically:
-
-```sh
-atlas install
-nim c -d:release -d:moe.matter --out:moe src/moe.nim
-```
-
-Matter 0.3.0's Nimble installation omits the archives. When building with
-Nimble, provide a full checkout of the same pinned source revision for assets:
+Build with `-d:moe.matter` to include the TextMate-grammar engine:
 
 ```sh
 nimble install -d -y
 nimble setup
-git clone --branch v0.3.0 --depth 1 https://github.com/elcritch/matter deps/matter-assets
-git -C deps/matter-assets rev-parse HEAD
-# Expected: 8db6f03d1028c42693c3a586ba3625e1b48e9589
-nim c -d:release -d:moe.matter \
-  -d:matterGrammarRoot="$PWD/deps/matter-assets" --out:moe src/moe.nim
+nim c -d:release -d:moe.matter --out:moe src/moe.nim
 ```
 
-Select the backend in `moerc.toml`; `builtin` remains the default:
+Moe does not embed or implicitly select any TextMate grammars. A Matter-enabled
+build continues to use the builtin tokenizer until a grammar is explicitly
+provided. Host applications can opt a buffer or an editor into Matter by passing
+grammar text through the public API:
+
+```nim
+let grammar = readFile("Nim.tmLanguage.json")
+editor.setMatterGrammar(langNim, grammar, "Nim.tmLanguage.json")
+# Or limit the opt-in to one buffer:
+buffer.setMatterGrammar(langNim, grammar, "Nim.tmLanguage.json")
+```
+
+For standalone Moe, place JSON `.tmLanguage.json` or XML plist `.tmLanguage`
+files inside Moe's configuration directory (normally `~/.config/moe`) and name
+them in `moerc.toml`. Relative subdirectories are allowed; absolute paths and
+paths escaping the configuration directory are rejected:
 
 ```toml
 [Highlight]
-backend = "matter" # or "builtin"
+backend = "matter"
+matterGrammarFiles = ["grammars/Nim.tmLanguage.json"]
 ```
+
+Config-loaded roots are matched to Moe languages by their declared TextMate
+`scopeName`; additional listed grammars may satisfy external includes. The API
+overload associates the supplied root with its `SourceLanguage` explicitly, so
+custom scope names are supported there.
 
 The existing `[Standard] syntax` toggle enables/disables rendering for either
 backend. Reloading config switches existing buffers and invalidates their syntax
 caches. A binary compiled without `-d:moe.matter` uses builtin highlighting even
-if the config requests Matter. Diff and Log always retain Moe's builtin lexer.
+if the config requests Matter. A Matter-enabled binary also falls back per
+language when no valid grammar was supplied. Diff and Log always retain Moe's
+builtin lexer.
 
 Matter shares Moe's progressive-load and budgeted incremental paths, per-line
 length cap, reserved-word colours, and URI/LSP/diagnostic overlays. Tokenization
@@ -194,14 +203,12 @@ builds and expensive grammars (notably C++) may reach this limit more often.
 Debug logging records these failures; see the logging section above.
 Build with `-d:matterTimeLimitMs=N` to adjust the soft deadline (`0` disables it).
 
-The executable does not read grammar files or access the network at runtime.
-Embedded archives retain each package's license and provenance. When distributing
-a Matter-enabled build, retain these notices and include Matter's
-`data/grammars/NOTICES.md` from the pinned source with accompanying materials.
+Moe never downloads grammars. The config path reads only the files explicitly
+listed by the user; the API path performs no filesystem access. Grammar licenses
+and provenance remain the responsibility of the user or embedding application.
 
 Run the optional tests with `nim c -r -d:moe.matter tests/test_matter_backend.nim`
-and `nim c -r -d:moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim`
-(add the grammar-root define above for a Nimble-only dependency installation).
+and `nim c -r -d:moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim`.
 
 ## Contributing
 

--- a/documents/developer.md
+++ b/documents/developer.md
@@ -151,12 +151,19 @@ nimble genhowtouse     # Just documents/howtouse.md
 
 ## Optional Matter syntax backend
 
-Build with `-d:moe.matter` or the Nimble feature define
-`-d:features.moe.matter` to include the TextMate-grammar engine:
+Enable the `matter` Nimble feature to install and build the TextMate-grammar
+engine (Nimble 0.24.1 or newer):
 
 ```sh
-nimble install -d -y
-nimble setup
+nimble --parser:declarative --features:matter build -d:release
+```
+
+For direct compiler invocations, install the optional dependencies first, then
+build with `-d:moe.matter` or `-d:features.moe.matter`:
+
+```sh
+nimble --parser:declarative --features:matter install -d -y
+nimble --parser:declarative --features:matter setup
 nim c -d:release -d:moe.matter --out:moe src/moe.nim
 ```
 

--- a/documents/developer.md
+++ b/documents/developer.md
@@ -151,7 +151,8 @@ nimble genhowtouse     # Just documents/howtouse.md
 
 ## Optional Matter syntax backend
 
-Build with `-d:moe.matter` to include the TextMate-grammar engine:
+Build with `-d:moe.matter` or the Nimble feature define
+`-d:features.moe.matter` to include the TextMate-grammar engine:
 
 ```sh
 nimble install -d -y
@@ -189,8 +190,8 @@ custom scope names are supported there.
 
 The existing `[Standard] syntax` toggle enables/disables rendering for either
 backend. Reloading config switches existing buffers and invalidates their syntax
-caches. A binary compiled without `-d:moe.matter` uses builtin highlighting even
-if the config requests Matter. A Matter-enabled binary also falls back per
+caches. A binary compiled without either Matter define uses builtin highlighting
+even if the config requests Matter. A Matter-enabled binary also falls back per
 language when no valid grammar was supplied. Diff and Log always retain Moe's
 builtin lexer.
 
@@ -207,8 +208,9 @@ Moe never downloads grammars. The config path reads only the files explicitly
 listed by the user; the API path performs no filesystem access. Grammar licenses
 and provenance remain the responsibility of the user or embedding application.
 
-Run the optional tests with `nim c -r -d:moe.matter tests/test_matter_backend.nim`
-and `nim c -r -d:moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim`.
+Run the optional tests with
+`nim c -r -d:features.moe.matter tests/test_matter_backend.nim` and
+`nim c -r -d:features.moe.matter -d:matterTimeLimitMs=0 tests/test_highlight_matter.nim`.
 
 ## Contributing
 

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -133,6 +133,8 @@ setupText = "{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} 
 
 [Highlight]
 
+backend = "builtin"                    # "matter" requires a -d:moe.matter build
+
 currentLine = true                     # Highlight current line
 
 currentColumn = false                  # Highlight current column

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -133,7 +133,9 @@ setupText = "{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} 
 
 [Highlight]
 
-backend = "builtin"                    # "matter" requires a -d:moe.matter build
+backend = "builtin"                    # "matter" requires -d:moe.matter and grammars below
+
+matterGrammarFiles = []                # TextMate grammar files inside ~/.config/moe
 
 currentLine = true                     # Highlight current line
 

--- a/example/moerc.toml
+++ b/example/moerc.toml
@@ -133,7 +133,7 @@ setupText = "{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} 
 
 [Highlight]
 
-backend = "builtin"                    # "matter" requires -d:moe.matter and grammars below
+backend = "builtin"                    # "matter" requires compile-time support and grammars below
 
 matterGrammarFiles = []                # TextMate grammar files inside ~/.config/moe
 

--- a/moe.nimble
+++ b/moe.nimble
@@ -19,7 +19,7 @@ requires "editorconfig >= 0.1.1"
 requires "regex >= 0.26.1"
 requires "jsony >= 1.1.6"
 # Matter 0.3.0; enabled only by `-d:moe.matter`.
-requires "https://github.com/elcritch/matter#8db6f03d1028c42693c3a586ba3625e1b48e9589"
+requires "https://github.com/elcritch/matter >= 0.3.0"
 
 task release, "Build for release":
   exec "nimble build -d:release"

--- a/moe.nimble
+++ b/moe.nimble
@@ -18,6 +18,8 @@ requires "stew >= 0.2.0"
 requires "editorconfig >= 0.1.1"
 requires "regex >= 0.26.1"
 requires "jsony >= 1.1.6"
+# Matter 0.3.0; enabled only by `-d:moe.matter`.
+requires "https://github.com/elcritch/matter#8db6f03d1028c42693c3a586ba3625e1b48e9589"
 
 task release, "Build for release":
   exec "nimble build -d:release"

--- a/moe.nimble
+++ b/moe.nimble
@@ -18,7 +18,7 @@ requires "stew >= 0.2.0"
 requires "editorconfig >= 0.1.1"
 requires "regex >= 0.26.1"
 requires "jsony >= 1.1.6"
-# Matter 0.3.0; enabled only by `-d:moe.matter`.
+# Matter 0.3.0 engine; compiled only with `-d:moe.matter`. Moe bundles no grammars.
 requires "https://github.com/elcritch/matter >= 0.3.0"
 
 task release, "Build for release":

--- a/moe.nimble
+++ b/moe.nimble
@@ -18,7 +18,7 @@ requires "stew >= 0.2.0"
 requires "editorconfig >= 0.1.1"
 requires "regex >= 0.26.1"
 requires "jsony >= 1.1.6"
-# Matter 0.3.0 engine; compiled only with `-d:moe.matter`. Moe bundles no grammars.
+# Matter 0.3.0 engine; enabled by its direct define or Nimble feature. No grammars bundled.
 requires "https://github.com/elcritch/matter >= 0.3.0"
 
 task release, "Build for release":

--- a/moe.nimble
+++ b/moe.nimble
@@ -19,7 +19,7 @@ requires "editorconfig >= 0.1.1"
 requires "regex >= 0.26.1"
 requires "jsony >= 1.1.6"
 # Matter 0.3.0 engine; enabled by its direct define or Nimble feature. No grammars bundled.
-requires "https://github.com/elcritch/matter >= 0.3.0"
+requires "https://github.com/elcritch/matter#333b79c75fa883a3ebb5ddd7d4fdbd7a11819b94"
 
 task release, "Build for release":
   exec "nimble build -d:release"

--- a/moe.nimble
+++ b/moe.nimble
@@ -18,8 +18,9 @@ requires "stew >= 0.2.0"
 requires "editorconfig >= 0.1.1"
 requires "regex >= 0.26.1"
 requires "jsony >= 1.1.6"
-# Matter is enabled by its direct define or Nimble feature. No grammars bundled.
-requires "https://github.com/elcritch/matter >= 0.4.2"
+# Optional Matter engine. No grammars bundled.
+feature "matter":
+  requires "https://github.com/elcritch/matter >= 0.4.2"
 
 task release, "Build for release":
   exec "nimble build -d:release"

--- a/moe.nimble
+++ b/moe.nimble
@@ -18,8 +18,8 @@ requires "stew >= 0.2.0"
 requires "editorconfig >= 0.1.1"
 requires "regex >= 0.26.1"
 requires "jsony >= 1.1.6"
-# Matter 0.3.0 engine; enabled by its direct define or Nimble feature. No grammars bundled.
-requires "https://github.com/elcritch/matter#333b79c75fa883a3ebb5ddd7d4fdbd7a11819b94"
+# Matter is enabled by its direct define or Nimble feature. No grammars bundled.
+requires "https://github.com/elcritch/matter >= 0.4.2"
 
 task release, "Build for release":
   exec "nimble build -d:release"

--- a/nimble.lock
+++ b/nimble.lock
@@ -141,6 +141,41 @@
       "checksums": {
         "sha1": "b28964a93a3cf7248126ba39047593cd63a3aa6d"
       }
+    },
+    "reni": {
+      "version": "#ae88f24",
+      "vcsRevision": "ae88f24359f7d0742328b7e4f538241d6af00fcc",
+      "url": "https://github.com/fox0430/reni",
+      "downloadMethod": "git",
+      "dependencies": [
+        "unicodedb"
+      ],
+      "checksums": {
+        "sha1": "4d9c35640c8349d7bb5030d890758326837665cd"
+      }
+    },
+    "zippy": {
+      "version": "#cd562ba",
+      "vcsRevision": "cd562ba43ae8904a4d1ba55611b8a521ef4a179e",
+      "url": "https://github.com/guzba/zippy",
+      "downloadMethod": "git",
+      "dependencies": [],
+      "checksums": {
+        "sha1": "fae5430d597432ea2916a6d45dee53542784d51e"
+      }
+    },
+    "matter": {
+      "version": "#8db6f03d1028c42693c3a586ba3625e1b48e9589",
+      "vcsRevision": "8db6f03d1028c42693c3a586ba3625e1b48e9589",
+      "url": "https://github.com/elcritch/matter",
+      "downloadMethod": "git",
+      "dependencies": [
+        "reni",
+        "zippy"
+      ],
+      "checksums": {
+        "sha1": "fb91316e3bd147651f73fd018230f41d49bd23d1"
+      }
     }
   },
   "tasks": {}

--- a/nimble.lock
+++ b/nimble.lock
@@ -165,8 +165,8 @@
       }
     },
     "matter": {
-      "version": "#8db6f03d1028c42693c3a586ba3625e1b48e9589",
-      "vcsRevision": "8db6f03d1028c42693c3a586ba3625e1b48e9589",
+      "version": "#333b79c75fa883a3ebb5ddd7d4fdbd7a11819b94",
+      "vcsRevision": "333b79c75fa883a3ebb5ddd7d4fdbd7a11819b94",
       "url": "https://github.com/elcritch/matter",
       "downloadMethod": "git",
       "dependencies": [
@@ -174,7 +174,7 @@
         "zippy"
       ],
       "checksums": {
-        "sha1": "fb91316e3bd147651f73fd018230f41d49bd23d1"
+        "sha1": "0fc81925fc84df06711eb3ba4834c45df3459416"
       }
     }
   },

--- a/nimble.lock
+++ b/nimble.lock
@@ -141,41 +141,6 @@
       "checksums": {
         "sha1": "b28964a93a3cf7248126ba39047593cd63a3aa6d"
       }
-    },
-    "reni": {
-      "version": "#ae88f24",
-      "vcsRevision": "ae88f24359f7d0742328b7e4f538241d6af00fcc",
-      "url": "https://github.com/fox0430/reni",
-      "downloadMethod": "git",
-      "dependencies": [
-        "unicodedb"
-      ],
-      "checksums": {
-        "sha1": "4d9c35640c8349d7bb5030d890758326837665cd"
-      }
-    },
-    "zippy": {
-      "version": "#cd562ba",
-      "vcsRevision": "cd562ba43ae8904a4d1ba55611b8a521ef4a179e",
-      "url": "https://github.com/guzba/zippy",
-      "downloadMethod": "git",
-      "dependencies": [],
-      "checksums": {
-        "sha1": "fae5430d597432ea2916a6d45dee53542784d51e"
-      }
-    },
-    "matter": {
-      "version": "#333b79c75fa883a3ebb5ddd7d4fdbd7a11819b94",
-      "vcsRevision": "333b79c75fa883a3ebb5ddd7d4fdbd7a11819b94",
-      "url": "https://github.com/elcritch/matter",
-      "downloadMethod": "git",
-      "dependencies": [
-        "reni",
-        "zippy"
-      ],
-      "checksums": {
-        "sha1": "0fc81925fc84df06711eb3ba4834c45df3459416"
-      }
     }
   },
   "tasks": {}

--- a/src/moepkg/buffer/core.nim
+++ b/src/moepkg/buffer/core.nim
@@ -22,6 +22,7 @@
 import std/[algorithm, deques, hashes, options, tables, times, unicode]
 
 import ../[encoding, highlight, logger, primitives, unicode_utils]
+import ../types/highlight_types
 import ../buffer_backends/[gap_buffer, sqrt_decomp, rope, piece_table]
 import cow_seq, seq_delta
 
@@ -366,6 +367,8 @@ type
     reservedWords*: seq[ReservedWord] # Reserved words to highlight (TODO, NOTE, etc.)
     maxHighlightLineLength*: int
       # Per-line tokenization cap in runes (synmaxcol). 0 = unlimited.
+    highlightBackend*: HighlightBackend
+      ## Requested syntax backend; unavailable optional backends fall back safely.
     uriScanParsedUpTo*: int # Last line scanned for URIs during progressive init
 
     # Change list (tracks positions where changes were made, like Vim's changelist)

--- a/src/moepkg/buffer/core.nim
+++ b/src/moepkg/buffer/core.nim
@@ -25,7 +25,7 @@ import std/[algorithm, deques, hashes, options, tables, times, unicode]
 
 import ../[encoding, highlight, logger, primitives, setting_issue, unicode_utils]
 import ../types/highlight_types
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import ../syntax/matter_backend
 import ../buffer_backends/[gap_buffer, sqrt_decomp, rope, piece_table]
 import cow_seq, seq_delta
@@ -408,7 +408,7 @@ type
       # Per-line tokenization cap in runes (synmaxcol). 0 = unlimited.
     highlightBackend*: HighlightBackend
       ## Requested syntax backend; unavailable optional backends fall back safely.
-    when defined(moe.matter):
+    when defined(moe.matter) or defined(features.moe.matter):
       matterGrammarSet*: MatterGrammarSet
         ## Explicit grammar collection shared with other buffers in the editor.
     uriScanParsedUpTo*: int # Last line scanned for URIs during progressive init

--- a/src/moepkg/buffer/core.nim
+++ b/src/moepkg/buffer/core.nim
@@ -25,6 +25,8 @@ import std/[algorithm, deques, hashes, options, tables, times, unicode]
 
 import ../[encoding, highlight, logger, primitives, setting_issue, unicode_utils]
 import ../types/highlight_types
+when defined(moe.matter):
+  import ../syntax/matter_backend
 import ../buffer_backends/[gap_buffer, sqrt_decomp, rope, piece_table]
 import cow_seq, seq_delta
 
@@ -406,6 +408,9 @@ type
       # Per-line tokenization cap in runes (synmaxcol). 0 = unlimited.
     highlightBackend*: HighlightBackend
       ## Requested syntax backend; unavailable optional backends fall back safely.
+    when defined(moe.matter):
+      matterGrammarSet*: MatterGrammarSet
+        ## Explicit grammar collection shared with other buffers in the editor.
     uriScanParsedUpTo*: int # Last line scanned for URIs during progressive init
 
     # Change list (tracks positions where changes were made, like Vim's changelist)

--- a/src/moepkg/buffer/file_io.nim
+++ b/src/moepkg/buffer/file_io.nim
@@ -240,11 +240,18 @@ proc loadFileWithContent*(
         lines[i] = b.getLine(i)
 
       let (segments, lineStates) = initHighlightIncremental(
-        lines, 0, chunkEnd, TokenizerState(), @[], b.language, b.maxHighlightLineLength
+        lines,
+        0,
+        chunkEnd,
+        newTokenizerState(b.highlightBackend, b.language),
+        @[],
+        b.language,
+        b.maxHighlightLineLength,
       )
 
       b.highlight = Highlight(colorSegments: segments)
       b.incrementalHighlight = IncrementalHighlight(
+        backend: effectiveHighlightBackend(b.highlightBackend, b.language),
         segments: segments,
         lineStates: LineStateCache(states: lineStates),
         parsedUpTo: chunkEnd,

--- a/src/moepkg/buffer/file_io.nim
+++ b/src/moepkg/buffer/file_io.nim
@@ -243,7 +243,7 @@ proc loadFileWithContent*(
         lines,
         0,
         chunkEnd,
-        newTokenizerState(b.highlightBackend, b.language),
+        b.newBufferTokenizerState(),
         @[],
         b.language,
         b.maxHighlightLineLength,
@@ -251,7 +251,8 @@ proc loadFileWithContent*(
 
       b.highlight = Highlight(colorSegments: segments)
       b.incrementalHighlight = IncrementalHighlight(
-        backend: effectiveHighlightBackend(b.highlightBackend, b.language),
+        backend: b.effectiveHighlightBackend,
+        initialState: b.newBufferTokenizerState(),
         segments: segments,
         lineStates: LineStateCache(states: lineStates),
         parsedUpTo: chunkEnd,

--- a/src/moepkg/buffer/highlight.nim
+++ b/src/moepkg/buffer/highlight.nim
@@ -32,6 +32,14 @@ when defined(moe.matter):
   import ../syntax/matter_backend
 import core, markers
 
+export highlight_types
+
+proc effectiveHighlightBackend*(b: TextBuffer): HighlightBackend =
+  ## Return the engine selected for this buffer's language and build. Matter
+  ## requests fall back to builtin when unavailable or for Diff/Log. This
+  ## query does not report per-line tokenizer failures or change buffer state.
+  effectiveHighlightBackend(b.highlightBackend, b.language)
+
 proc matches*(pr: PendingReparse, b: TextBuffer): bool =
   ## TextBuffer-scoped overload of `PendingReparse.matches`.
   pr.matches(b.lastChangedLines, b.len, b.contentVersion, b.reservedWords)
@@ -40,6 +48,8 @@ proc setHighlightBackend*(b: TextBuffer, backend: HighlightBackend) =
   ## Change the requested syntax engine and invalidate every syntax-derived
   ## cache. URI styling is rebuilt; semantic and diagnostic overlays retain
   ## their identity and content version because the buffer text has not changed.
+  ## The next updateHighlight/normal editor frame reparses with the selected
+  ## engine. Use effectiveHighlightBackend to inspect compile/language fallback.
   if b.highlightBackend != backend:
     b.highlightBackend = backend
     b.incrementalHighlight = nil

--- a/src/moepkg/buffer/highlight.nim
+++ b/src/moepkg/buffer/highlight.nim
@@ -26,12 +26,25 @@
 import std/tables
 
 import ../[highlight, uri_utils]
+import ../types/highlight_types
 import ../syntax/tokenizer
+when defined(moe.matter):
+  import ../syntax/matter_backend
 import core, markers
 
 proc matches*(pr: PendingReparse, b: TextBuffer): bool =
   ## TextBuffer-scoped overload of `PendingReparse.matches`.
   pr.matches(b.lastChangedLines, b.len, b.contentVersion, b.reservedWords)
+
+proc setHighlightBackend*(b: TextBuffer, backend: HighlightBackend) =
+  ## Change the requested syntax engine and invalidate every syntax-derived
+  ## cache. URI styling is rebuilt; semantic and diagnostic overlays retain
+  ## their identity and content version because the buffer text has not changed.
+  if b.highlightBackend != backend:
+    b.highlightBackend = backend
+    b.incrementalHighlight = nil
+    b.uriScanParsedUpTo = -1
+    b.highlightNeedsUpdate = true
 
 proc rewindUriScan(b: TextBuffer, to: int) =
   ## Move the URI-scan frontier back to `to` (clamped to -1); no-op if it is
@@ -52,6 +65,10 @@ proc isCodeBlockLine*(b: TextBuffer, line: int): bool =
   let states = b.incrementalHighlight.lineStates.states
   if line < 0 or line >= states.len:
     return false
+  when defined(moe.matter):
+    if states[line].backend == hbMatter:
+      let enterInBlock = line >= 1 and isMatterCodeBlock(states[line - 1].matterState)
+      return enterInBlock or isMatterCodeBlock(states[line].matterState)
   let enterInBlock = line >= 1 and states[line - 1].lang.markdown.inCodeBlock
   let exitInBlock = states[line].lang.markdown.inCodeBlock
   enterInBlock or exitInBlock
@@ -144,6 +161,7 @@ proc continueInitialHighlight*(
   # blank / alone-header lines), so rewind to a safe line and re-parse the
   # previous chunk's tail together with the new one.
   while startLine > 0 and
+      b.incrementalHighlight.lineStates.states[startLine - 1].backend == hbBuiltin and
       chunkHandoffUnsafe(
         b.language,
         b.incrementalHighlight.lineStates.states[startLine - 1].state,
@@ -164,7 +182,7 @@ proc continueInitialHighlight*(
     else:
       min(startLine + max(ChunkSize, 2 * reparsedLines) - 1, b.len - 1)
 
-  var lastState = TokenizerState()
+  var lastState = newTokenizerState(b.highlightBackend, b.language)
   if startLine > 0:
     lastState = b.incrementalHighlight.lineStates.states[startLine - 1]
 
@@ -342,7 +360,10 @@ proc updateHighlight*(b: TextBuffer, reparseBudget: int, parsedLines: var int): 
         elif reparseBudget > 0:
           b.highlight.colorSegments = @[]
           b.incrementalHighlight = IncrementalHighlight(
-            segments: @[], lineStates: LineStateCache(states: @[]), parsedUpTo: -1
+            backend: effectiveHighlightBackend(b.highlightBackend, b.language),
+            segments: @[],
+            lineStates: LineStateCache(states: @[]),
+            parsedUpTo: -1,
           )
           discard continueInitialHighlight(b, reparseBudget, parsedLines)
         else:
@@ -356,7 +377,7 @@ proc updateHighlight*(b: TextBuffer, reparseBudget: int, parsedLines: var int): 
             lines,
             0,
             lines.high,
-            TokenizerState(), # Default initial state
+            newTokenizerState(b.highlightBackend, b.language),
             b.reservedWords,
             b.language,
             b.maxHighlightLineLength,
@@ -364,6 +385,7 @@ proc updateHighlight*(b: TextBuffer, reparseBudget: int, parsedLines: var int): 
 
           b.highlight.colorSegments = segments
           b.incrementalHighlight = IncrementalHighlight(
+            backend: effectiveHighlightBackend(b.highlightBackend, b.language),
             segments: segments,
             lineStates: LineStateCache(states: lineStates),
             parsedUpTo: b.len - 1,

--- a/src/moepkg/buffer/highlight.nim
+++ b/src/moepkg/buffer/highlight.nim
@@ -38,7 +38,16 @@ proc effectiveHighlightBackend*(b: TextBuffer): HighlightBackend =
   ## Return the engine selected for this buffer's language and build. Matter
   ## requests fall back to builtin when unavailable or for Diff/Log. This
   ## query does not report per-line tokenizer failures or change buffer state.
-  effectiveHighlightBackend(b.highlightBackend, b.language)
+  when defined(moe.matter):
+    effectiveHighlightBackend(b.highlightBackend, b.language, b.matterGrammarSet)
+  else:
+    effectiveHighlightBackend(b.highlightBackend, b.language)
+
+proc newBufferTokenizerState*(b: TextBuffer): TokenizerState =
+  when defined(moe.matter):
+    newTokenizerState(b.highlightBackend, b.language, b.matterGrammarSet)
+  else:
+    newTokenizerState(b.highlightBackend, b.language)
 
 proc matches*(pr: PendingReparse, b: TextBuffer): bool =
   ## TextBuffer-scoped overload of `PendingReparse.matches`.
@@ -55,6 +64,35 @@ proc setHighlightBackend*(b: TextBuffer, backend: HighlightBackend) =
     b.incrementalHighlight = nil
     b.uriScanParsedUpTo = -1
     b.highlightNeedsUpdate = true
+
+when defined(moe.matter):
+  proc setMatterGrammarSet*(b: TextBuffer, grammars: MatterGrammarSet) =
+    ## Replace the explicit grammar collection and invalidate syntax caches.
+    if b.matterGrammarSet != grammars:
+      b.matterGrammarSet = grammars
+      b.incrementalHighlight = nil
+      b.uriScanParsedUpTo = -1
+      b.highlightNeedsUpdate = true
+
+proc setMatterGrammar*(
+    b: TextBuffer,
+    language: SourceLanguage,
+    grammar: string,
+    path = "grammar.tmLanguage.json",
+) =
+  ## Opt this buffer into Matter by supplying its TextMate grammar text.
+  ## Invalid grammar input raises a catchable error and leaves the buffer
+  ## unchanged. Matter support must be compiled with `-d:moe.matter`.
+  when defined(moe.matter):
+    let grammars = b.matterGrammarSet.withMatterGrammar(language, grammar, path)
+    b.setMatterGrammarSet(grammars)
+    b.setHighlightBackend(hbMatter)
+  else:
+    discard b
+    discard language
+    discard grammar
+    discard path
+    raise newException(TextMateGrammarError, "Matter support requires -d:moe.matter")
 
 proc rewindUriScan(b: TextBuffer, to: int) =
   ## Move the URI-scan frontier back to `to` (clamped to -1); no-op if it is
@@ -192,7 +230,7 @@ proc continueInitialHighlight*(
     else:
       min(startLine + max(ChunkSize, 2 * reparsedLines) - 1, b.len - 1)
 
-  var lastState = newTokenizerState(b.highlightBackend, b.language)
+  var lastState = b.newBufferTokenizerState()
   if startLine > 0:
     lastState = b.incrementalHighlight.lineStates.states[startLine - 1]
 
@@ -370,7 +408,8 @@ proc updateHighlight*(b: TextBuffer, reparseBudget: int, parsedLines: var int): 
         elif reparseBudget > 0:
           b.highlight.colorSegments = @[]
           b.incrementalHighlight = IncrementalHighlight(
-            backend: effectiveHighlightBackend(b.highlightBackend, b.language),
+            backend: b.effectiveHighlightBackend,
+            initialState: b.newBufferTokenizerState(),
             segments: @[],
             lineStates: LineStateCache(states: @[]),
             parsedUpTo: -1,
@@ -387,7 +426,7 @@ proc updateHighlight*(b: TextBuffer, reparseBudget: int, parsedLines: var int): 
             lines,
             0,
             lines.high,
-            newTokenizerState(b.highlightBackend, b.language),
+            b.newBufferTokenizerState(),
             b.reservedWords,
             b.language,
             b.maxHighlightLineLength,
@@ -395,7 +434,8 @@ proc updateHighlight*(b: TextBuffer, reparseBudget: int, parsedLines: var int): 
 
           b.highlight.colorSegments = segments
           b.incrementalHighlight = IncrementalHighlight(
-            backend: effectiveHighlightBackend(b.highlightBackend, b.language),
+            backend: b.effectiveHighlightBackend,
+            initialState: b.newBufferTokenizerState(),
             segments: segments,
             lineStates: LineStateCache(states: lineStates),
             parsedUpTo: b.len - 1,

--- a/src/moepkg/buffer/highlight.nim
+++ b/src/moepkg/buffer/highlight.nim
@@ -28,7 +28,7 @@ import std/tables
 import ../[highlight, uri_utils]
 import ../types/highlight_types
 import ../syntax/tokenizer
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import ../syntax/matter_backend
 import core, markers
 
@@ -38,13 +38,13 @@ proc effectiveHighlightBackend*(b: TextBuffer): HighlightBackend =
   ## Return the engine selected for this buffer's language and build. Matter
   ## requests fall back to builtin when unavailable or for Diff/Log. This
   ## query does not report per-line tokenizer failures or change buffer state.
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     effectiveHighlightBackend(b.highlightBackend, b.language, b.matterGrammarSet)
   else:
     effectiveHighlightBackend(b.highlightBackend, b.language)
 
 proc newBufferTokenizerState*(b: TextBuffer): TokenizerState =
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     newTokenizerState(b.highlightBackend, b.language, b.matterGrammarSet)
   else:
     newTokenizerState(b.highlightBackend, b.language)
@@ -65,7 +65,7 @@ proc setHighlightBackend*(b: TextBuffer, backend: HighlightBackend) =
     b.uriScanParsedUpTo = -1
     b.highlightNeedsUpdate = true
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   proc setMatterGrammarSet*(b: TextBuffer, grammars: MatterGrammarSet) =
     ## Replace the explicit grammar collection and invalidate syntax caches.
     if b.matterGrammarSet != grammars:
@@ -82,8 +82,8 @@ proc setMatterGrammar*(
 ) =
   ## Opt this buffer into Matter by supplying its TextMate grammar text.
   ## Invalid grammar input raises a catchable error and leaves the buffer
-  ## unchanged. Matter support must be compiled with `-d:moe.matter`.
-  when defined(moe.matter):
+  ## unchanged. Matter support must be enabled by its direct define or Nimble feature.
+  when defined(moe.matter) or defined(features.moe.matter):
     let grammars = b.matterGrammarSet.withMatterGrammar(language, grammar, path)
     b.setMatterGrammarSet(grammars)
     b.setHighlightBackend(hbMatter)
@@ -92,7 +92,9 @@ proc setMatterGrammar*(
     discard language
     discard grammar
     discard path
-    raise newException(TextMateGrammarError, "Matter support requires -d:moe.matter")
+    raise newException(
+      TextMateGrammarError, "Matter support is not enabled at compile time"
+    )
 
 proc rewindUriScan(b: TextBuffer, to: int) =
   ## Move the URI-scan frontier back to `to` (clamped to -1); no-op if it is
@@ -113,7 +115,7 @@ proc isCodeBlockLine*(b: TextBuffer, line: int): bool =
   let states = b.incrementalHighlight.lineStates.states
   if line < 0 or line >= states.len:
     return false
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     if states[line].backend == hbMatter:
       let enterInBlock = line >= 1 and isMatterCodeBlock(states[line - 1].matterState)
       return enterInBlock or isMatterCodeBlock(states[line].matterState)

--- a/src/moepkg/color.nim
+++ b/src/moepkg/color.nim
@@ -1053,9 +1053,14 @@ proc applyColorModeFallback*(requested: ColorModeKind): ColorModeKind =
   if requested == cmkNone:
     return cmkNone
 
-  let capability = detectTerminalColorCapability()
-
-  if colorModeRank(requested) <= colorModeRank(capability):
+  when defined(moe.embedded):
+    # Embedded frontends render color values themselves and have no terminal
+    # capability to probe. Honor the host's requested color precision.
     return requested
   else:
-    return capability
+    let capability = detectTerminalColorCapability()
+
+    if colorModeRank(requested) <= colorModeRank(capability):
+      return requested
+    else:
+      return capability

--- a/src/moepkg/config.nim
+++ b/src/moepkg/config.nim
@@ -26,7 +26,8 @@
 import std/[options, tables, os, osproc]
 
 import types/config_types
-export config_types
+import types/highlight_types
+export config_types, highlight_types
 
 proc isToolAvailable(toolCommand: string): bool =
   ## Check if a command-line tool is available in PATH
@@ -118,6 +119,7 @@ proc newEditorConfig*(): EditorConfig =
         "{lineNumber}/{totalLines} {columnNumber}/{totalColumns} {encoding} {lineEnding} {fileType}",
     ),
     highlight: HighlightConfig(
+      backend: hbBuiltin,
       currentLine: true,
       reservedWord: @["TODO", "WIP", "NOTE"],
       replaceText: true,

--- a/src/moepkg/config.nim
+++ b/src/moepkg/config.nim
@@ -32,7 +32,7 @@ import types/config_types
 import types/highlight_types
 export config_types, highlight_types
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import syntax/matter_backend
 
 proc isToolAvailable(toolCommand: string): bool =
@@ -300,5 +300,5 @@ proc newEditorConfig*(): EditorConfig =
     commandAliases: initTable[string, UserCommandEntry](),
     disabledCommandAliases: @[],
   )
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     result.highlight.matterGrammarSet = newMatterGrammarSet()

--- a/src/moepkg/config.nim
+++ b/src/moepkg/config.nim
@@ -32,6 +32,9 @@ import types/config_types
 import types/highlight_types
 export config_types, highlight_types
 
+when defined(moe.matter):
+  import syntax/matter_backend
+
 proc isToolAvailable(toolCommand: string): bool =
   ## Check if a command-line tool is available in PATH
   when defined(moe.embedded):
@@ -67,7 +70,7 @@ proc detectClipboardTool*(): ClipboardTool =
 
 proc newEditorConfig*(): EditorConfig =
   ## Create a new configuration with default values
-  EditorConfig(
+  result = EditorConfig(
     standard: StandardConfig(
       number: true,
       relativeNumber: false,
@@ -130,6 +133,7 @@ proc newEditorConfig*(): EditorConfig =
     ),
     highlight: HighlightConfig(
       backend: hbBuiltin,
+      matterGrammarFiles: @[],
       currentLine: true,
       reservedWord: @["TODO", "WIP", "NOTE"],
       replaceText: true,
@@ -296,3 +300,5 @@ proc newEditorConfig*(): EditorConfig =
     commandAliases: initTable[string, UserCommandEntry](),
     disabledCommandAliases: @[],
   )
+  when defined(moe.matter):
+    result.highlight.matterGrammarSet = newMatterGrammarSet()

--- a/src/moepkg/config_loader.nim
+++ b/src/moepkg/config_loader.nim
@@ -38,11 +38,50 @@ import pkg/[parsetoml, results]
 
 import config, color, config_macros
 
+when defined(moe.matter):
+  import syntax/matter_backend
+  import syntax/tokenizer
+
 import
   config_loader/[
     base, save_base, simple, debug, lsp, theme as themeLoader, keymapping, user_commands
   ]
 export base, save_base, simple, debug, lsp, themeLoader, keymapping, user_commands
+
+when defined(moe.matter):
+  proc loadMatterGrammarFiles(
+      configPath: string, config: var HighlightConfig, vr: var ValidationResult
+  ) =
+    ## Load only files contained by the directory holding moerc.toml. Grammar
+    ## contents stay in memory; Matter itself never performs implicit I/O.
+    let configDir = normalizedPath(absolutePath(parentDir(configPath)))
+    var sources: seq[MatterGrammarSource]
+    for fileName in config.matterGrammarFiles:
+      let grammarPath = normalizedPath(absolutePath(configDir / fileName))
+      if fileName.isAbsolute or not grammarPath.isRelativeTo(configDir):
+        vr.addError(
+          "Highlight.matterGrammarFiles", fileName, "relative path inside " & configDir
+        )
+      elif not fileExists(grammarPath):
+        vr.addError(
+          "Highlight.matterGrammarFiles", fileName, "readable TextMate grammar file"
+        )
+      else:
+        try:
+          let source = MatterGrammarSource(
+            content: readFile(grammarPath), path: grammarPath, language: langNone
+          )
+          # Validate each source separately so one malformed file does not
+          # prevent other configured grammars from remaining available.
+          discard newMatterGrammarSet([source])
+          sources.add(source)
+        except CatchableError as error:
+          vr.addError(
+            "Highlight.matterGrammarFiles",
+            fileName,
+            "valid TextMate grammar: " & error.msg,
+          )
+    config.matterGrammarSet = newMatterGrammarSet(sources)
 
 proc loadConfigFromToml*(
     path: string
@@ -87,6 +126,9 @@ proc loadConfigFromToml*(
   # DisabledCommandAliases) and the nested [StartUp.*] sections are handled by
   # hand below.
   generateSectionLoaders(toml, config, vr, EditorConfig)
+
+  when defined(moe.matter):
+    loadMatterGrammarFiles(path, config.highlight, vr)
 
   if toml.hasKey("Theme"):
     loadThemeConfig(toml["Theme"].getTable(), config.theme, vr)

--- a/src/moepkg/config_loader.nim
+++ b/src/moepkg/config_loader.nim
@@ -38,7 +38,7 @@ import pkg/[parsetoml, results]
 
 import config, color, config_macros
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import syntax/matter_backend
   import syntax/tokenizer
 
@@ -48,7 +48,7 @@ import
   ]
 export base, save_base, simple, debug, lsp, themeLoader, keymapping, user_commands
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   proc loadMatterGrammarFiles(
       configPath: string, config: var HighlightConfig, vr: var ValidationResult
   ) =
@@ -127,7 +127,7 @@ proc loadConfigFromToml*(
   # hand below.
   generateSectionLoaders(toml, config, vr, EditorConfig)
 
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     loadMatterGrammarFiles(path, config.highlight, vr)
 
   if toml.hasKey("Theme"):

--- a/src/moepkg/config_loader/base.nim
+++ b/src/moepkg/config_loader/base.nim
@@ -170,6 +170,12 @@ proc parseBufferBackendKind*(s: string): BufferBackendKind =
   of "pieceTable": bbcPieceTable
   else: bbcAuto
 
+proc parseHighlightBackend*(s: string): HighlightBackend =
+  case s
+  of "builtin": hbBuiltin
+  of "matter": hbMatter
+  else: hbBuiltin
+
 proc parseBracketSplitMode*(s: string): BracketSplitMode =
   case s
   of "disable": bsmDisable
@@ -418,4 +424,5 @@ const
   ValidSplitTypes* = ["horizontal", "vertical"]
   ValidLspTraceLevels* = ["off", "messages", "verbose"]
   ValidBufferBackendKinds* = ["auto", "gapBuffer", "sqrtDecomp", "rope", "pieceTable"]
+  ValidHighlightBackends* = ["builtin", "matter"]
   ValidBracketSplitModes* = ["disable", "noIndent", "indent"]

--- a/src/moepkg/editor_config_reload.nim
+++ b/src/moepkg/editor_config_reload.nim
@@ -41,6 +41,21 @@ import
   key_router,
   lsp_integration
 
+import buffer/highlight
+
+export HighlightBackend
+
+proc setHighlightBackend*(e: Editor, backend: HighlightBackend) =
+  ## Select the highlighter for all current and future editor buffers without
+  ## loading or writing a configuration file. Existing syntax caches are
+  ## invalidated and rebuilt by the normal frame/updateHighlight path; semantic
+  ## and diagnostic overlays are preserved. The requested default is stored in
+  ## e.config, so a later config reload can replace it in the usual way.
+  ## Matter still requires a -d:moe.matter build; Diff/Log remain builtin.
+  e.config.highlight.backend = backend
+  for buffer in e.buffers:
+    buffer.setHighlightBackend(backend)
+
 proc applyConfigSettings*(e: Editor, newConfig: EditorConfig) =
   ## Apply configuration settings to the editor.
   ## Display/edit flags are pull-read from `e.config`, so the ref swap at the

--- a/src/moepkg/editor_config_reload.nim
+++ b/src/moepkg/editor_config_reload.nim
@@ -43,7 +43,7 @@ import
 
 import buffer/highlight
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import syntax/matter_backend
 
 export HighlightBackend
@@ -54,7 +54,7 @@ proc setHighlightBackend*(e: Editor, backend: HighlightBackend) =
   ## invalidated and rebuilt by the normal frame/updateHighlight path; semantic
   ## and diagnostic overlays are preserved. The requested default is stored in
   ## e.config, so a later config reload can replace it in the usual way.
-  ## Matter still requires a -d:moe.matter build; Diff/Log remain builtin.
+  ## Matter still requires compile-time enablement; Diff/Log remain builtin.
   e.config.highlight.backend = backend
   for buffer in e.buffers:
     buffer.setHighlightBackend(backend)
@@ -68,7 +68,7 @@ proc setMatterGrammar*(
   ## Opt current and future editor buffers into Matter by supplying a TextMate
   ## grammar. The content is kept in memory and is never written to moerc.toml.
   ## Invalid grammar input raises a catchable error without changing the editor.
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     let grammars =
       e.config.highlight.matterGrammarSet.withMatterGrammar(language, grammar, path)
     e.config.highlight.matterGrammarSet = grammars
@@ -81,7 +81,9 @@ proc setMatterGrammar*(
     discard language
     discard grammar
     discard path
-    raise newException(TextMateGrammarError, "Matter support requires -d:moe.matter")
+    raise newException(
+      TextMateGrammarError, "Matter support is not enabled at compile time"
+    )
 
 proc applyConfigSettings*(e: Editor, newConfig: EditorConfig) =
   ## Apply configuration settings to the editor.

--- a/src/moepkg/editor_config_reload.nim
+++ b/src/moepkg/editor_config_reload.nim
@@ -43,6 +43,9 @@ import
 
 import buffer/highlight
 
+when defined(moe.matter):
+  import syntax/matter_backend
+
 export HighlightBackend
 
 proc setHighlightBackend*(e: Editor, backend: HighlightBackend) =
@@ -55,6 +58,30 @@ proc setHighlightBackend*(e: Editor, backend: HighlightBackend) =
   e.config.highlight.backend = backend
   for buffer in e.buffers:
     buffer.setHighlightBackend(backend)
+
+proc setMatterGrammar*(
+    e: Editor,
+    language: SourceLanguage,
+    grammar: string,
+    path = "grammar.tmLanguage.json",
+) =
+  ## Opt current and future editor buffers into Matter by supplying a TextMate
+  ## grammar. The content is kept in memory and is never written to moerc.toml.
+  ## Invalid grammar input raises a catchable error without changing the editor.
+  when defined(moe.matter):
+    let grammars =
+      e.config.highlight.matterGrammarSet.withMatterGrammar(language, grammar, path)
+    e.config.highlight.matterGrammarSet = grammars
+    e.config.highlight.backend = hbMatter
+    for buffer in e.buffers:
+      buffer.setMatterGrammarSet(grammars)
+      buffer.setHighlightBackend(hbMatter)
+  else:
+    discard e
+    discard language
+    discard grammar
+    discard path
+    raise newException(TextMateGrammarError, "Matter support requires -d:moe.matter")
 
 proc applyConfigSettings*(e: Editor, newConfig: EditorConfig) =
   ## Apply configuration settings to the editor.

--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -23,10 +23,13 @@ import
 import pkg/celina
 
 import color, unicode_utils
+import types/highlight_types
 import syntax/tokenizer
 import lsp/protocol/types
+when defined(moe.matter):
+  import syntax/matter_backend
 
-export SourceLanguage, EditorColorPairIndex
+export SourceLanguage, EditorColorPairIndex, HighlightBackend
 
 type
   # Runes type alias for sequence of Unicode characters
@@ -94,6 +97,9 @@ type
     ## Tokenizer state captured at a line boundary for incremental re-parsing.
     state*: TokenClass
     lang*: LangState
+    backend*: HighlightBackend
+    when defined(moe.matter):
+      matterState*: MatterLineState
 
   LineStateCache* = object ## Cache of tokenizer states for each line
     states*: seq[TokenizerState]
@@ -133,6 +139,7 @@ type
       ## fresh flights.
 
   IncrementalHighlight* = ref object ## Incremental highlighting information
+    backend*: HighlightBackend
     segments*: seq[ColorSegment]
     lineStates*: LineStateCache
     parsedUpTo*: int ## Last line parsed during initial load. -1 = not started.
@@ -205,6 +212,31 @@ const NoContentVersion* = low(int)
   ## Sentinel for callers without version tracking; `matches` skips the
   ## version check when either side carries it. Real values (incl. `-1`)
   ## still participate.
+
+proc effectiveHighlightBackend*(
+    backend: HighlightBackend, language: SourceLanguage
+): HighlightBackend =
+  ## Resolve compile-time availability and specialised lexer fallbacks.
+  when defined(moe.matter):
+    if backend == hbMatter and matterSupports(language):
+      return hbMatter
+  hbBuiltin
+
+proc newTokenizerState*(
+    backend: HighlightBackend, language: SourceLanguage
+): TokenizerState =
+  ## Fresh state for the selected engine, including unavailable-backend fallback.
+  TokenizerState(backend: effectiveHighlightBackend(backend, language))
+
+proc `==`*(a, b: TokenizerState): bool =
+  ## Keep engine-specific equality at this boundary so clients comparing
+  ## cached states do not need to import Matter's structural stack operator.
+  if a.backend != b.backend:
+    return false
+  when defined(moe.matter):
+    if a.backend == hbMatter:
+      return a.matterState == b.matterState
+  a.state == b.state and a.lang == b.lang
 
 proc matches*(
     pr: PendingReparse,
@@ -1071,6 +1103,121 @@ func capturedBoundaryState(
   else:
     token.state
 
+when defined(moe.matter):
+  proc matterColor(category: MatterColorCategory): EditorColorPairIndex =
+    case category
+    of mccComment: comment
+    of mccString: stringLit
+    of mccNumber: decNumber
+    of mccKeyword: keyword
+    of mccFunction: functionName
+    of mccType: typeName
+    of mccBuiltin: builtin
+    of mccIdentifier: identifier
+    of mccBoolean: boolean
+    of mccOperator: operator
+    of mccPreprocessor: preprocessor
+    of mccProperty: property
+    of mccDefault: default
+
+  proc initMatterHighlight(
+      bufferStr: string,
+      startLine, endLine: int,
+      initialState: TokenizerState,
+      reservedWords: seq[ReservedWord],
+      language: SourceLanguage,
+      tailSegments: seq[ColorSegment],
+  ): tuple[segments: seq[ColorSegment], lineStates: seq[TokenizerState]] =
+    let
+      # Bare CR is a character in a buffer line, not an extra cached row.
+      lines = bufferStr.split('\n')
+      words = reservedWords.filterIt(it.word.len > 0)
+    var
+      state = initialState.matterState
+      tailIndex = 0
+    for offset in 0 ..< max(0, endLine - startLine + 1):
+      let
+        line =
+          if offset < lines.len:
+            lines[offset]
+          else:
+            ""
+        row = startLine + offset
+        parsed = tokenizeMatterLine(line, language, state)
+        style =
+          if language == langMarkdown and
+              (state.isMatterCodeBlock or parsed.nextState.isMatterCodeBlock):
+            Style(bg: getThemeStyle(EditorColorPairIndex.markdownCodeBlock).bg)
+          else:
+            defaultStyle
+      state = parsed.nextState
+
+      # One linear pass per line, rather than rescanning every token's prefix.
+      # All bytes within a character map to its editor column; malformed bytes
+      # each occupy one column, just as they do in the buffer and renderer.
+      var columns = newSeq[int](line.len + 1)
+      var bytePos, column: int
+      while bytePos < line.len:
+        let size = line.runeSizeAt(bytePos)
+        for i in bytePos ..< bytePos + size:
+          columns[i] = column
+        bytePos += size
+        inc column
+      columns[line.len] = column
+
+      template addSpan(first, last: int, spanColor: EditorColorPairIndex) =
+        if columns[last] > columns[first]:
+          result.segments.add(
+            ColorSegment(
+              firstRow: row,
+              lastRow: row,
+              firstColumn: columns[first],
+              lastColumn: columns[last] - 1,
+              color: spanColor,
+              style: style,
+            )
+          )
+
+      if parsed.spans.len == 0:
+        # Explicit plain coverage also prevents URI overlays from inheriting a
+        # previous row's colour when tokenization is interrupted.
+        result.segments.add(
+          ColorSegment(
+            firstRow: row,
+            lastRow: row,
+            firstColumn: 0,
+            lastColumn: column - 1,
+            color: EditorColorPairIndex.default,
+            style: style,
+          )
+        )
+      else:
+        for span in parsed.spans:
+          let
+            first = clamp(span.firstByte, 0, line.len)
+            last = clamp(span.lastByte, first, line.len)
+            color = matterColor(span.category)
+          if span.category == mccComment and words.len > 0:
+            var partStart = first
+            for (text, partColor) in line[first ..< last].parseReservedWord(
+              words, color
+            ):
+              let partEnd = partStart + text.len
+              addSpan(partStart, partEnd, partColor)
+              partStart = partEnd
+          else:
+            addSpan(first, last, color)
+
+      # Capped tails are already sorted by relative row and follow every token
+      # on their line. Keep the same absolute-row contract as the builtin path.
+      while tailIndex < tailSegments.len and tailSegments[tailIndex].firstRow == offset:
+        var tail = tailSegments[tailIndex]
+        tail.firstRow += startLine
+        tail.lastRow += startLine
+        result.segments.add(tail)
+        inc tailIndex
+      result.lineStates.add(TokenizerState(backend: hbMatter, matterState: state))
+
 proc initHighlightIncrementalFromStr*(
     bufferStr: string,
     startLine: int,
@@ -1087,6 +1234,12 @@ proc initHighlightIncrementalFromStr*(
   ## `startLine + i + 1` — even when the tokenizer stops before the end of
   ## the buffer (interior NUL, defensive break). Consumers index into it
   ## positionally and must be able to rely on this.
+  when defined(moe.matter):
+    if initialState.backend == hbMatter:
+      return initMatterHighlight(
+        bufferStr, startLine, endLine, initialState, reservedWords, language,
+        tailSegments,
+      )
 
   var
     currentRow = startLine
@@ -1531,7 +1684,7 @@ proc updateHighlightIncremental*(
     if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
       initialState = incrHighlight.lineStates.states[reparseStart - 1]
     else:
-      initialState = TokenizerState()
+      initialState = newTokenizerState(incrHighlight.backend, language)
 
     # Multi-line tokens record the depth at their completion, so restarting
     # mid-token restores a stale depth (e.g. nested comments); rewind to the
@@ -1542,7 +1695,7 @@ proc updateHighlightIncremental*(
 
     # Also rewind across chunk-handoff hazards (see `chunkHandoffUnsafe`);
     # rewinding early is safe: the re-parse restarts from a cached state.
-    while reparseStart > 0 and (
+    while initialState.backend == hbBuiltin and reparseStart > 0 and (
       initialState.state in MultiLineKinds or
       chunkHandoffUnsafe(language, initialState.state, getLine(reparseStart))
     )
@@ -1551,7 +1704,7 @@ proc updateHighlightIncremental*(
       if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
         initialState = incrHighlight.lineStates.states[reparseStart - 1]
       else:
-        initialState = TokenizerState()
+        initialState = newTokenizerState(incrHighlight.backend, language)
 
     if oldFrontier >= 0 and reparseStart > oldFrontier:
       # Rows between the old frontier and the new anchor were trimmed but
@@ -1560,7 +1713,7 @@ proc updateHighlightIncremental*(
       if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
         initialState = incrHighlight.lineStates.states[reparseStart - 1]
       else:
-        initialState = TokenizerState()
+        initialState = newTokenizerState(incrHighlight.backend, language)
     elif oldReparseStart >= 0 and reparseStart - 1 >= incrHighlight.lineStates.states.len:
       # The discarded flight's trim left no seed state below the new anchor;
       # restart from the top of the available cache (fresh flights always
@@ -1569,7 +1722,7 @@ proc updateHighlightIncremental*(
       if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
         initialState = incrHighlight.lineStates.states[reparseStart - 1]
       else:
-        initialState = TokenizerState()
+        initialState = newTokenizerState(incrHighlight.backend, language)
 
     let trimIdx = incrHighlight.segments.segmentCutIndex(reparseStart)
     if trimIdx < incrHighlight.segments.len:
@@ -1625,7 +1778,7 @@ proc updateHighlightIncremental*(
     # block scalar) moves back so the rewound lines re-parse with their
     # context; the final chunk keeps the whole window.
     var handoff = chunkEnd + 1
-    if chunkEnd < lastLine:
+    if currentState.backend == hbBuiltin and chunkEnd < lastLine:
       while handoff > currentStart and
           chunkHandoffUnsafe(
             language, newLineStates[handoff - currentStart - 1].state, getLine(handoff)

--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -257,6 +257,18 @@ proc freshTokenizerState(
     return incrHighlight.initialState
   newTokenizerState(incrHighlight.backend, language)
 
+proc cachedTokenizerState(
+    incrHighlight: IncrementalHighlight, startLine: int, language: SourceLanguage
+): TokenizerState =
+  ## Return the cached state entering `startLine`, or a fresh state when that
+  ## row is outside the cache or belongs to another syntax backend. Default
+  ## states may fill a gap below an in-flight reparse's frontier.
+  if startLine > 0 and startLine - 1 < incrHighlight.lineStates.states.len:
+    let cached = incrHighlight.lineStates.states[startLine - 1]
+    if cached.backend == incrHighlight.backend:
+      return cached
+  incrHighlight.freshTokenizerState(language)
+
 proc `==`*(a, b: TokenizerState): bool =
   ## Keep engine-specific equality at this boundary so clients comparing
   ## cached states do not need to import Matter's structural stack operator.
@@ -1710,10 +1722,7 @@ proc updateHighlightIncremental*(
     # A small backward margin covers tokens spanning the boundary.
     reparseStart = max(0, changedStartLine - 2)
 
-    if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
-      initialState = incrHighlight.lineStates.states[reparseStart - 1]
-    else:
-      initialState = incrHighlight.freshTokenizerState(language)
+    initialState = incrHighlight.cachedTokenizerState(reparseStart, language)
 
     # Multi-line tokens record the depth at their completion, so restarting
     # mid-token restores a stale depth (e.g. nested comments); rewind to the
@@ -1730,28 +1739,25 @@ proc updateHighlightIncremental*(
     )
     :
       dec reparseStart
-      if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
-        initialState = incrHighlight.lineStates.states[reparseStart - 1]
-      else:
-        initialState = incrHighlight.freshTokenizerState(language)
+      initialState = incrHighlight.cachedTokenizerState(reparseStart, language)
 
     if oldFrontier >= 0 and reparseStart > oldFrontier:
       # Rows between the old frontier and the new anchor were trimmed but
       # never re-parsed; restart from the old start line instead.
       reparseStart = oldReparseStart
-      if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
-        initialState = incrHighlight.lineStates.states[reparseStart - 1]
-      else:
-        initialState = incrHighlight.freshTokenizerState(language)
+      initialState = incrHighlight.cachedTokenizerState(reparseStart, language)
     elif oldReparseStart >= 0 and reparseStart - 1 >= incrHighlight.lineStates.states.len:
       # The discarded flight's trim left no seed state below the new anchor;
       # restart from the top of the available cache (fresh flights always
       # have `states.len >= reparseStart`).
       reparseStart = incrHighlight.lineStates.states.len
-      if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
-        initialState = incrHighlight.lineStates.states[reparseStart - 1]
-      else:
-        initialState = incrHighlight.freshTokenizerState(language)
+      initialState = incrHighlight.cachedTokenizerState(reparseStart, language)
+
+    when defined(moe.matter) or defined(features.moe.matter):
+      if initialState.backend == hbMatter:
+        # A timeout or grammar error remains sticky within one parse flight,
+        # but a later edit starts a new flight and gets one recovery attempt.
+        initialState.matterState.failed = false
 
     let trimIdx = incrHighlight.segments.segmentCutIndex(reparseStart)
     if trimIdx < incrHighlight.segments.len:

--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -26,7 +26,7 @@ import color, unicode_utils
 import types/highlight_types
 import syntax/tokenizer
 import lsp/protocol/types
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import syntax/matter_backend
 
 export SourceLanguage, EditorColorPairIndex, HighlightBackend
@@ -98,7 +98,7 @@ type
     state*: TokenClass
     lang*: LangState
     backend*: HighlightBackend
-    when defined(moe.matter):
+    when defined(moe.matter) or defined(features.moe.matter):
       matterState*: MatterLineState
 
   LineStateCache* = object ## Cache of tokenizer states for each line
@@ -223,7 +223,7 @@ proc effectiveHighlightBackend*(
   discard language
   hbBuiltin
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   proc effectiveHighlightBackend*(
       backend: HighlightBackend, language: SourceLanguage, grammars: MatterGrammarSet
   ): HighlightBackend =
@@ -238,7 +238,7 @@ proc newTokenizerState*(
   ## Fresh state without an explicit grammar. Matter therefore falls back.
   TokenizerState(backend: effectiveHighlightBackend(backend, language))
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   proc newTokenizerState*(
       backend: HighlightBackend, language: SourceLanguage, grammars: MatterGrammarSet
   ): TokenizerState =
@@ -262,7 +262,7 @@ proc `==`*(a, b: TokenizerState): bool =
   ## cached states do not need to import Matter's structural stack operator.
   if a.backend != b.backend:
     return false
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     if a.backend == hbMatter:
       return a.matterState == b.matterState
   a.state == b.state and a.lang == b.lang
@@ -1132,7 +1132,7 @@ func capturedBoundaryState(
   else:
     token.state
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   proc matterColor(category: MatterColorCategory): EditorColorPairIndex =
     case category
     of mccComment: comment
@@ -1263,7 +1263,7 @@ proc initHighlightIncrementalFromStr*(
   ## `startLine + i + 1` — even when the tokenizer stops before the end of
   ## the buffer (interior NUL, defensive break). Consumers index into it
   ## positionally and must be able to rely on this.
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     if initialState.backend == hbMatter:
       return initMatterHighlight(
         bufferStr, startLine, endLine, initialState, reservedWords, language,

--- a/src/moepkg/highlight.nim
+++ b/src/moepkg/highlight.nim
@@ -140,6 +140,8 @@ type
 
   IncrementalHighlight* = ref object ## Incremental highlighting information
     backend*: HighlightBackend
+    initialState*: TokenizerState
+      ## Fresh state for this cache's backend, including its opted-in grammar.
     segments*: seq[ColorSegment]
     lineStates*: LineStateCache
     parsedUpTo*: int ## Last line parsed during initial load. -1 = not started.
@@ -217,16 +219,43 @@ proc effectiveHighlightBackend*(
     backend: HighlightBackend, language: SourceLanguage
 ): HighlightBackend =
   ## Resolve compile-time availability and specialised lexer fallbacks.
-  when defined(moe.matter):
-    if backend == hbMatter and matterSupports(language):
-      return hbMatter
+  discard backend
+  discard language
   hbBuiltin
+
+when defined(moe.matter):
+  proc effectiveHighlightBackend*(
+      backend: HighlightBackend, language: SourceLanguage, grammars: MatterGrammarSet
+  ): HighlightBackend =
+    ## Resolve backend availability after an explicit grammar opt-in.
+    if backend == hbMatter and grammars.matterSupports(language):
+      return hbMatter
+    hbBuiltin
 
 proc newTokenizerState*(
     backend: HighlightBackend, language: SourceLanguage
 ): TokenizerState =
-  ## Fresh state for the selected engine, including unavailable-backend fallback.
+  ## Fresh state without an explicit grammar. Matter therefore falls back.
   TokenizerState(backend: effectiveHighlightBackend(backend, language))
+
+when defined(moe.matter):
+  proc newTokenizerState*(
+      backend: HighlightBackend, language: SourceLanguage, grammars: MatterGrammarSet
+  ): TokenizerState =
+    ## Fresh state for the selected engine and explicit grammar collection.
+    let effective = effectiveHighlightBackend(backend, language, grammars)
+    result.backend = effective
+    if effective == hbMatter:
+      result.matterState = initialMatterState(grammars, language)
+
+proc freshTokenizerState(
+    incrHighlight: IncrementalHighlight, language: SourceLanguage
+): TokenizerState =
+  ## Recover the immutable engine seed retained by this cache. Older/manual
+  ## cache constructors without a seed continue to get the builtin default.
+  if incrHighlight.initialState.backend == incrHighlight.backend:
+    return incrHighlight.initialState
+  newTokenizerState(incrHighlight.backend, language)
 
 proc `==`*(a, b: TokenizerState): bool =
   ## Keep engine-specific equality at this boundary so clients comparing
@@ -1684,7 +1713,7 @@ proc updateHighlightIncremental*(
     if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
       initialState = incrHighlight.lineStates.states[reparseStart - 1]
     else:
-      initialState = newTokenizerState(incrHighlight.backend, language)
+      initialState = incrHighlight.freshTokenizerState(language)
 
     # Multi-line tokens record the depth at their completion, so restarting
     # mid-token restores a stale depth (e.g. nested comments); rewind to the
@@ -1704,7 +1733,7 @@ proc updateHighlightIncremental*(
       if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
         initialState = incrHighlight.lineStates.states[reparseStart - 1]
       else:
-        initialState = newTokenizerState(incrHighlight.backend, language)
+        initialState = incrHighlight.freshTokenizerState(language)
 
     if oldFrontier >= 0 and reparseStart > oldFrontier:
       # Rows between the old frontier and the new anchor were trimmed but
@@ -1713,7 +1742,7 @@ proc updateHighlightIncremental*(
       if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
         initialState = incrHighlight.lineStates.states[reparseStart - 1]
       else:
-        initialState = newTokenizerState(incrHighlight.backend, language)
+        initialState = incrHighlight.freshTokenizerState(language)
     elif oldReparseStart >= 0 and reparseStart - 1 >= incrHighlight.lineStates.states.len:
       # The discarded flight's trim left no seed state below the new anchor;
       # restart from the top of the available cache (fresh flights always
@@ -1722,7 +1751,7 @@ proc updateHighlightIncremental*(
       if reparseStart > 0 and reparseStart - 1 < incrHighlight.lineStates.states.len:
         initialState = incrHighlight.lineStates.states[reparseStart - 1]
       else:
-        initialState = newTokenizerState(incrHighlight.backend, language)
+        initialState = incrHighlight.freshTokenizerState(language)
 
     let trimIdx = incrHighlight.segments.segmentCutIndex(reparseStart)
     if trimIdx < incrHighlight.segments.len:

--- a/src/moepkg/highlight_config.nim
+++ b/src/moepkg/highlight_config.nim
@@ -17,7 +17,7 @@
 #                                                                              #
 #[############################################################################]#
 
-## Push the editor's `config.highlight` settings (reserved words and the
+## Push the editor's `config.highlight` settings (reserved words, backend and
 ## per-line tokenization cap) into a buffer's syntax-highlight state. This is
 ## about the editor's OWN config, not `.editorconfig` files — those live in
 ## `editorconfig_helper`.
@@ -26,14 +26,18 @@ import config
 import buffer/[core, highlight]
 
 proc applyHighlightCap*(buffer: TextBuffer, config: EditorConfig) =
-  ## Seed the per-line tokenization cap from config. Must run BEFORE `loadFile`,
+  ## Seed the backend and per-line cap from config. Must run BEFORE `loadFile`,
   ## which reads `maxHighlightLineLength` to cap the first chunk. Applying it
   ## afterwards would nil the freshly-seeded progressive-load cache and force a
   ## full synchronous reparse on open — the stall the cap exists to prevent.
+  when defined(moe.matter):
+    buffer.setHighlightBackend(config.highlight.backend)
+  else:
+    buffer.setHighlightBackend(hbBuiltin)
   buffer.setMaxHighlightLineLength(config.highlight.maxHighlightLineLength)
 
 proc applyHighlightConfig*(buffer: TextBuffer, config: EditorConfig) =
-  ## Apply config-derived highlight settings (reserved words + per-line cap) to
+  ## Apply config-derived settings (reserved words, backend and per-line cap) to
   ## a buffer, funnelling both through one call so they cannot drift.
   ##
   ## Reserved words must be applied AFTER `loadFile` (it clears

--- a/src/moepkg/highlight_config.nim
+++ b/src/moepkg/highlight_config.nim
@@ -30,10 +30,7 @@ proc applyHighlightCap*(buffer: TextBuffer, config: EditorConfig) =
   ## which reads `maxHighlightLineLength` to cap the first chunk. Applying it
   ## afterwards would nil the freshly-seeded progressive-load cache and force a
   ## full synchronous reparse on open — the stall the cap exists to prevent.
-  when defined(moe.matter):
-    buffer.setHighlightBackend(config.highlight.backend)
-  else:
-    buffer.setHighlightBackend(hbBuiltin)
+  buffer.setHighlightBackend(config.highlight.backend)
   buffer.setMaxHighlightLineLength(config.highlight.maxHighlightLineLength)
 
 proc applyHighlightConfig*(buffer: TextBuffer, config: EditorConfig) =

--- a/src/moepkg/highlight_config.nim
+++ b/src/moepkg/highlight_config.nim
@@ -30,7 +30,7 @@ proc applyHighlightCap*(buffer: TextBuffer, config: EditorConfig) =
   ## which reads `maxHighlightLineLength` to cap the first chunk. Applying it
   ## afterwards would nil the freshly-seeded progressive-load cache and force a
   ## full synchronous reparse on open — the stall the cap exists to prevent.
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     buffer.setMatterGrammarSet(config.highlight.matterGrammarSet)
   buffer.setHighlightBackend(config.highlight.backend)
   buffer.setMaxHighlightLineLength(config.highlight.maxHighlightLineLength)

--- a/src/moepkg/highlight_config.nim
+++ b/src/moepkg/highlight_config.nim
@@ -30,6 +30,8 @@ proc applyHighlightCap*(buffer: TextBuffer, config: EditorConfig) =
   ## which reads `maxHighlightLineLength` to cap the first chunk. Applying it
   ## afterwards would nil the freshly-seeded progressive-load cache and force a
   ## full synchronous reparse on open — the stall the cap exists to prevent.
+  when defined(moe.matter):
+    buffer.setMatterGrammarSet(config.highlight.matterGrammarSet)
   buffer.setHighlightBackend(config.highlight.backend)
   buffer.setMaxHighlightLineLength(config.highlight.maxHighlightLineLength)
 

--- a/src/moepkg/syntax/matter_backend.nim
+++ b/src/moepkg/syntax/matter_backend.nim
@@ -1,0 +1,253 @@
+## Optional Matter TextMate adapter, with resources embedded from the pinned
+## source package. Only Matter-enabled builds import this module. Grammar and
+## resource caches belong to the editor thread; immutable line states belong to
+## each buffer's incremental cache.
+
+when not defined(moe.matter):
+  {.error: "moepkg/syntax/matter_backend requires -d:moe.matter".}
+
+import std/[macros, options, os, sets, streams, strutils, tables]
+import matter/[engine, grammarloader, grammarpackages]
+import zippy/ziparchives_v1
+
+import tokenizer
+import ../[logger, unicode_utils]
+
+const matterGrammarRoot* {.strdefine.} = ""
+  ## Optional full Matter source checkout containing data/grammars. Atlas
+  ## checkouts are located automatically; Nimble 0.3.0 installs omit the assets.
+
+const MatterTimeLimitMs* {.intdefine.} = 20
+  ## Soft per-line deadline. Override with -d:matterTimeLimitMs=N; 0 disables
+  ## timing for deterministic equivalence tests or intentionally unlimited builds.
+
+static:
+  doAssert MatterTimeLimitMs >= 0, "matterTimeLimitMs must be non-negative"
+
+macro matterRoot(): untyped =
+  if matterGrammarRoot.len > 0:
+    result = newLit(matterGrammarRoot)
+  else:
+    let source = bindSym"findMoeGrammar".getImpl.lineInfoObj.filename
+    result = newLit(source.parentDir.parentDir.parentDir)
+
+const ResolvedMatterRoot = matterRoot()
+
+static:
+  doAssert dirExists(ResolvedMatterRoot / "data/grammars"),
+    "Matter grammar assets are unavailable. Build with Atlas, or pass " &
+      "-d:matterGrammarRoot=/full/matter-v0.3.0-source-checkout"
+
+macro embedArchives(): untyped =
+  # Use the pinned package catalog as the single source of archive names.
+  result = newNimNode(nnkBracket)
+  for package in knownPackages:
+    result.add(
+      newTree(
+        nnkTupleConstr,
+        newLit(package.dataArchivePath),
+        newCall(
+          bindSym"staticRead", newLit(ResolvedMatterRoot / package.dataArchivePath)
+        ),
+      )
+    )
+
+const EmbeddedArchives = embedArchives()
+
+type
+  MatterColorCategory* = enum
+    mccDefault
+    mccComment
+    mccString
+    mccNumber
+    mccBoolean
+    mccKeyword
+    mccOperator
+    mccPreprocessor
+    mccFunction
+    mccType
+    mccBuiltin
+    mccIdentifier
+    mccProperty
+
+  MatterSpan* = object ## Half-open UTF-8 byte range in the original input line.
+    firstByte*, lastByte*: int
+    scopes*: seq[string]
+    category*: MatterColorCategory
+
+  MatterLineState* = object
+    ## Completed state entering the next line. A failure is sticky so a slow
+    ## or invalid grammar cannot be retried on every subsequent line/frame.
+    stack*: StateStack
+    failed*: bool
+
+var
+  grammarCache: Table[string, Grammar]
+  unavailableScopes: HashSet[string]
+  extractedArchives: Table[string, Table[string, string]]
+
+proc `==`*(a, b: MatterLineState): bool =
+  a.failed == b.failed and a.stack == b.stack
+
+func scopeMatches(scope, prefix: string): bool =
+  scope == prefix or scope.startsWith(prefix & ".")
+
+proc isMatterCodeBlock*(state: MatterLineState): bool =
+  ## Whether a completed Markdown state is inside a fenced or indented block.
+  not state.failed and (
+    state.stack.hasActiveScope("markup.fenced_code.block") or
+    state.stack.hasActiveScope("markup.raw.block")
+  )
+
+proc category(scopes: openArray[string]): MatterColorCategory =
+  # Keep comment captures in the comment channel so Moe can apply its own
+  # configurable reserved words, even when a grammar marks TODO specially.
+  for scope in scopes:
+    if scope.scopeMatches("comment"):
+      return mccComment
+  # Prefer the most specific scope, including interpolated expressions inside
+  # strings. Match scope components, not substrings in language names.
+  for i in countdown(scopes.high, 0):
+    let scope = scopes[i]
+    if scope.scopeMatches("comment"):
+      return mccComment
+    if scope.scopeMatches("constant.numeric"):
+      return mccNumber
+    if scope.scopeMatches("constant.language") or scope.scopeMatches("constant.boolean"):
+      return mccBoolean
+    if scope.scopeMatches("entity.name.function"):
+      return mccFunction
+    if scope.scopeMatches("variable.other.property") or
+        scope.scopeMatches("support.type.property-name") or
+        scope.scopeMatches("string.quoted.double.json") and
+        "meta.structure.dictionary.key.json" in scopes:
+      return mccProperty
+    if scope.scopeMatches("entity.name.type") or scope.scopeMatches("support.type"):
+      return mccType
+    if scope.scopeMatches("keyword.operator"):
+      return mccOperator
+    if scope.scopeMatches("meta.preprocessor") or
+        scope.scopeMatches("keyword.control.directive"):
+      return mccPreprocessor
+    if scope.scopeMatches("keyword") or scope.scopeMatches("storage"):
+      return mccKeyword
+    if scope.scopeMatches("support.function") or scope.scopeMatches("support.class"):
+      return mccBuiltin
+    if scope.scopeMatches("variable"):
+      return mccIdentifier
+    if scope.scopeMatches("string") or scope.scopeMatches("markup.inline.raw"):
+      return mccString
+  mccDefault
+
+proc embeddedArchive(path: string): string =
+  for archive in EmbeddedArchives:
+    if archive[0] == path:
+      return archive[1]
+
+proc embeddedResource(contribution: GrammarContribution): Option[string] =
+  let path = contribution.dataArchivePath
+  if not extractedArchives.hasKey(path):
+    let data = embeddedArchive(path)
+    if data.len == 0:
+      return none(string)
+    var archive = ZipArchive()
+    # Zippy's modern reader accepts file paths only. Keep the deprecated
+    # in-memory stream API isolated until Zippy provides a bytes reader.
+    {.push warning[Deprecated]: off.}
+    archive.open(newStringStream(data))
+    {.pop.}
+    var members: Table[string, string]
+    for grammar in knownGrammars:
+      if grammar.dataArchivePath == path and
+          archive.contents.hasKey(grammar.archiveMember):
+        members[grammar.archiveMember] =
+          archive.contents[grammar.archiveMember].contents
+    extractedArchives[path] = members
+  if extractedArchives[path].hasKey(contribution.archiveMember):
+    some(extractedArchives[path][contribution.archiveMember])
+  else:
+    none(string)
+
+proc scopeFor(language: SourceLanguage): string =
+  if language in {langNone, langDiff, langLog}:
+    return ""
+  let mode = ($language)[4 .. ^1].toLowerAscii
+  for mapping in moeGrammarMappings:
+    if mapping.modeName.toLowerAscii == mode:
+      return mapping.scopeName
+
+proc matterSupports*(language: SourceLanguage): bool =
+  ## Diff and Log deliberately retain Moe's specialised built-in highlighters.
+  scopeFor(language).len > 0
+
+proc grammarFor(language: SourceLanguage): Grammar =
+  let scope = scopeFor(language)
+  if scope.len == 0 or scope in unavailableScopes:
+    return nil
+  if grammarCache.hasKey(scope):
+    return grammarCache[scope]
+  try:
+    let registry = newRegistry()
+    # Optional external includes are common in TextMate packages. The loader
+    # registers every available dependency; missing optional scopes are not a
+    # reason to disable the root grammar.
+    discard registry.loadGrammarPackage(embeddedResource, scope)
+    result = registry.loadGrammar(scope)
+    grammarCache[scope] = result
+  except CatchableError as error:
+    unavailableScopes.incl(scope)
+    logWarn("highlight", "Matter grammar " & scope & " is unavailable: " & error.msg)
+
+proc sanitizeInvalidUtf8(line: string): string =
+  ## Replace only malformed high bytes with spaces, preserving byte positions
+  ## for returned spans. The buffer's original contents are never modified.
+  result = line
+  var pos = 0
+  while pos < result.len:
+    let size = result.runeSizeAt(pos)
+    if size == 1 and uint8(result[pos]) >= 0x80:
+      result[pos] = ' '
+    pos += size
+
+proc tokenizeMatterLine*(
+    line: string,
+    language: SourceLanguage,
+    previous = MatterLineState(),
+    timeLimitMs = MatterTimeLimitMs,
+): tuple[spans: seq[MatterSpan], nextState: MatterLineState] =
+  ## Tokenize one line with a soft deadline (0 disables it). Failed/partial
+  ## parses return no spans and no partial stack. Subsequent lines stay plain
+  ## until the caller restarts from an earlier successful or fresh state.
+  if previous.failed:
+    result.nextState = previous
+    return
+  let grammar = grammarFor(language)
+  if grammar.isNil:
+    result.nextState.failed = true
+    return
+  try:
+    let parsed =
+      grammar.tokenizeLine(sanitizeInvalidUtf8(line), previous.stack, timeLimitMs)
+    if parsed.stoppedEarly:
+      result.nextState.failed = true
+      logWarn(
+        "highlight",
+        "Matter tokenization exceeded its soft line budget for " & $language,
+      )
+      return
+    result.nextState.stack = parsed.completedRuleStack
+    for token in parsed.tokens:
+      if token.endIndex > token.startIndex:
+        result.spans.add(
+          MatterSpan(
+            firstByte: token.startIndex,
+            lastByte: token.endIndex,
+            scopes: token.scopes,
+            category: category(token.scopes),
+          )
+        )
+  except CatchableError as error:
+    result.nextState.failed = true
+    logWarn(
+      "highlight", "Matter tokenization failed for " & $language & ": " & error.msg
+    )

--- a/src/moepkg/syntax/matter_backend.nim
+++ b/src/moepkg/syntax/matter_backend.nim
@@ -70,8 +70,12 @@ proc `==`*(a, b: MatterLineState): bool =
 
 proc `==`*(a, b: MatterGrammarSet): bool =
   ## Runtime caches do not participate in configuration value equality.
-  if a.isNil or b.isNil:
-    return a.isNil and b.isNil
+  if cast[pointer](a) == cast[pointer](b):
+    return true
+  if a.isNil:
+    return b.sources.len == 0
+  if b.isNil:
+    return a.sources.len == 0
   a.sources == b.sources
 
 func scopeMatches(scope, prefix: string): bool =

--- a/src/moepkg/syntax/matter_backend.nim
+++ b/src/moepkg/syntax/matter_backend.nim
@@ -2,8 +2,8 @@
 ## grammar source explicitly, either through the public editor/buffer API or
 ## through files named by the user's configuration.
 
-when not defined(moe.matter):
-  {.error: "moepkg/syntax/matter_backend requires -d:moe.matter".}
+when not (defined(moe.matter) or defined(features.moe.matter)):
+  {.error: "moepkg/syntax/matter_backend requires the Matter feature".}
 
 import std/[sets, strutils, tables]
 import matter/[engine, grammarpackages, rawgrammar]

--- a/src/moepkg/syntax/matter_backend.nim
+++ b/src/moepkg/syntax/matter_backend.nim
@@ -1,21 +1,16 @@
-## Optional Matter TextMate adapter, with resources embedded from the pinned
-## source package. Only Matter-enabled builds import this module. Grammar and
-## resource caches belong to the editor thread; immutable line states belong to
-## each buffer's incremental cache.
+## Optional Matter TextMate adapter. Moe does not bundle grammars: callers add
+## grammar source explicitly, either through the public editor/buffer API or
+## through files named by the user's configuration.
 
 when not defined(moe.matter):
   {.error: "moepkg/syntax/matter_backend requires -d:moe.matter".}
 
-import std/[macros, options, os, sets, streams, strutils, tables]
-import matter/[engine, grammarloader, grammarpackages]
-import zippy/ziparchives_v1
+import std/[sets, strutils, tables]
+import matter/[engine, grammarpackages, rawgrammar]
 
 import tokenizer
 import ../[logger, unicode_utils]
-
-const matterGrammarRoot* {.strdefine.} = ""
-  ## Optional full Matter source checkout containing data/grammars. Atlas
-  ## checkouts are located automatically; Nimble 0.3.0 installs omit the assets.
+import ../types/highlight_types
 
 const MatterTimeLimitMs* {.intdefine.} = 20
   ## Soft per-line deadline. Override with -d:matterTimeLimitMs=N; 0 disables
@@ -23,36 +18,6 @@ const MatterTimeLimitMs* {.intdefine.} = 20
 
 static:
   doAssert MatterTimeLimitMs >= 0, "matterTimeLimitMs must be non-negative"
-
-macro matterRoot(): untyped =
-  if matterGrammarRoot.len > 0:
-    result = newLit(matterGrammarRoot)
-  else:
-    let source = bindSym"findMoeGrammar".getImpl.lineInfoObj.filename
-    result = newLit(source.parentDir.parentDir.parentDir)
-
-const ResolvedMatterRoot = matterRoot()
-
-static:
-  doAssert dirExists(ResolvedMatterRoot / "data/grammars"),
-    "Matter grammar assets are unavailable. Build with Atlas, or pass " &
-      "-d:matterGrammarRoot=/full/matter-v0.3.0-source-checkout"
-
-macro embedArchives(): untyped =
-  # Use the pinned package catalog as the single source of archive names.
-  result = newNimNode(nnkBracket)
-  for package in knownPackages:
-    result.add(
-      newTree(
-        nnkTupleConstr,
-        newLit(package.dataArchivePath),
-        newCall(
-          bindSym"staticRead", newLit(ResolvedMatterRoot / package.dataArchivePath)
-        ),
-      )
-    )
-
-const EmbeddedArchives = embedArchives()
 
 type
   MatterColorCategory* = enum
@@ -75,19 +40,39 @@ type
     scopes*: seq[string]
     category*: MatterColorCategory
 
+  MatterGrammarSource* = object
+    ## One caller-owned TextMate grammar. `path` selects JSON (`.json`) versus
+    ## XML plist parsing and is used in diagnostics; Moe never reads it here.
+    content*: string
+    path*: string
+    language*: SourceLanguage
+      ## `langNone` lets Moe infer the language from the grammar's scope name.
+
+  MatterGrammarSet* = ref object
+    ## An immutable-by-convention collection shared by an editor's buffers.
+    ## Use `withMatterGrammar` to derive a set with a programmatic override.
+    sources: seq[MatterGrammarSource]
+    registry: Registry
+    scopes: HashSet[string]
+    languageScopes: Table[SourceLanguage, string]
+    grammarCache: Table[SourceLanguage, Grammar]
+    unavailableLanguages: HashSet[SourceLanguage]
+
   MatterLineState* = object
     ## Completed state entering the next line. A failure is sticky so a slow
     ## or invalid grammar cannot be retried on every subsequent line/frame.
+    grammar: Grammar
     stack*: StateStack
     failed*: bool
 
-var
-  grammarCache: Table[string, Grammar]
-  unavailableScopes: HashSet[string]
-  extractedArchives: Table[string, Table[string, string]]
-
 proc `==`*(a, b: MatterLineState): bool =
-  a.failed == b.failed and a.stack == b.stack
+  a.failed == b.failed and a.grammar == b.grammar and a.stack == b.stack
+
+proc `==`*(a, b: MatterGrammarSet): bool =
+  ## Runtime caches do not participate in configuration value equality.
+  if a.isNil or b.isNil:
+    return a.isNil and b.isNil
+  a.sources == b.sources
 
 func scopeMatches(scope, prefix: string): bool =
   scope == prefix or scope.startsWith(prefix & ".")
@@ -139,35 +124,6 @@ proc category(scopes: openArray[string]): MatterColorCategory =
       return mccString
   mccDefault
 
-proc embeddedArchive(path: string): string =
-  for archive in EmbeddedArchives:
-    if archive[0] == path:
-      return archive[1]
-
-proc embeddedResource(contribution: GrammarContribution): Option[string] =
-  let path = contribution.dataArchivePath
-  if not extractedArchives.hasKey(path):
-    let data = embeddedArchive(path)
-    if data.len == 0:
-      return none(string)
-    var archive = ZipArchive()
-    # Zippy's modern reader accepts file paths only. Keep the deprecated
-    # in-memory stream API isolated until Zippy provides a bytes reader.
-    {.push warning[Deprecated]: off.}
-    archive.open(newStringStream(data))
-    {.pop.}
-    var members: Table[string, string]
-    for grammar in knownGrammars:
-      if grammar.dataArchivePath == path and
-          archive.contents.hasKey(grammar.archiveMember):
-        members[grammar.archiveMember] =
-          archive.contents[grammar.archiveMember].contents
-    extractedArchives[path] = members
-  if extractedArchives[path].hasKey(contribution.archiveMember):
-    some(extractedArchives[path][contribution.archiveMember])
-  else:
-    none(string)
-
 proc scopeFor(language: SourceLanguage): string =
   if language in {langNone, langDiff, langLog}:
     return ""
@@ -176,27 +132,104 @@ proc scopeFor(language: SourceLanguage): string =
     if mapping.modeName.toLowerAscii == mode:
       return mapping.scopeName
 
-proc matterSupports*(language: SourceLanguage): bool =
-  ## Diff and Log deliberately retain Moe's specialised built-in highlighters.
-  scopeFor(language).len > 0
+proc newMatterGrammarSet*(): MatterGrammarSet =
+  ## Create an empty set. An empty set cannot select Matter highlighting.
+  MatterGrammarSet(
+    registry: newRegistry(),
+    scopes: initHashSet[string](),
+    languageScopes: initTable[SourceLanguage, string](),
+    grammarCache: initTable[SourceLanguage, Grammar](),
+    unavailableLanguages: initHashSet[SourceLanguage](),
+  )
 
-proc grammarFor(language: SourceLanguage): Grammar =
-  let scope = scopeFor(language)
-  if scope.len == 0 or scope in unavailableScopes:
+proc newMatterGrammarSet*(sources: openArray[MatterGrammarSource]): MatterGrammarSet =
+  ## Parse and register caller-provided grammar text. All sources are added
+  ## before any root is compiled, so they may provide external includes for
+  ## one another. Parse errors are reported to the caller.
+  result = newMatterGrammarSet()
+  for source in sources:
+    let path = if source.path.len > 0: source.path else: "grammar.tmLanguage.json"
+    let raw =
+      try:
+        parseRawGrammar(source.content, path)
+      except CatchableError as error:
+        raise newException(TextMateGrammarError, error.msg)
+    try:
+      result.registry.addGrammar(raw)
+    except CatchableError as error:
+      raise newException(TextMateGrammarError, error.msg)
+    result.scopes.incl(raw.scopeName)
+    result.sources.add(
+      MatterGrammarSource(
+        content: source.content, path: path, language: source.language
+      )
+    )
+    if source.language != langNone:
+      result.languageScopes[source.language] = raw.scopeName
+
+proc grammarFor(grammars: MatterGrammarSet, language: SourceLanguage): Grammar =
+  if grammars.isNil or language in {langNone, langDiff, langLog} or
+      language in grammars.unavailableLanguages:
     return nil
-  if grammarCache.hasKey(scope):
-    return grammarCache[scope]
+  let scope =
+    if grammars.languageScopes.hasKey(language):
+      grammars.languageScopes[language]
+    else:
+      scopeFor(language)
+  if scope.len == 0 or scope notin grammars.scopes:
+    return nil
+  if grammars.grammarCache.hasKey(language):
+    return grammars.grammarCache[language]
   try:
-    let registry = newRegistry()
-    # Optional external includes are common in TextMate packages. The loader
-    # registers every available dependency; missing optional scopes are not a
-    # reason to disable the root grammar.
-    discard registry.loadGrammarPackage(embeddedResource, scope)
-    result = registry.loadGrammar(scope)
-    grammarCache[scope] = result
+    result = grammars.registry.loadGrammar(scope)
+    grammars.grammarCache[language] = result
   except CatchableError as error:
-    unavailableScopes.incl(scope)
+    grammars.unavailableLanguages.incl(language)
     logWarn("highlight", "Matter grammar " & scope & " is unavailable: " & error.msg)
+
+proc matterSupports*(grammars: MatterGrammarSet, language: SourceLanguage): bool =
+  ## Matter is available only after this set received a valid root grammar.
+  ## Diff and Log deliberately retain Moe's specialised built-in highlighters.
+  not grammars.grammarFor(language).isNil
+
+proc matterSupports*(language: SourceLanguage): bool =
+  ## The compatibility query has no implicit global grammar registry. Callers
+  ## must pass the grammar set they opted into.
+  discard language
+  false
+
+proc withMatterGrammar*(
+    grammars: MatterGrammarSet,
+    language: SourceLanguage,
+    content: string,
+    path = "grammar.tmLanguage.json",
+): MatterGrammarSet =
+  ## Return a grammar set with one programmatic root for `language`. Existing
+  ## inferred/config-file grammars and roots for other languages are retained.
+  ## The new root is compiled before return, so malformed regexes fail at the
+  ## API boundary instead of silently degrading on the first rendered line.
+  if language in {langNone, langDiff, langLog}:
+    raise newException(
+      TextMateGrammarError,
+      "Matter highlighting requires a concrete non-Diff/Log language",
+    )
+  var sources: seq[MatterGrammarSource]
+  if not grammars.isNil:
+    for source in grammars.sources:
+      if source.language != language:
+        sources.add(source)
+  sources.add(MatterGrammarSource(content: content, path: path, language: language))
+  result = newMatterGrammarSet(sources)
+  if result.grammarFor(language).isNil:
+    raise newException(
+      TextMateGrammarError, "TextMate grammar could not be compiled for " & $language
+    )
+
+proc initialMatterState*(
+    grammars: MatterGrammarSet, language: SourceLanguage
+): MatterLineState =
+  ## Create a fresh line state for a grammar set/language pair.
+  MatterLineState(grammar: grammars.grammarFor(language))
 
 proc sanitizeInvalidUtf8(line: string): string =
   ## Replace only malformed high bytes with spaces, preserving byte positions
@@ -214,6 +247,7 @@ proc tokenizeMatterLine*(
     language: SourceLanguage,
     previous = MatterLineState(),
     timeLimitMs = MatterTimeLimitMs,
+    grammars: MatterGrammarSet = nil,
 ): tuple[spans: seq[MatterSpan], nextState: MatterLineState] =
   ## Tokenize one line with a soft deadline (0 disables it). Failed/partial
   ## parses return no spans and no partial stack. Subsequent lines stay plain
@@ -221,10 +255,15 @@ proc tokenizeMatterLine*(
   if previous.failed:
     result.nextState = previous
     return
-  let grammar = grammarFor(language)
+  let grammar =
+    if previous.grammar.isNil:
+      grammars.grammarFor(language)
+    else:
+      previous.grammar
   if grammar.isNil:
     result.nextState.failed = true
     return
+  result.nextState.grammar = grammar
   try:
     let parsed =
       grammar.tokenizeLine(sanitizeInvalidUtf8(line), previous.stack, timeLimitMs)
@@ -235,6 +274,7 @@ proc tokenizeMatterLine*(
         "Matter tokenization exceeded its soft line budget for " & $language,
       )
       return
+    result.nextState.grammar = grammar
     result.nextState.stack = parsed.completedRuleStack
     for token in parsed.tokens:
       if token.endIndex > token.startIndex:

--- a/src/moepkg/types/config_types.nim
+++ b/src/moepkg/types/config_types.nim
@@ -27,6 +27,7 @@
 import std/[options, tables]
 
 import ../modes
+import highlight_types
 
 import ../config_macros
 export config_macros
@@ -232,6 +233,9 @@ type
 
   # Highlight settings
   HighlightConfig* {.cfgSection: "Highlight".} = object
+    backend* {.
+      cfg, cfgDocDescription: "Syntax highlighting backend (builtin or matter)"
+    .}: HighlightBackend
     currentLine* {.cfg, cfgDocDescription: "Highlight the current line background".}:
       bool
     currentColumn* {.cfg, cfgDocDescription: "Highlight the current column background".}:

--- a/src/moepkg/types/config_types.nim
+++ b/src/moepkg/types/config_types.nim
@@ -28,6 +28,8 @@ import std/[options, tables]
 
 import ../modes
 import highlight_types
+when defined(moe.matter):
+  import ../syntax/matter_backend
 
 import ../config_macros
 export config_macros
@@ -236,6 +238,15 @@ type
     backend* {.
       cfg, cfgDocDescription: "Syntax highlighting backend (builtin or matter)"
     .}: HighlightBackend
+    matterGrammarFiles* {.
+      cfg,
+      cfgNoUi,
+      cfgDocDescription:
+        "TextMate grammar files, resolved inside Moe's configuration directory"
+    .}: seq[string]
+    when defined(moe.matter):
+      matterGrammarSet* {.cfgSkip.}: MatterGrammarSet
+        ## Parsed runtime grammar collection; never serialized into TOML.
     currentLine* {.cfg, cfgDocDescription: "Highlight the current line background".}:
       bool
     currentColumn* {.cfg, cfgDocDescription: "Highlight the current column background".}:

--- a/src/moepkg/types/config_types.nim
+++ b/src/moepkg/types/config_types.nim
@@ -28,7 +28,7 @@ import std/[options, tables]
 
 import ../modes
 import highlight_types
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import ../syntax/matter_backend
 
 import ../config_macros
@@ -244,7 +244,7 @@ type
       cfgDocDescription:
         "TextMate grammar files, resolved inside Moe's configuration directory"
     .}: seq[string]
-    when defined(moe.matter):
+    when defined(moe.matter) or defined(features.moe.matter):
       matterGrammarSet* {.cfgSkip.}: MatterGrammarSet
         ## Parsed runtime grammar collection; never serialized into TOML.
     currentLine* {.cfg, cfgDocDescription: "Highlight the current line background".}:

--- a/src/moepkg/types/highlight_types.nim
+++ b/src/moepkg/types/highlight_types.nim
@@ -1,0 +1,5 @@
+## Shared syntax-highlighting configuration types.
+
+type HighlightBackend* = enum
+  hbBuiltin = "builtin" ## Moe's built-in tokenizer
+  hbMatter = "matter" ## Optional Matter TextMate grammar tokenizer

--- a/src/moepkg/types/highlight_types.nim
+++ b/src/moepkg/types/highlight_types.nim
@@ -1,5 +1,9 @@
 ## Shared syntax-highlighting configuration types.
 
-type HighlightBackend* = enum
-  hbBuiltin = "builtin" ## Moe's built-in tokenizer
-  hbMatter = "matter" ## Optional Matter TextMate grammar tokenizer
+type
+  HighlightBackend* = enum
+    hbBuiltin = "builtin" ## Moe's built-in tokenizer
+    hbMatter = "matter" ## Optional Matter TextMate grammar tokenizer
+
+  TextMateGrammarError* = object of ValueError
+    ## Invalid grammar input or unavailable Matter support at the public API.

--- a/tests/matter_test_grammars.nim
+++ b/tests/matter_test_grammars.nim
@@ -1,0 +1,69 @@
+when defined(moe.matter):
+  import ../src/moepkg/syntax/[matter_backend, tokenizer]
+
+  const
+    NimMatterGrammar* = """
+{
+  "name": "Nim test grammar",
+  "scopeName": "source.nim",
+  "patterns": [
+    {"include": "#blockComment"},
+    {"match": "#.*$", "name": "comment.line.number-sign.nim"},
+    {"match": "\\b(true|false)\\b", "name": "constant.language.boolean.nim"},
+    {"match": "\\b(proc|let|discard)\\b", "name": "keyword.nim"},
+    {"match": "\\b[0-9]+\\b", "name": "constant.numeric.nim"}
+  ],
+  "repository": {
+    "blockComment": {
+      "begin": "#\\[",
+      "end": "\\]#",
+      "name": "comment.block.nim",
+      "patterns": [{"include": "#blockComment"}]
+    }
+  }
+}
+"""
+
+    JsoncMatterGrammar* = """
+{
+  "name": "JSONC test grammar",
+  "scopeName": "source.json.comments",
+  "patterns": [
+    {"match": "//.*$", "name": "comment.line.double-slash.jsonc"},
+    {"match": "\\b(true|false|null)\\b", "name": "constant.language.jsonc"}
+  ]
+}
+"""
+
+    MarkdownMatterGrammar* = """
+{
+  "name": "Markdown test grammar",
+  "scopeName": "text.html.markdown",
+  "patterns": [
+    {
+      "begin": "^(```|~~~).*$",
+      "end": "^\\1\\s*$",
+      "name": "markup.fenced_code.block.markdown"
+    }
+  ]
+}
+"""
+
+  proc newTestMatterGrammarSet*(): MatterGrammarSet =
+    newMatterGrammarSet(
+      [
+        MatterGrammarSource(
+          content: NimMatterGrammar, path: "nim.tmLanguage.json", language: langNim
+        ),
+        MatterGrammarSource(
+          content: JsoncMatterGrammar,
+          path: "jsonc.tmLanguage.json",
+          language: langJsonc,
+        ),
+        MatterGrammarSource(
+          content: MarkdownMatterGrammar,
+          path: "markdown.tmLanguage.json",
+          language: langMarkdown,
+        ),
+      ]
+    )

--- a/tests/matter_test_grammars.nim
+++ b/tests/matter_test_grammars.nim
@@ -1,4 +1,4 @@
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import ../src/moepkg/syntax/[matter_backend, tokenizer]
 
   const

--- a/tests/test_color.nim
+++ b/tests/test_color.nim
@@ -381,3 +381,10 @@ suite "color - colorModeRank":
 suite "color - applyColorModeFallback":
   test "cmkNone always returns cmkNone":
     check applyColorModeFallback(cmkNone) == cmkNone
+
+  when defined(moe.embedded):
+    test "embedded frontends retain the requested color precision":
+      check applyColorModeFallback(cmk8color) == cmk8color
+      check applyColorModeFallback(cmk16color) == cmk16color
+      check applyColorModeFallback(cmk256color) == cmk256color
+      check applyColorModeFallback(cmk24bit) == cmk24bit

--- a/tests/test_config.nim
+++ b/tests/test_config.nim
@@ -56,6 +56,11 @@ suite "Config - SplitType enum":
     check $stHorizontal == "horizontal"
     check $stVertical == "vertical"
 
+suite "Config - HighlightBackend enum":
+  test "HighlightBackend string values":
+    check $hbBuiltin == "builtin"
+    check $hbMatter == "matter"
+
 suite "Config - LspTraceLevel enum":
   test "LspTraceLevel string values":
     check $ltOff == "off"
@@ -137,6 +142,7 @@ suite "Config - newEditorConfig defaults":
   test "Highlight config defaults":
     let config = newEditorConfig()
 
+    check config.highlight.backend == hbBuiltin
     check config.highlight.currentLine == true
     check config.highlight.currentColumn == false
     check config.highlight.reservedWord == @["TODO", "WIP", "NOTE"]

--- a/tests/test_config_loader.nim
+++ b/tests/test_config_loader.nim
@@ -485,6 +485,23 @@ friction = -1.0
     check config.smoothScroll.friction == 80.0 # Default value
 
 suite "Config Validation - Highlight section":
+  test "matter backend loads from TOML":
+    let content = """
+[Highlight]
+backend = "matter"
+"""
+    let (config, vr) = loadFromTomlString(content)
+    check not vr.hasErrors
+    check config.highlight.backend == hbMatter
+
+  test "invalid backend is rejected":
+    let content = """
+[Highlight]
+backend = "unknown"
+"""
+    let (_, vr) = loadFromTomlString(content)
+    check vr.hasErrors
+
   test "Valid Highlight config passes validation":
     let tomlStr = """
 [Highlight]

--- a/tests/test_config_loader.nim
+++ b/tests/test_config_loader.nim
@@ -25,6 +25,10 @@ import ../src/moepkg/[config_loader, config, color, theme, modes]
 
 import config_test_helper
 
+when defined(moe.matter):
+  import ../src/moepkg/syntax/[matter_backend, tokenizer]
+  import matter_test_grammars
+
 var testFileCounter {.global.} = 0
 
 # Helper proc to load config from a TOML string using a temp file
@@ -501,6 +505,60 @@ backend = "unknown"
 """
     let (_, vr) = loadFromTomlString(content)
     check vr.hasErrors
+
+  when defined(moe.matter):
+    test "Matter grammar files resolve from the moerc directory":
+      inc testFileCounter
+      let
+        directory = getTempDir() / "moe_matter_config_" & $testFileCounter
+        grammarPath = directory / "nim.tmLanguage.json"
+        configPath = directory / "moerc.toml"
+      createDir(directory)
+      defer:
+        removeFile(configPath)
+        removeFile(grammarPath)
+        removeDir(directory)
+      writeFile(grammarPath, NimMatterGrammar)
+      writeFile(
+        configPath,
+        """
+[Highlight]
+backend = "matter"
+matterGrammarFiles = ["nim.tmLanguage.json"]
+""",
+      )
+
+      let loaded = loadConfigFromToml(configPath)
+      require loaded.isOk
+      let (config, vr) = loaded.get
+      check not vr.hasErrors
+      check config.highlight.backend == hbMatter
+      check config.highlight.matterGrammarSet.matterSupports(langNim)
+      check not config.highlight.matterGrammarSet.matterSupports(langRust)
+
+    test "Matter grammar paths cannot escape the moerc directory":
+      inc testFileCounter
+      let
+        directory = getTempDir() / "moe_matter_escape_" & $testFileCounter
+        configPath = directory / "moerc.toml"
+      createDir(directory)
+      defer:
+        removeFile(configPath)
+        removeDir(directory)
+      writeFile(
+        configPath,
+        """
+[Highlight]
+backend = "matter"
+matterGrammarFiles = ["../outside.tmLanguage.json"]
+""",
+      )
+
+      let loaded = loadConfigFromToml(configPath)
+      require loaded.isOk
+      let (_, vr) = loaded.get
+      check vr.hasErrors
+      check vr.errors.anyIt(it.name == "Highlight.matterGrammarFiles")
 
   test "Valid Highlight config passes validation":
     let tomlStr = """

--- a/tests/test_config_loader.nim
+++ b/tests/test_config_loader.nim
@@ -25,7 +25,7 @@ import ../src/moepkg/[config_loader, config, color, theme, modes]
 
 import config_test_helper
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import ../src/moepkg/syntax/[matter_backend, tokenizer]
   import matter_test_grammars
 
@@ -506,7 +506,7 @@ backend = "unknown"
     let (_, vr) = loadFromTomlString(content)
     check vr.hasErrors
 
-  when defined(moe.matter):
+  when defined(moe.matter) or defined(features.moe.matter):
     test "Matter grammar files resolve from the moerc directory":
       inc testFileCounter
       let

--- a/tests/test_configmode.nim
+++ b/tests/test_configmode.nim
@@ -2388,6 +2388,7 @@ suite "ConfigMode - descriptor completeness":
     let excluded = [
       ("StatusLine", "setupText"),
       ("Highlight", "reservedWord"),
+      ("Highlight", "matterGrammarFiles"),
       ("AutoBackup", "backupDir"),
       ("AutoBackup", "dirToExclude"),
       ("BuildOnSave", "workspaceRoot"),

--- a/tests/test_highlight_matter.nim
+++ b/tests/test_highlight_matter.nim
@@ -1,0 +1,162 @@
+import std/[sequtils, unittest]
+
+import pkg/results
+
+import ../src/moepkg/[config, highlight, highlight_config, syntax/tokenizer]
+import ../src/moepkg/buffer {.all.}
+import ../src/moepkg/types/highlight_types
+
+when defined(moe.matter):
+  import pkg/celina
+
+  suite "Matter incremental highlight":
+    test "Matter seed produces one state per line":
+      let lines = @["proc hello() =", "  discard", "# note"]
+      let (segments, states) = initHighlightIncremental(
+        lines,
+        0,
+        lines.high,
+        newTokenizerState(hbMatter, SourceLanguage.langNim),
+        @[],
+        SourceLanguage.langNim,
+      )
+      check states.len == lines.len
+      check states.allIt(it.backend == hbMatter)
+      check segments.len > 0
+
+    test "trailing empty line keeps a state":
+      let (segments, states) = initHighlightIncrementalFromStr(
+        "# one\n",
+        0,
+        1,
+        newTokenizerState(hbMatter, SourceLanguage.langNim),
+        @[],
+        SourceLanguage.langNim,
+      )
+      discard segments
+      check states.len == 2
+
+    test "Diff and Log fall back to builtin":
+      check newTokenizerState(hbMatter, SourceLanguage.langDiff).backend == hbBuiltin
+      check newTokenizerState(hbMatter, SourceLanguage.langLog).backend == hbBuiltin
+
+    test "Markdown fences use Matter state":
+      var buffer = newTextBuffer("```nim\nproc x() = discard\n```\n")
+      buffer.language = SourceLanguage.langMarkdown
+      buffer.highlightBackend = hbMatter
+      buffer.highlightNeedsUpdate = true
+      discard buffer.updateHighlight()
+      check buffer.isCodeBlockLine(0)
+      check buffer.isCodeBlockLine(1)
+      check buffer.isCodeBlockLine(2)
+
+    test "switching backends invalidates incremental state":
+      var buffer = newTextBuffer("proc x() = discard")
+      buffer.language = SourceLanguage.langNim
+      buffer.setHighlightBackend(hbMatter)
+      buffer.highlightNeedsUpdate = true
+      discard buffer.updateHighlight()
+      check buffer.incrementalHighlight.backend == hbMatter
+      buffer.setHighlightBackend(hbBuiltin)
+      check buffer.incrementalHighlight.isNil
+      check buffer.uriScanParsedUpTo == -1
+
+    test "budgeted multiline edit converges to a fresh Matter parse":
+      var lines = @["#["]
+      for i in 0 ..< 350:
+        lines.add("comment line " & $i)
+      lines.add("]#")
+      lines.add("proc tail() = discard")
+      let seed = newTokenizerState(hbMatter, SourceLanguage.langNim)
+      let (oldSegments, oldStates) = initHighlightIncremental(
+        lines, 0, lines.high, seed, @[], SourceLanguage.langNim
+      )
+      var incremental = IncrementalHighlight(
+        backend: hbMatter,
+        segments: oldSegments,
+        lineStates: LineStateCache(states: oldStates),
+        parsedUpTo: lines.high,
+      )
+      lines[0] = "# ordinary comment"
+      var parsed: int
+      var ongoing = updateHighlightIncremental(
+        lines.len,
+        proc(i: int): string =
+          lines[i],
+        incremental,
+        0,
+        @[],
+        SourceLanguage.langNim,
+        0,
+        25,
+        1,
+        parsed,
+      )
+      check ongoing
+      check parsed <= 100
+      while ongoing:
+        ongoing = updateHighlightIncremental(
+          lines.len,
+          proc(i: int): string =
+            lines[i],
+          incremental,
+          0,
+          @[],
+          SourceLanguage.langNim,
+          0,
+          25,
+          1,
+          parsed,
+        )
+      let (freshSegments, freshStates) = initHighlightIncremental(
+        lines,
+        0,
+        lines.high,
+        newTokenizerState(hbMatter, SourceLanguage.langNim),
+        @[],
+        SourceLanguage.langNim,
+      )
+      check incremental.segments == freshSegments
+      check incremental.lineStates.states == freshStates
+
+    test "progressive Matter load survives an edit before completion":
+      var content = ""
+      for i in 0 ..< 1600:
+        content.add("let value" & $i & " = " & $i & "\n")
+      var buffer = newTextBuffer()
+      var config = newEditorConfig()
+      config.highlight.backend = hbMatter
+      buffer.applyHighlightCap(config)
+      check buffer.loadFileWithContent("matter-progressive.nim", content).isOk
+      check buffer.incrementalHighlight.backend == hbMatter
+      check buffer.incrementalHighlight.parsedUpTo == 999
+      let initialCache = buffer.incrementalHighlight
+      buffer.applyHighlightConfig(config)
+      check buffer.incrementalHighlight == initialCache
+      check buffer.incrementalHighlight.parsedUpTo == 999
+      discard buffer.beginTransaction()
+      discard buffer.insert(500, "let edited = 42")
+      discard buffer.commitTransaction()
+      var parsed: int
+      discard buffer.updateHighlight(100, parsed)
+      while buffer.continueIncrementalHighlight(100, parsed):
+        discard
+      while buffer.continueInitialHighlight(100, parsed):
+        discard
+      check buffer.incrementalHighlight.parsedUpTo == buffer.len - 1
+      var lines = newSeq[string](buffer.len)
+      for i in 0 ..< buffer.len:
+        lines[i] = buffer.getLine(i)
+      let (freshSegments, freshStates) = initHighlightIncremental(
+        lines,
+        0,
+        lines.high,
+        newTokenizerState(hbMatter, SourceLanguage.langNim),
+        @[],
+        SourceLanguage.langNim,
+      )
+      check buffer.incrementalHighlight.segments == freshSegments
+      check buffer.incrementalHighlight.lineStates.states == freshStates
+else:
+  static:
+    doAssert true

--- a/tests/test_highlight_matter.nim
+++ b/tests/test_highlight_matter.nim
@@ -6,7 +6,7 @@ import ../src/moepkg/[config, highlight, highlight_config, syntax/tokenizer]
 import ../src/moepkg/buffer {.all.}
 import ../src/moepkg/types/highlight_types
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import pkg/celina
   import matter_test_grammars
 

--- a/tests/test_highlight_matter.nim
+++ b/tests/test_highlight_matter.nim
@@ -160,6 +160,89 @@ when defined(moe.matter) or defined(features.moe.matter):
       )
       check buffer.incrementalHighlight.segments == freshSegments
       check buffer.incrementalHighlight.lineStates.states == freshStates
+
+    test "default config preserves a progressive builtin load cache":
+      var content = ""
+      for i in 0 ..< 1600:
+        content.add("let value" & $i & " = " & $i & "\n")
+      let buffer = newTextBuffer()
+      check buffer.loadFileWithContent("builtin-progressive.nim", content).isOk
+      check buffer.incrementalHighlight.parsedUpTo == 999
+      let initialCache = buffer.incrementalHighlight
+      buffer.applyHighlightConfig(newEditorConfig())
+      check buffer.incrementalHighlight == initialCache
+      check buffer.incrementalHighlight.parsedUpTo == 999
+
+    test "Matter reparse rejects a default state from a cache gap":
+      var lines = newSeq[string](220)
+      for i in 0 ..< lines.len:
+        lines[i] = "let value" & $i & " = " & $i
+      let seed = newTokenizerState(hbMatter, langNim, newTestMatterGrammarSet())
+      let (segments, states) = initHighlightIncremental(
+        lines, 0, lines.high, seed, @[], SourceLanguage.langNim
+      )
+      var incremental = IncrementalHighlight(
+        backend: hbMatter,
+        initialState: seed,
+        segments: segments,
+        lineStates: LineStateCache(states: states),
+        parsedUpTo: lines.high,
+      )
+      incremental.lineStates.states[147] = TokenizerState()
+      lines[150] = "# edited"
+      var parsed: int
+      while updateHighlightIncremental(
+        lines.len,
+        proc(i: int): string =
+          lines[i],
+        incremental,
+        150,
+        @[],
+        SourceLanguage.langNim,
+        0,
+        25,
+        1,
+        parsed,
+      )
+      :
+        discard
+      check incremental.lineStates.states[148 .. ^1].allIt(it.backend == hbMatter)
+
+    test "a fresh Matter reparse retries a cached failed state":
+      var lines = newSeq[string](20)
+      for i in 0 ..< lines.len:
+        lines[i] = "let value" & $i & " = " & $i
+      let seed = newTokenizerState(hbMatter, langNim, newTestMatterGrammarSet())
+      let (segments, states) = initHighlightIncremental(
+        lines, 0, lines.high, seed, @[], SourceLanguage.langNim
+      )
+      var incremental = IncrementalHighlight(
+        backend: hbMatter,
+        initialState: seed,
+        segments: segments,
+        lineStates: LineStateCache(states: states),
+        parsedUpTo: lines.high,
+      )
+      for i in 2 ..< incremental.lineStates.states.len:
+        incremental.lineStates.states[i].matterState.failed = true
+      lines[5] = "# edited"
+      var parsed: int
+      while updateHighlightIncremental(
+        lines.len,
+        proc(i: int): string =
+          lines[i],
+        incremental,
+        5,
+        @[],
+        SourceLanguage.langNim,
+        0,
+        5,
+        1,
+        parsed,
+      )
+      :
+        discard
+      check incremental.lineStates.states[3 .. ^1].allIt(not it.matterState.failed)
 else:
   static:
     doAssert true

--- a/tests/test_highlight_matter.nim
+++ b/tests/test_highlight_matter.nim
@@ -8,15 +8,17 @@ import ../src/moepkg/types/highlight_types
 
 when defined(moe.matter):
   import pkg/celina
+  import matter_test_grammars
 
   suite "Matter incremental highlight":
     test "Matter seed produces one state per line":
+      let grammars = newTestMatterGrammarSet()
       let lines = @["proc hello() =", "  discard", "# note"]
       let (segments, states) = initHighlightIncremental(
         lines,
         0,
         lines.high,
-        newTokenizerState(hbMatter, SourceLanguage.langNim),
+        newTokenizerState(hbMatter, SourceLanguage.langNim, grammars),
         @[],
         SourceLanguage.langNim,
       )
@@ -25,11 +27,12 @@ when defined(moe.matter):
       check segments.len > 0
 
     test "trailing empty line keeps a state":
+      let grammars = newTestMatterGrammarSet()
       let (segments, states) = initHighlightIncrementalFromStr(
         "# one\n",
         0,
         1,
-        newTokenizerState(hbMatter, SourceLanguage.langNim),
+        newTokenizerState(hbMatter, SourceLanguage.langNim, grammars),
         @[],
         SourceLanguage.langNim,
       )
@@ -37,13 +40,16 @@ when defined(moe.matter):
       check states.len == 2
 
     test "Diff and Log fall back to builtin":
-      check newTokenizerState(hbMatter, SourceLanguage.langDiff).backend == hbBuiltin
-      check newTokenizerState(hbMatter, SourceLanguage.langLog).backend == hbBuiltin
+      let grammars = newTestMatterGrammarSet()
+      check newTokenizerState(hbMatter, langDiff, grammars).backend == hbBuiltin
+      check newTokenizerState(hbMatter, langLog, grammars).backend == hbBuiltin
 
     test "Markdown fences use Matter state":
       var buffer = newTextBuffer("```nim\nproc x() = discard\n```\n")
       buffer.language = SourceLanguage.langMarkdown
-      buffer.highlightBackend = hbMatter
+      buffer.setMatterGrammar(
+        langMarkdown, MarkdownMatterGrammar, "markdown.tmLanguage.json"
+      )
       buffer.highlightNeedsUpdate = true
       discard buffer.updateHighlight()
       check buffer.isCodeBlockLine(0)
@@ -53,7 +59,7 @@ when defined(moe.matter):
     test "switching backends invalidates incremental state":
       var buffer = newTextBuffer("proc x() = discard")
       buffer.language = SourceLanguage.langNim
-      buffer.setHighlightBackend(hbMatter)
+      buffer.setMatterGrammar(langNim, NimMatterGrammar, "nim.tmLanguage.json")
       buffer.highlightNeedsUpdate = true
       discard buffer.updateHighlight()
       check buffer.incrementalHighlight.backend == hbMatter
@@ -67,12 +73,13 @@ when defined(moe.matter):
         lines.add("comment line " & $i)
       lines.add("]#")
       lines.add("proc tail() = discard")
-      let seed = newTokenizerState(hbMatter, SourceLanguage.langNim)
+      let seed = newTokenizerState(hbMatter, langNim, newTestMatterGrammarSet())
       let (oldSegments, oldStates) = initHighlightIncremental(
         lines, 0, lines.high, seed, @[], SourceLanguage.langNim
       )
       var incremental = IncrementalHighlight(
         backend: hbMatter,
+        initialState: seed,
         segments: oldSegments,
         lineStates: LineStateCache(states: oldStates),
         parsedUpTo: lines.high,
@@ -109,12 +116,7 @@ when defined(moe.matter):
           parsed,
         )
       let (freshSegments, freshStates) = initHighlightIncremental(
-        lines,
-        0,
-        lines.high,
-        newTokenizerState(hbMatter, SourceLanguage.langNim),
-        @[],
-        SourceLanguage.langNim,
+        lines, 0, lines.high, seed, @[], SourceLanguage.langNim
       )
       check incremental.segments == freshSegments
       check incremental.lineStates.states == freshStates
@@ -126,6 +128,7 @@ when defined(moe.matter):
       var buffer = newTextBuffer()
       var config = newEditorConfig()
       config.highlight.backend = hbMatter
+      config.highlight.matterGrammarSet = newTestMatterGrammarSet()
       buffer.applyHighlightCap(config)
       check buffer.loadFileWithContent("matter-progressive.nim", content).isOk
       check buffer.incrementalHighlight.backend == hbMatter
@@ -151,7 +154,7 @@ when defined(moe.matter):
         lines,
         0,
         lines.high,
-        newTokenizerState(hbMatter, SourceLanguage.langNim),
+        newTokenizerState(hbMatter, langNim, config.highlight.matterGrammarSet),
         @[],
         SourceLanguage.langNim,
       )

--- a/tests/test_highlighter_api.nim
+++ b/tests/test_highlighter_api.nim
@@ -1,0 +1,85 @@
+## Exercise only the public facades used by host applications, without TOML.
+import std/[os, tempfiles, unittest]
+import pkg/results
+import ../src/moepkg/[buffer, config, editor, highlight]
+
+suite "Programmatic highlighter selection":
+  test "buffer facade exposes selection and effective fallback":
+    let buffer = newTextBuffer("let x = true")
+    buffer.language = langNim
+    buffer.setHighlightBackend(hbMatter)
+    check buffer.highlightBackend == hbMatter
+    when defined(moe.matter):
+      check buffer.effectiveHighlightBackend == hbMatter
+    else:
+      check buffer.effectiveHighlightBackend == hbBuiltin
+    discard buffer.updateHighlight()
+    check buffer.incrementalHighlight.backend == buffer.effectiveHighlightBackend
+    buffer.setHighlightBackend(hbBuiltin)
+    check buffer.incrementalHighlight.isNil
+    check buffer.highlightNeedsUpdate
+    check buffer.effectiveHighlightBackend == hbBuiltin
+
+  test "editor setter updates existing buffers and future buffer defaults":
+    let config = newEditorConfig()
+    config.lsp.enable = false
+    config.clipboard.enable = false
+    let editor = newEditor(config)
+    let extra = newTextBuffer("# extra")
+    extra.language = langNim
+    editor.addBuffer(extra)
+    let current = editor.activeBuffer()
+    current.language = langNim
+    discard current.updateHighlight()
+    let originalHighlight = current.highlight
+
+    editor.setHighlightBackend(hbMatter)
+    check editor.config.highlight.backend == hbMatter
+    check editor.state.config.highlight.backend == hbMatter
+    for buffer in editor.buffers:
+      check buffer.highlightBackend == hbMatter
+      check buffer.highlightNeedsUpdate
+      when defined(moe.matter):
+        check buffer.effectiveHighlightBackend == hbMatter
+      else:
+        check buffer.effectiveHighlightBackend == hbBuiltin
+    check current.highlight == originalHighlight
+
+    let directory = createTempDir("moe_highlighter_api_", "")
+    defer:
+      removeDir(directory)
+    let opened = editor.loadOrCreateBuffer(directory / "future.nim")
+    require opened.isOk
+    check opened.get.highlightBackend == hbMatter
+    when defined(moe.matter):
+      check opened.get.effectiveHighlightBackend == hbMatter
+    else:
+      check opened.get.effectiveHighlightBackend == hbBuiltin
+
+    editor.setHighlightBackend(hbBuiltin)
+    check editor.config.highlight.backend == hbBuiltin
+    for buffer in editor.buffers:
+      check buffer.effectiveHighlightBackend == hbBuiltin
+
+  test "editor constructor accepts programmatic backend configuration":
+    let config = newEditorConfig()
+    config.lsp.enable = false
+    config.clipboard.enable = false
+    config.highlight.backend = hbMatter
+    let editor = newEditor(config)
+    editor.activeBuffer().language = langNim
+    when defined(moe.matter):
+      check editor.activeBuffer().effectiveHighlightBackend == hbMatter
+    else:
+      check editor.activeBuffer().effectiveHighlightBackend == hbBuiltin
+
+  test "per-buffer override does not change the editor default":
+    let config = newEditorConfig()
+    config.lsp.enable = false
+    config.clipboard.enable = false
+    let editor = newEditor(config)
+    let buffer = editor.activeBuffer()
+    buffer.language = langDiff
+    buffer.setHighlightBackend(hbMatter)
+    check buffer.effectiveHighlightBackend == hbBuiltin
+    check editor.config.highlight.backend == hbBuiltin

--- a/tests/test_highlighter_api.nim
+++ b/tests/test_highlighter_api.nim
@@ -3,7 +3,7 @@ import std/[os, tempfiles, unittest]
 import pkg/results
 import ../src/moepkg/[buffer, config, editor, highlight]
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import matter_test_grammars
 
 suite "Programmatic highlighter selection":
@@ -13,7 +13,7 @@ suite "Programmatic highlighter selection":
     buffer.setHighlightBackend(hbMatter)
     check buffer.highlightBackend == hbMatter
     check buffer.effectiveHighlightBackend == hbBuiltin
-    when defined(moe.matter):
+    when defined(moe.matter) or defined(features.moe.matter):
       buffer.setMatterGrammar(langNim, NimMatterGrammar, "nim.tmLanguage.json")
       check buffer.effectiveHighlightBackend == hbMatter
     else:
@@ -47,7 +47,7 @@ suite "Programmatic highlighter selection":
       check buffer.effectiveHighlightBackend == hbBuiltin
     check current.highlight == originalHighlight
 
-    when defined(moe.matter):
+    when defined(moe.matter) or defined(features.moe.matter):
       editor.setMatterGrammar(langNim, NimMatterGrammar, "nim.tmLanguage.json")
       for buffer in editor.buffers:
         check buffer.effectiveHighlightBackend == hbMatter
@@ -58,7 +58,7 @@ suite "Programmatic highlighter selection":
     let opened = editor.loadOrCreateBuffer(directory / "future.nim")
     require opened.isOk
     check opened.get.highlightBackend == hbMatter
-    when defined(moe.matter):
+    when defined(moe.matter) or defined(features.moe.matter):
       check opened.get.effectiveHighlightBackend == hbMatter
     else:
       check opened.get.effectiveHighlightBackend == hbBuiltin
@@ -80,7 +80,7 @@ suite "Programmatic highlighter selection":
   test "invalid or unavailable grammar API does not change backend":
     let buffer = newTextBuffer("let x = true")
     buffer.language = langNim
-    when defined(moe.matter):
+    when defined(moe.matter) or defined(features.moe.matter):
       expect TextMateGrammarError:
         buffer.setMatterGrammar(langNim, "{", "invalid.tmLanguage.json")
     else:

--- a/tests/test_highlighter_api.nim
+++ b/tests/test_highlighter_api.nim
@@ -3,13 +3,18 @@ import std/[os, tempfiles, unittest]
 import pkg/results
 import ../src/moepkg/[buffer, config, editor, highlight]
 
+when defined(moe.matter):
+  import matter_test_grammars
+
 suite "Programmatic highlighter selection":
   test "buffer facade exposes selection and effective fallback":
     let buffer = newTextBuffer("let x = true")
     buffer.language = langNim
     buffer.setHighlightBackend(hbMatter)
     check buffer.highlightBackend == hbMatter
+    check buffer.effectiveHighlightBackend == hbBuiltin
     when defined(moe.matter):
+      buffer.setMatterGrammar(langNim, NimMatterGrammar, "nim.tmLanguage.json")
       check buffer.effectiveHighlightBackend == hbMatter
     else:
       check buffer.effectiveHighlightBackend == hbBuiltin
@@ -39,11 +44,13 @@ suite "Programmatic highlighter selection":
     for buffer in editor.buffers:
       check buffer.highlightBackend == hbMatter
       check buffer.highlightNeedsUpdate
-      when defined(moe.matter):
-        check buffer.effectiveHighlightBackend == hbMatter
-      else:
-        check buffer.effectiveHighlightBackend == hbBuiltin
+      check buffer.effectiveHighlightBackend == hbBuiltin
     check current.highlight == originalHighlight
+
+    when defined(moe.matter):
+      editor.setMatterGrammar(langNim, NimMatterGrammar, "nim.tmLanguage.json")
+      for buffer in editor.buffers:
+        check buffer.effectiveHighlightBackend == hbMatter
 
     let directory = createTempDir("moe_highlighter_api_", "")
     defer:
@@ -61,17 +68,25 @@ suite "Programmatic highlighter selection":
     for buffer in editor.buffers:
       check buffer.effectiveHighlightBackend == hbBuiltin
 
-  test "editor constructor accepts programmatic backend configuration":
+  test "backend configuration alone does not opt into Matter":
     let config = newEditorConfig()
     config.lsp.enable = false
     config.clipboard.enable = false
     config.highlight.backend = hbMatter
     let editor = newEditor(config)
     editor.activeBuffer().language = langNim
+    check editor.activeBuffer().effectiveHighlightBackend == hbBuiltin
+
+  test "invalid or unavailable grammar API does not change backend":
+    let buffer = newTextBuffer("let x = true")
+    buffer.language = langNim
     when defined(moe.matter):
-      check editor.activeBuffer().effectiveHighlightBackend == hbMatter
+      expect TextMateGrammarError:
+        buffer.setMatterGrammar(langNim, "{", "invalid.tmLanguage.json")
     else:
-      check editor.activeBuffer().effectiveHighlightBackend == hbBuiltin
+      expect TextMateGrammarError:
+        buffer.setMatterGrammar(langNim, "{}")
+    check buffer.highlightBackend == hbBuiltin
 
   test "per-buffer override does not change the editor default":
     let config = newEditorConfig()

--- a/tests/test_matter_backend.nim
+++ b/tests/test_matter_backend.nim
@@ -1,0 +1,84 @@
+import std/[sequtils, unittest]
+
+when defined(moe.matter):
+  import ../src/moepkg/syntax/[matter_backend, tokenizer]
+
+  suite "Matter syntax backend":
+    test "embedded Nim grammar highlights without filesystem access":
+      let first = tokenizeMatterLine("proc hello() = discard", SourceLanguage.langNim)
+      let second =
+        tokenizeMatterLine("# comment", SourceLanguage.langNim, first.nextState)
+      check not first.nextState.failed
+      check not second.nextState.failed
+      check first.spans.len > 0
+
+    test "unsupported grammars fail safely":
+      let result = tokenizeMatterLine("text", SourceLanguage.langNone)
+      check result.nextState.failed
+      check result.spans.len == 0
+
+    test "failed state is sticky":
+      let failed = tokenizeMatterLine("text", SourceLanguage.langNone).nextState
+      let retry = tokenizeMatterLine("proc x = discard", SourceLanguage.langNim, failed)
+      check retry.nextState == failed
+
+    test "invalid UTF-8 bytes do not reach Matter regexes":
+      let line = "# " & char(0xff) & char(0xc0) & " lambda"
+      let result = tokenizeMatterLine(line, SourceLanguage.langNim)
+      check not result.nextState.failed
+
+    test "all catalogued editor languages except Diff and Log are available":
+      for language in SourceLanguage:
+        if language in {langNone, langDiff, langLog}:
+          check not matterSupports(language)
+        else:
+          check matterSupports(language)
+          let parsed = tokenizeMatterLine("", language, timeLimitMs = 0)
+          check not parsed.nextState.failed
+
+    test "multiline resume uses completed structurally equal states":
+      let lines = ["#[ outer", "  #[ nested ]#", "still comment", "]#", "let x = true"]
+      var first, repeated: MatterLineState
+      for i, line in lines:
+        let a = tokenizeMatterLine(line, langNim, first, timeLimitMs = 0)
+        let b = tokenizeMatterLine(line, langNim, repeated, timeLimitMs = 0)
+        check not a.nextState.failed
+        check a == b
+        if i in 1 .. 2:
+          check a.spans.anyIt(it.category == mccComment)
+        first = a.nextState
+        repeated = b.nextState
+      check tokenizeMatterLine("true", langNim, first, timeLimitMs = 0).spans.anyIt(
+        it.category == mccBoolean
+      )
+
+    test "JSONC selects the comment-enabled grammar":
+      let parsed = tokenizeMatterLine("// comment", langJsonc, timeLimitMs = 0)
+      check not parsed.nextState.failed
+      check parsed.spans.anyIt(it.category == mccComment)
+
+    test "Markdown code block state covers opening and content but ends at fence":
+      let opening = tokenizeMatterLine("~~~nim", langMarkdown, timeLimitMs = 0)
+      check isMatterCodeBlock(opening.nextState)
+      let content = tokenizeMatterLine("let x = 1", langMarkdown, opening.nextState, 0)
+      check isMatterCodeBlock(content.nextState)
+      let closing = tokenizeMatterLine("~~~", langMarkdown, content.nextState, 0)
+      check not isMatterCodeBlock(closing.nextState)
+
+    test "malformed Unicode preserves input bytes and span bounds":
+      var samples = @["\xed\xa0\x80", "\xf4\x90\x80\x80", "\xc0\xaf", "\xe2\x82"]
+      for value in 128 .. 255:
+        samples.add($char(value))
+      for sample in samples:
+        let line = "# " & sample & " λ"
+        let original = line
+        let parsed = tokenizeMatterLine(line, langNim, timeLimitMs = 0)
+        check not parsed.nextState.failed
+        check line == original
+        for span in parsed.spans:
+          check span.firstByte >= 0
+          check span.lastByte <= line.len
+          check span.firstByte < span.lastByte
+else:
+  static:
+    doAssert true

--- a/tests/test_matter_backend.nim
+++ b/tests/test_matter_backend.nim
@@ -2,10 +2,19 @@ import std/[sequtils, unittest]
 
 when defined(moe.matter):
   import ../src/moepkg/syntax/[matter_backend, tokenizer]
+  import matter_test_grammars
 
   suite "Matter syntax backend":
-    test "embedded Nim grammar highlights without filesystem access":
-      let first = tokenizeMatterLine("proc hello() = discard", SourceLanguage.langNim)
+    test "no grammar is available until the caller supplies one":
+      check not matterSupports(SourceLanguage.langNim)
+      let missing = tokenizeMatterLine("proc hello() = discard", langNim)
+      check missing.nextState.failed
+
+    test "caller-provided Nim grammar highlights without filesystem access":
+      let grammars = newTestMatterGrammarSet()
+      let first = tokenizeMatterLine(
+        "proc hello() = discard", SourceLanguage.langNim, grammars = grammars
+      )
       let second =
         tokenizeMatterLine("# comment", SourceLanguage.langNim, first.nextState)
       check not first.nextState.failed
@@ -23,25 +32,30 @@ when defined(moe.matter):
       check retry.nextState == failed
 
     test "invalid UTF-8 bytes do not reach Matter regexes":
+      let grammars = newTestMatterGrammarSet()
       let line = "# " & char(0xff) & char(0xc0) & " lambda"
-      let result = tokenizeMatterLine(line, SourceLanguage.langNim)
+      let result = tokenizeMatterLine(line, langNim, grammars = grammars)
       check not result.nextState.failed
 
-    test "all catalogued editor languages except Diff and Log are available":
-      for language in SourceLanguage:
-        if language in {langNone, langDiff, langLog}:
-          check not matterSupports(language)
-        else:
-          check matterSupports(language)
-          let parsed = tokenizeMatterLine("", language, timeLimitMs = 0)
-          check not parsed.nextState.failed
+    test "a grammar set opts in only its supplied languages":
+      let grammars = newTestMatterGrammarSet()
+      check grammars.matterSupports(langNim)
+      check grammars.matterSupports(langJsonc)
+      check grammars.matterSupports(langMarkdown)
+      check not grammars.matterSupports(langRust)
+      check not grammars.matterSupports(langDiff)
+      check not grammars.matterSupports(langLog)
 
     test "multiline resume uses completed structurally equal states":
       let lines = ["#[ outer", "  #[ nested ]#", "still comment", "]#", "let x = true"]
+      let grammars = newTestMatterGrammarSet()
       var first, repeated: MatterLineState
       for i, line in lines:
-        let a = tokenizeMatterLine(line, langNim, first, timeLimitMs = 0)
-        let b = tokenizeMatterLine(line, langNim, repeated, timeLimitMs = 0)
+        let a =
+          tokenizeMatterLine(line, langNim, first, timeLimitMs = 0, grammars = grammars)
+        let b = tokenizeMatterLine(
+          line, langNim, repeated, timeLimitMs = 0, grammars = grammars
+        )
         check not a.nextState.failed
         check a == b
         if i in 1 .. 2:
@@ -53,12 +67,16 @@ when defined(moe.matter):
       )
 
     test "JSONC selects the comment-enabled grammar":
-      let parsed = tokenizeMatterLine("// comment", langJsonc, timeLimitMs = 0)
+      let parsed = tokenizeMatterLine(
+        "// comment", langJsonc, timeLimitMs = 0, grammars = newTestMatterGrammarSet()
+      )
       check not parsed.nextState.failed
       check parsed.spans.anyIt(it.category == mccComment)
 
     test "Markdown code block state covers opening and content but ends at fence":
-      let opening = tokenizeMatterLine("~~~nim", langMarkdown, timeLimitMs = 0)
+      let grammars = newTestMatterGrammarSet()
+      let opening =
+        tokenizeMatterLine("~~~nim", langMarkdown, timeLimitMs = 0, grammars = grammars)
       check isMatterCodeBlock(opening.nextState)
       let content = tokenizeMatterLine("let x = 1", langMarkdown, opening.nextState, 0)
       check isMatterCodeBlock(content.nextState)
@@ -70,9 +88,11 @@ when defined(moe.matter):
       for value in 128 .. 255:
         samples.add($char(value))
       for sample in samples:
+        let grammars = newTestMatterGrammarSet()
         let line = "# " & sample & " λ"
         let original = line
-        let parsed = tokenizeMatterLine(line, langNim, timeLimitMs = 0)
+        let parsed =
+          tokenizeMatterLine(line, langNim, timeLimitMs = 0, grammars = grammars)
         check not parsed.nextState.failed
         check line == original
         for span in parsed.spans:

--- a/tests/test_matter_backend.nim
+++ b/tests/test_matter_backend.nim
@@ -1,6 +1,6 @@
 import std/[sequtils, unittest]
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import ../src/moepkg/syntax/[matter_backend, tokenizer]
   import matter_test_grammars
 

--- a/tests/test_matter_highlight_edges.nim
+++ b/tests/test_matter_highlight_edges.nim
@@ -1,0 +1,118 @@
+import std/unittest
+
+import ../src/moepkg/[buffer, config, highlight, highlight_config]
+import ../src/moepkg/syntax/tokenizer
+import pkg/celina
+
+when defined(moe.matter):
+  import std/[sequtils, strutils, tables]
+  import ../src/moepkg/unicode_utils
+
+  suite "Matter highlight edge cases":
+    test "capped Unicode tails remain plain and reserved words use editor columns":
+      let lines = @["# λTODO界abcdef", "let x = 1"]
+      let (segments, states) = initHighlightIncremental(
+        lines,
+        0,
+        lines.high,
+        newTokenizerState(hbMatter, langNim),
+        @[ReservedWord(word: "TODO", color: reservedWord)],
+        langNim,
+        8,
+      )
+      let h = Highlight(colorSegments: segments)
+      check states.len == lines.len
+      check h.getColorPair(0, 2) == comment
+      check h.getColorPair(0, 3) == reservedWord
+      check h.getColorPair(0, 6) == reservedWord
+      check h.getColorPair(0, 7) == comment
+      check h.getColorPair(0, 8) == EditorColorPairIndex.default
+      for i in 1 ..< segments.len:
+        check (segments[i - 1].firstRow, segments[i - 1].firstColumn) <=
+          (segments[i].firstRow, segments[i].firstColumn)
+
+    test "bare CR and malformed bytes do not shift rows or columns":
+      let lines = @["# \xffλTODO\rtext", "", "let x = 1"]
+      let (segments, states) = initHighlightIncremental(
+        lines,
+        0,
+        lines.high,
+        newTokenizerState(hbMatter, langNim),
+        @[ReservedWord(word: "TODO", color: reservedWord)],
+        langNim,
+      )
+      check states.len == 3
+      let h = Highlight(colorSegments: segments)
+      check h.getColorPair(0, 4) == reservedWord
+      check h.getColorPair(0, 7) == reservedWord
+      for segment in segments:
+        check segment.firstRow in 0 .. 2
+        check segment.lastColumn < lines[segment.firstRow].charLen
+
+    test "empty reserved words do not stall comment parsing":
+      let (_, states) = initHighlightIncremental(
+        @["# TODO"],
+        0,
+        0,
+        newTokenizerState(hbMatter, langNim),
+        @[ReservedWord(word: "", color: reservedWord)],
+        langNim,
+      )
+      check states.len == 1
+
+    test "failed line states remain plain and keep capped tails":
+      var seed = newTokenizerState(hbMatter, langNim)
+      seed.matterState.failed = true
+      let (segments, states) = initHighlightIncremental(
+        @["let x = 1", "# comment"], 0, 1, seed, @[], langNim, 3
+      )
+      check states.len == 2
+      check states.allIt(it.matterState.failed)
+      check segments.allIt(it.color == EditorColorPairIndex.default)
+      check segments.len == 4
+
+    test "backend reload preserves semantic diagnostic and URI overlays":
+      let text = "let x = 1 # https://example.com\nlet y = 2"
+      let buffer = newTextBuffer(text)
+      buffer.language = langNim
+      buffer.setHighlightBackend(hbMatter)
+      buffer.diagnostics = @[
+        BufferDiagnostic(
+          startLine: 1,
+          startCol: 0,
+          endLine: 1,
+          endCol: 3,
+          severity: bdsError,
+          message: "diagnostic",
+        )
+      ]
+      buffer.diagnosticsDirty = true
+      discard buffer.updateHighlight()
+      let original = buffer.highlight
+      original.semantic[0] = SemanticOverlayLine(
+        tokens: @[SemanticOverlayToken(firstColumn: 4, length: 1, color: functionName)]
+      )
+      original.semanticContentVersion = buffer.contentVersion
+      let uriColumn = text.find("https")
+      for backend in [hbBuiltin, hbMatter]:
+        var config = newEditorConfig()
+        config.highlight.backend = backend
+        buffer.applyHighlightConfig(config)
+        discard buffer.updateHighlight()
+        check buffer.highlight == original
+        check buffer.highlight.semanticContentVersion == buffer.contentVersion
+        check buffer.highlight.getColorPair(0, 4) == functionName
+        check buffer.highlight.getColorPair(1, 0) == syntaxCheckErr
+        check Underline in buffer.highlight.getSegmentModifiers(0, uriColumn)
+        check Undercurl in buffer.highlight.getSegmentModifiers(1, 0)
+else:
+  suite "Matter-disabled configuration":
+    test "portable Matter config safely selects builtin":
+      let buffer = newTextBuffer("let x = 1")
+      buffer.language = langNim
+      var config = newEditorConfig()
+      config.highlight.backend = hbMatter
+      buffer.applyHighlightConfig(config)
+      discard buffer.updateHighlight()
+      check buffer.highlightBackend == hbBuiltin
+      check buffer.incrementalHighlight.backend == hbBuiltin

--- a/tests/test_matter_highlight_edges.nim
+++ b/tests/test_matter_highlight_edges.nim
@@ -4,7 +4,7 @@ import ../src/moepkg/[buffer, config, highlight, highlight_config]
 import ../src/moepkg/syntax/tokenizer
 import pkg/celina
 
-when defined(moe.matter):
+when defined(moe.matter) or defined(features.moe.matter):
   import std/[sequtils, strutils, tables]
   import ../src/moepkg/unicode_utils
   import matter_test_grammars

--- a/tests/test_matter_highlight_edges.nim
+++ b/tests/test_matter_highlight_edges.nim
@@ -7,6 +7,7 @@ import pkg/celina
 when defined(moe.matter):
   import std/[sequtils, strutils, tables]
   import ../src/moepkg/unicode_utils
+  import matter_test_grammars
 
   suite "Matter highlight edge cases":
     test "capped Unicode tails remain plain and reserved words use editor columns":
@@ -15,7 +16,7 @@ when defined(moe.matter):
         lines,
         0,
         lines.high,
-        newTokenizerState(hbMatter, langNim),
+        newTokenizerState(hbMatter, langNim, newTestMatterGrammarSet()),
         @[ReservedWord(word: "TODO", color: reservedWord)],
         langNim,
         8,
@@ -37,7 +38,7 @@ when defined(moe.matter):
         lines,
         0,
         lines.high,
-        newTokenizerState(hbMatter, langNim),
+        newTokenizerState(hbMatter, langNim, newTestMatterGrammarSet()),
         @[ReservedWord(word: "TODO", color: reservedWord)],
         langNim,
       )
@@ -54,14 +55,14 @@ when defined(moe.matter):
         @["# TODO"],
         0,
         0,
-        newTokenizerState(hbMatter, langNim),
+        newTokenizerState(hbMatter, langNim, newTestMatterGrammarSet()),
         @[ReservedWord(word: "", color: reservedWord)],
         langNim,
       )
       check states.len == 1
 
     test "failed line states remain plain and keep capped tails":
-      var seed = newTokenizerState(hbMatter, langNim)
+      var seed = newTokenizerState(hbMatter, langNim, newTestMatterGrammarSet())
       seed.matterState.failed = true
       let (segments, states) = initHighlightIncremental(
         @["let x = 1", "# comment"], 0, 1, seed, @[], langNim, 3
@@ -75,7 +76,7 @@ when defined(moe.matter):
       let text = "let x = 1 # https://example.com\nlet y = 2"
       let buffer = newTextBuffer(text)
       buffer.language = langNim
-      buffer.setHighlightBackend(hbMatter)
+      buffer.setMatterGrammar(langNim, NimMatterGrammar, "nim.tmLanguage.json")
       buffer.diagnostics = @[
         BufferDiagnostic(
           startLine: 1,
@@ -97,6 +98,7 @@ when defined(moe.matter):
       for backend in [hbBuiltin, hbMatter]:
         var config = newEditorConfig()
         config.highlight.backend = backend
+        config.highlight.matterGrammarSet = newTestMatterGrammarSet()
         buffer.applyHighlightConfig(config)
         discard buffer.updateHighlight()
         check buffer.highlight == original
@@ -114,5 +116,6 @@ else:
       config.highlight.backend = hbMatter
       buffer.applyHighlightConfig(config)
       discard buffer.updateHighlight()
-      check buffer.highlightBackend == hbBuiltin
+      check buffer.highlightBackend == hbMatter
+      check buffer.effectiveHighlightBackend == hbBuiltin
       check buffer.incrementalHighlight.backend == hbBuiltin


### PR DESCRIPTION
## Summary

Add an optional Matter TextMate syntax backend while keeping builtin highlighting as the default. Enable it with `nimble --parser:declarative --features:matter build -d:release` (Nimble 0.24.1 or newer). The feature requires Matter >= 0.4.2; default dependency installation excludes Matter and its dedicated dependencies.

Grammars are supplied explicitly through `[Highlight] matterGrammarFiles` inside Moe's configuration directory, or as grammar text through the editor/buffer API. Moe does not bundle or download grammars. Runtime `backend = "matter"` selects the backend; languages without a valid supplied grammar fall back to builtin highlighting. Diff and Log retain their builtin lexers.

The backend integrates with progressive loading, budgeted incremental parsing, Unicode columns, per-line length caps, reserved words, Markdown block detection, and URI/LSP/diagnostic overlays. Review fixes preserve progressive caches for empty grammar configurations, reject cached tokenizer states from a different backend, avoid comparing grammar contents for identical references, and retry a sticky Matter failure once when a later edit starts a fresh reparse flight.

Includes backend and regression tests, a Matter-enabled CI job (including config-loader coverage), example configuration, and build documentation.

## Validation

- Latest dependency change: default dependency installation and build passed in an isolated checkout without workspace vendored dependencies.
- Matter feature installation/setup selected Matter 0.4.2, and the feature-enabled release build passed.
- Earlier review fixes: Matter adapter, incremental highlighting, edge-case, public API, builtin highlighting, and release build checks passed locally, including regressions for progressive caches, mismatched cached backends, and failure recovery.
- Whitespace checks passed. The config-loader suite has a previously observed unrelated macOS clipboard-tool expectation failure; Matter CI runs on Linux.

Tokenization uses a configurable soft 20ms per-line deadline. Timeout or grammar errors leave the affected line and subsequent lines plain for that parsing flight; a later edit can retry. Equivalence tests disable the wall-clock deadline for deterministic results.
